### PR TITLE
Point to code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Compliant Kubernetes Documentation
 
-This is the main repository for documentation about the Compliant Kubernetes project.
+This is the main repository for documentation about the Compliant Kubernetes project. For Compliant Kubernetes code, please refer to:
+
+* [`compliantkubernetes-kubespray`](https://github.com/elastisys/compliantkubernetes-kubespray) for setting up a vanilla Kubernetes cluster on top of a compliant cloud provider;
+* [`compliantkubernetes-apps`](https://github.com/elastisys/compliantkubernetes-apps) for augmenting a vanilla Kubernetes cluster with security and observability.
 
 ## Prerequisites
 


### PR DESCRIPTION
This commit clarifies the relationship between the
`compliantkubernetes`, `compliantkubernetes-kubespray` and
`compliantkubernetes-apps` repos.