### PR TITLE
Move inventory.ini

### DIFF
--- a/docs/operator-manual/troubleshooting.md
+++ b/docs/operator-manual/troubleshooting.md
@@ -354,7 +354,6 @@ for CLUSTER in ${SERVICE_CLUSTER} "${WORKLOAD_CLUSTERS[@]}"; do
     terraform init $TF_SCRIPTS_DIR
     terraform plan \
         -var-file=cluster.tfvars \
-        -state=cluster.tfstate  \
         $TF_SCRIPTS_DIR
     popd
 done


### PR DESCRIPTION
We slowly seem to converge to a standardized config folder structure,
which can be observed both in the ops config repo and in the
soon-to-be-public ck8s-devbox. I adjusted the troubleshooting guide to
match this config folder structure.