### PR TITLE
Prepare for Terraform v0.15.0

### DIFF
--- a/docs/operator-manual/troubleshooting.md
+++ b/docs/operator-manual/troubleshooting.md
@@ -386,12 +386,12 @@ Go to the docs of the cloud provider and run Terraform `plan` instead of `apply`
 ```bash
 TF_SCRIPTS_DIR=$(readlink -f compliantkubernetes-kubespray/kubespray/contrib/terraform/exoscale)
 for CLUSTER in ${SERVICE_CLUSTER} "${WORKLOAD_CLUSTERS[@]}"; do
-    pushd ${CLUSTER}-config
+    pushd ${TF_SCRIPTS_DIR}
     export TF_VAR_inventory_file=${CK8S_CONFIG_PATH}/${CLUSTER}-config/inventory.ini
-    terraform init $TF_SCRIPTS_DIR
+    terraform init
     terraform plan \
-        -var-file=cluster.tfvars \
-        $TF_SCRIPTS_DIR
+        -var-file=${CK8S_CONFIG_PATH}/${CLUSTER}-config/cluster.tfvars \
+        -state=${CK8S_CONFIG_PATH}/${CLUSTER}-config/terraform.tfstate
     popd
 done
 ```


### PR DESCRIPTION
I have now fully processed what Simon said back [here](https://github.com/elastisys/compliantkubernetes/pull/130#discussion_r645469221). :smile:

> I think you're right that it's a good mental check to manually change directory to know what you are working on. However, terraform devs seem to think you should have a separate module configuration for each cluster in that case. In v0.15.0 not running from the root module is going to become deprecated and you will have to use a -chdir flag if you want to keep running from elsewhere.
>
> I believe this also makes automatic pickup of terraform.tfstate not working anymore if it's not located in the root module path. Haven't confirmed this though.

Terraform v0.15.0 does not take the root module as argument anymore.
Instead, it expects to always have the working directory set to the root
module, either my `cd`-ing into that folder, or by giving it the
`-chdir` parameter.

This PR does exactly that, `cd`-ing into the root module folder, which
is compatible with both Terraform v0.13.x, v0.14.x and v0.15.x.