### PR TITLE
Update AWS operator manual to v0.17.0

### DIFF
--- a/docs/operator-manual/aws.md
+++ b/docs/operator-manual/aws.md
@@ -9,7 +9,7 @@ The setup has two major parts:
 Before starting, make sure you have [all necessary tools](getting-started.md).
 
 !!!note
-    This guide is written for compliantkubernetes-apps [v0.13.0](https://github.com/elastisys/compliantkubernetes-apps/tree/v0.13.0)
+    This guide is written for compliantkubernetes-apps [v0.17.0](https://github.com/elastisys/compliantkubernetes-apps/tree/v0.17.0)
 
 ## Setup
 


### PR DESCRIPTION
While working on another project I have verified that the manual is working fine for v0.17.0.