### PR TITLE
Improve teardown docs

### DIFF
--- a/docs/operator-manual/aws.md
+++ b/docs/operator-manual/aws.md
@@ -304,6 +304,9 @@ kibana.$BASE_DOMAIN   60s A $SC_INGRESS_LB_IP
 
 ### Remove infrastructure
 
+!!!note
+    Even if you want to completely destroy the cluster with all its infrastructure, it is recommended to first execute the `clean` scripts described above, otherwise resources created by the cloud controller (e.g. volumes and loadbalancers) are not removed and `terraform destroy` might fail.
+
 ```bash
 pushd kubespray/contrib/terraform/aws
 for CLUSTER in ${SERVICE_CLUSTER} "${WORKLOAD_CLUSTERS[@]}"; do

--- a/docs/operator-manual/clean-up.md
+++ b/docs/operator-manual/clean-up.md
@@ -1,6 +1,6 @@
 # Removing Compliant Kubernetes Apps from your cluster
 
-To remove the applications added by compliant kubernetes you can use the two scripts `clean-sc.sh` and `clean-wc.sh`, they are located here in the [scripts folder](https://github.com/elastisys/compliantkubernetes-apps/tree/main/scripts).
+To remove the applications added by Compliant Kubernetes you can use the two scripts `clean-sc.sh` and `clean-wc.sh`, they are located here in the [scripts folder](https://github.com/elastisys/compliantkubernetes-apps/tree/main/scripts).
 
 They perform the following actions:
 
@@ -9,4 +9,5 @@ They perform the following actions:
 3. Delete any remaining PersistentVolumes
 4. Delete the added CustomResourceDefinitions
 
-Note: if user namespaces are managed by Compliant Kubernetes apps then they will also be deleted if you clean up the workload cluster.
+!!!note
+    If user namespaces are managed by Compliant Kubernetes apps then they will also be deleted if you clean up the workload cluster.


### PR DESCRIPTION
This PR improves Teardown documentation by:

- fixing formatting
- adding clarification that one should run `clean` scripts even when removing the whole infrastructure