### PR TITLE
Openstack use application credentials safespring

### DIFF
--- a/docs/operator-manual/openstack.md
+++ b/docs/operator-manual/openstack.md
@@ -225,6 +225,21 @@ For cloud provider integration, you have a few options [as described here](https
 We will be going with the in-tree cloud provider and simply source the Openstack credentials.
 This doesn't require any changes to the variables as set up using this guide.
 
+!!!note
+    At this point if the cluster is running on Safespring and you are using `kubespray v2.17.0+` it is possible to create an application credential.
+    Which will give the cluster its own set of credentials instead of using your own.
+
+    To create a set of credentials use the following command:
+    `openstack application credential create <name>`
+
+    And set the following environment variables
+
+    ```console
+    export OS_APPLICATION_CREDENTIAL_NAME: <name>
+    export OS_APPLICATION_CREDENTIAL_ID: <project_id>
+    export OS_APPLICATION_CREDENTIAL_SECRET: <secret>
+    ```
+
 ### Run Kubespray
 
 Copy the script for generating dynamic ansible inventories:


### PR DESCRIPTION
This PR documents the finding of: [#497](https://github.com/elastisys/ck8s-ops/issues/497)

Unfortunately it only worked for safespring.

Added information about using application credentials when running cluster on safesrping with kubespray version v2.17.0+.

![Screenshot from 2021-09-24 15-31-43](https://user-images.githubusercontent.com/12862587/134682865-70b1c7ba-d9f0-41b2-8dd9-4d7483f498d8.png)

