### PR TITLE
Update note on Cinder CSI default configuration

### DIFF
--- a/docs/operator-manual/openstack.md
+++ b/docs/operator-manual/openstack.md
@@ -242,20 +242,20 @@ external_openstack_cloud_controller_extra_args:
 
 cinder_csi_enabled: true
 persistent_volumes_enabled: true
-expand_persistent_volumes: true
+# expand_persistent_volumes: true
 openstack_blockstorage_ignore_volume_az: true
 
 storage_classes:
   - name: cinder-csi
     is_default: true
     parameters:
-      allowVolumeExpansion: true
+      # allowVolumeExpansion: true
       availability: nova
 ```
 
 `cluster-name` should be set to a name that is unique in the Openstack project you're deploying your clusters in. If you don't have any other clusters in the project, just make sure that the service cluster and workload clusters have different names.
 
-Cinder CSI is enabled by default along with the configuration options to enable persistent volumes and the expansion of these volumes. It is also set to ignore the volume availability zone to allow volumes to attach to nodes in different or mismatching zones. The default works well with both CityCloud and SafeSpring.
+Cinder CSI is enabled by default along with the configuration options to enable persistent volumes. It is also set to ignore the volume availability zone to allow volumes to attach to nodes in different or mismatching zones. The default works well with both CityCloud and SafeSpring, CityCloud also supports volume expansion which can be enabled by uncommenting `expand_persistent_volumes` and `allowVolumeExpansion`.
 
 If you want to set up LBaaS in your cluster, you can add the following config:
 


### PR DESCRIPTION
Seems I was a bit to quick earlier. SafeSpring currently has issues with volume expansion with Cinder CSI so it will be disabled. 
Updated the documentation to match https://github.com/elastisys/compliantkubernetes-kubespray/pull/118 and this time I'll leave it open until it is merged.