### PR TITLE
Make trademark usage more prominent

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 ![Created by Elastisys](img/logos/created-by.svg)
 </center>
 
-Compliant Kubernetes is a [Certified Kubernetes](https://landscape.cncf.io/organization=elastisys&selected=elastisys-compliant-kubernetes) distribution, i.e., an opinionated way of packaging and configuring Kubernetes together with other projects. Compliant Kubernetes reduces the compliance burden, as required to comply with:
+Elastisys Compliant Kubernetes® is a [Certified Kubernetes](https://landscape.cncf.io/organization=elastisys&selected=elastisys-compliant-kubernetes) distribution, i.e., an opinionated way of packaging and configuring Kubernetes together with other projects. Compliant Kubernetes reduces the compliance burden, as required to comply with:
 
 * [Swedish Healthcare (Patientdatalagen)](https://elastisys.com/how-to-use-kubernetes-in-swedish-healthcare/)
 * General Data Protection Regulation (GDPR)

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -9,3 +9,8 @@ g.type='text/javascript'; g.async=true; g.src="\/\/elastisys.com\/wp-content\/up
 </script>
 <!-- End Matomo Code -->
 {% endblock %}
+
+{% set extracopyright %}
+<br/>
+Kubernetes® is a registered trademark of The Linux Foundation in the United States and other countries, and is used pursuant to a license from The Linux Foundation.
+{% endset %}


### PR DESCRIPTION
See below screenshot:

- "Elastisys Compliant Kubernetes(R)" is written on the first page.
- Kubernetes is properly acknowledged as a trademark on the footer of every page.

![image](https://user-images.githubusercontent.com/1660833/140822861-75c7d5b7-e37d-479c-b5f4-16859c13301c.png)