### PR TITLE
User demo now tolerates Node failure and reboot

### DIFF
--- a/docs/compliantkubernetes/user-guide/go-live.md
+++ b/docs/compliantkubernetes/user-guide/go-live.md
@@ -25,7 +25,10 @@ To move from production anxiety to production karma, here is a checklist to go t
     * **Why?** Node failure may cause application downtime. Said downtime can be large if it happens at night, when administrators need to wake up before they can respond. Also, administrators need some extra capacity for performing critical security updates on the base operating system of the Nodes.
     * **How?** As above, but now ask the administrator to perform a rolling reboot of Nodes.
     * **Desired outcome**: The measured downtime (due to Pod migration) during Node failure or drain is acceptable. Capacity is sufficient to tolerate one Node failure or drain.
-    * **Possible resolution**: Ensure the application has proper resource requests and limits (see our [user demo for an example](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L42-L51)). Ensure the application has at least two replicas. Consider adding `topologySpreadConstraints` to ensure Pods do not end up on the same Node.
+    * **Possible resolution**:
+        * Ensure the application has proper resource requests and limits (see our [user demo for an example](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L42-L51)).
+        * Ensure the application has at least two replicas (see our [user demo for an example](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L5)).
+        * Ensure the application has `topologySpreadConstraints` to ensure Pods do not end up on the same Node (see our [user demo for an example](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L76-L82)).
 - [ ] Disaster recovery testing was performed:
     * **Why?** This ensures that the application and platform team agreed on who backs up what, instead of ending up thinking that "backing up this thingy" is the other team's problem.
     * **How?** Ask the administrator to destroy the environment and restore from off-site backups. Check if your application is back up and its data is restored as expected.

--- a/docs/compliantkubernetes/user-guide/prepare.md
+++ b/docs/compliantkubernetes/user-guide/prepare.md
@@ -12,7 +12,7 @@ To make the most out of Compliant Kubernetes, prepare your application so it fea
     - [HTTPS Ingresses](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L37-L40);
     - [ServiceMonitor for metrics collection](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/templates/servicemonitor.yaml);
     - [PrometheusRule for alerting](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/templates/prometheusrule.yaml);
-    - [topologySpreadConstraints for tolerating a zone failure](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L76-L82);
+    - [topologySpreadConstraints for tolerating single Node or single Zone failure](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L76-L82);
     - [resources for capacity management](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L42-L51);
     - [NetworkPolicies for network segmentation](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L83-L94);
 - [Grafana dashboards for metrics visualization](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/dashboards);

--- a/user-demo/deploy/ck8s-user-demo/templates/deployment.yaml
+++ b/user-demo/deploy/ck8s-user-demo/templates/deployment.yaml
@@ -56,7 +56,13 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.topologySpreadConstraints }}
-      topologySpreadConstraints: {{ toYaml .Values.topologySpreadConstraints | nindent 8 }}
+      topologySpreadConstraints:
+        {{- range $c := .Values.topologySpreadConstraints }}
+        - {{- toYaml $c | nindent 10 }}
+          labelSelector:
+            matchLabels:
+              {{- include "ck8s-user-demo.selectorLabels" $ | nindent 14 }}
+        {{- end }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/user-demo/deploy/ck8s-user-demo/values.yaml
+++ b/user-demo/deploy/ck8s-user-demo/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: 2
 
 image:
   repository: i-didnt-read-the-docs/ck8s-user-demo
@@ -52,7 +52,7 @@ resources:
 
 autoscaling:
   enabled: false
-  minReplicas: 1
+  minReplicas: 2
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
@@ -72,13 +72,13 @@ prometheusRule:
 ## Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
 ##
-topologySpreadConstraints: []
-  # - maxSkew: 1
-  #   topologyKey: topology.kubernetes.io/zone
-  #   whenUnsatisfiable: DoNotSchedule
-  #   labelSelector:
-  #     matchLabels:
-  #       app.kubernetes.io/instance: myapp
+topologySpreadConstraints:
+  - maxSkew: 1
+    whenUnsatisfiable: DoNotSchedule
+    topologyKey: kubernetes.io/hostname
+    ## Comment the line above and uncomment the line below if you want your application to tolerate Zone failures.
+    ## Ref: https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone
+    # topologyKey: topology.kubernetes.io/zone
 
 ## Network Policy configuration
 ## ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/


### PR DESCRIPTION
Recommend replication 2 and topologySpreadConstraints, so that the
application tolerates single Node failure by default. Provide an option
to allow the application to tolerate single Zone failures.

@Pavan-Gunda Please check if this is in line with what we discussed the application needs to do to tolerate Node reboots.

Fixes #207 