### PR TITLE
Document arch decision on replacing InfluxDB with Thanos

### DIFF
--- a/docs/compliantkubernetes/tech-radar/index.html
+++ b/docs/compliantkubernetes/tech-radar/index.html
@@ -107,6 +107,20 @@ radar_visualization({
       moved: 0
     },
     {
+      quadrant: 1,
+      ring: 1,
+      label: "Thanos",
+      active: true,
+      moved: 0
+    },
+    {
+      quadrant: 3,
+      ring: 3,
+      label: "InfluxDB",
+      active: true,
+      moved: 0
+    },
+    {
       quadrant: 3,
       ring: 0,
       label: "jq",

--- a/docs/compliantkubernetes/tech-radar/index.html
+++ b/docs/compliantkubernetes/tech-radar/index.html
@@ -137,7 +137,7 @@ radar_visualization({
     {
       quadrant: 1,
       ring: 0,
-      label: "OpenPolicyAgent/Gatekeeper",
+      label: "OPA/Gatekeeper",
       active: false,
       moved: 0
     },


### PR DESCRIPTION
Keeping Thanos in "trial" ring, until initial implementation is ready, we see more internal adoption and we build more confidence.