### PR TITLE
tests: added pre-commit hooks to stop commits to main and check for m…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.1.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -10,6 +10,8 @@ repos:
     -   id: check-yaml
         exclude: '[/]templates[/]'
     -   id: check-added-large-files
+    - id: check-merge-conflict
+    - id: no-commit-to-branch
 -   repo: local
     hooks:
     -   id: svg-must-embed


### PR DESCRIPTION
**What this PR does / why we need it**:

Added pre-commit hooks to stop commits to main and to check for merge conflicts.

**Which issue this PR fixes** : fixes ([1478](https://github.com/elastisys/ck8s-ops/issues/1478) in ck8s-ops )