### PR TITLE
docs: added timescaledb documentation

### DIFF
--- a/docs/compliantkubernetes/user-guide/additional-services/postgresql.md
+++ b/docs/compliantkubernetes/user-guide/additional-services/postgresql.md
@@ -137,6 +137,22 @@ To expose the PostgreSQL cluster credentials to your application, follow one of 
 * [Create a Pod that has access to the secret data through a Volume](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#create-a-pod-that-has-access-to-the-secret-data-through-a-volume)
 * [Define container environment variables using Secret data](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-container-environment-variables-using-secret-data)
 
+## Deploy TimescaleDB on managed PostgreSQL.
+
+If you only want to use TimescaleDB on your cluster, ask your administrator to [provision a new standard PostgreSQL cluster](https://elastisys.io/compliantkubernetes/user-guide/additional-services/postgresql/#provision-a-new-postgresql-cluster). Then set up the TimescaleDB extension.
+
+* Connect to the created database:
+```bash
+\c $APP_DATABASE
+```
+* Add the TimescaleDB extension:
+```bash
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+```
+
+!!!important
+    Due to very different performance-tuning characteristics, Timescale and PostgreSQL databases should never run on the same PostgreSQL cluster.
+
 ## Follow the Go-Live Checklist
 
 You should be all set.


### PR DESCRIPTION
Added documentation to let the user know they can use TimescaleDB.

Fixes #294 

Did I miss an important step? Are there any (regular PostgreSQL setup) step that is not required to do when using Timescale? Please let me know. :slightly_smiling_face: