### PR TITLE
docs: remove sc/wc references in 'for AD'

### DIFF
--- a/docs/compliantkubernetes/user-guide/alerts.md
+++ b/docs/compliantkubernetes/user-guide/alerts.md
@@ -7,7 +7,7 @@ description: Alerting on metrics with AlertManager in Elastisys Compliant Kubern
 Compliant Kubernetes (CK8S) includes alerts via [Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/).
 
 !!!important
-    By default, you will get some platform alerts, specifically those originating from the workload cluster. This may benefit you, by giving you improved "situational awareness". Please decide if these alerts are of interest to you or not. Feel free to silence them, as the Compliant Kubernetes administrator will take responsibility for them.
+    By default, you will get some platform alerts. This may benefit you, by giving you improved "situational awareness". Please decide if these alerts are of interest to you or not. Feel free to silence them, as the Compliant Kubernetes administrator will take responsibility for them.
 
     Your focus should be on **user alerts** or **application-level alerts**, i.e., alerts under the control and responsibility of the Compliant Kubernetes user. We will focus on user alerts in this document.
 

--- a/docs/compliantkubernetes/user-guide/backup.md
+++ b/docs/compliantkubernetes/user-guide/backup.md
@@ -18,7 +18,7 @@ The requirements to comply with ISO 27001 are stated in ISO [27001:2013](https:/
 
 ## Usage
 
-Velero is deployed in both the workload cluster and the service cluster. Following are instructions for backing up and restoring resources.
+The following are instructions for backing up and restoring resources.
 
 ### Backing up
 
@@ -48,9 +48,9 @@ The Compliant Kubernetes administrator will take the following measure to ensure
 
     **Why?** This ensures backups remain confidential, even if, e.g., hard drives are not safely disposed.
 
-2. Backups are replicated to an off-site location, if requested. This process is performed from the service cluster, hence the users -- or attackers gaining access to their application -- cannot access the off-site replicas.
+2. Backups are replicated to an off-site location, if requested. This process is performed from outside the cluster, hence the users -- or attackers gaining access to their application -- cannot access the off-site replicas.
 
-    **Why?** This ensures backups are available even if the primary location is subject to a disaster, such as extreme weather. The backups also remain available -- though unlikely confidential -- in case an attacker manages to gain access to the workload cluster.
+    **Why?** This ensures backups are available even if the primary location is subject to a disaster, such as extreme weather. The backups also remain available -- though unlikely confidential -- in case an attacker manages to gain access to the cluster.
 
 <!--
 

--- a/docs/compliantkubernetes/user-guide/setup.md
+++ b/docs/compliantkubernetes/user-guide/setup.md
@@ -66,7 +66,7 @@ curl --head https://dex.$DOMAIN/healthz
 curl --head https://harbor.$DOMAIN/healthz
 curl --head https://grafana.$DOMAIN/healthz
 curl --head https://opensearch.$DOMAIN/api/status
-curl --insecure --head https://app.$DOMAIN/healthz  # WC Ingress Controller
+curl --insecure --head https://app.$DOMAIN/healthz  # Ingress Controller
 # All commands above should return 'HTTP/2 200'
 ```
 


### PR DESCRIPTION
Removed references to SC and WC in "For Application Developers" part of the docs.

Fixes #339 