### PR TITLE
Added Ingress OAuth2 example

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     -   id: end-of-file-fixer
         exclude: '[.](svg|drawio.xml)$'
     -   id: check-yaml
-        exclude: '[/]templates[/]'
+        exclude: '[/](templates[/]|oauth2-proxy.yaml)'
     -   id: check-added-large-files
     - id: check-merge-conflict
     - id: no-commit-to-branch

--- a/docs/compliantkubernetes/user-guide/network-model.md
+++ b/docs/compliantkubernetes/user-guide/network-model.md
@@ -76,6 +76,8 @@ spec:
 !!!example
     Feel free to take inspiration from the [user demo](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L34).
 
+    If you want to protect your Ingress with OAuth2-based authentication, check out [oauth2-proxy](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/oauth2-proxy.yaml).
+
 !!!important
     The DNS name in `spec.rules[0].host` and `spec.tls[0].hosts[0]` must be the same as the DNS entry used by your application users. Otherwise, the application users will get a "Your connection is not private" error.
 

--- a/user-demo/deploy/ck8s-user-demo/values.yaml
+++ b/user-demo/deploy/ck8s-user-demo/values.yaml
@@ -41,6 +41,12 @@ ingress:
     ## Uncomment the line below to implement source IP allowlisting.
     ## Blocklisted IPs will get HTTP 403.
     # nginx.ingress.kubernetes.io/whitelist-source-range: 98.128.193.2/32
+    ## Uncomment the lines below to get OAuth authentication
+    ## You will also need to configure and install oauth2-proxy
+    ## (see ../oauth2-proxy.yaml for an example and more details.)
+    # nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+    # nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
+    # nginx.ingress.kubernetes.io/auth-response-headers: "authorization"
 
 resources:
   # Most Compliant Kubernetes clusters require the application to specify resources.

--- a/user-demo/deploy/oauth2-proxy.yaml
+++ b/user-demo/deploy/oauth2-proxy.yaml
@@ -1,0 +1,115 @@
+# This is an example oauth2-proxy deployment to be used with Nginx Ingress controller.
+#
+# Usage
+# =====
+#
+# 1. Start by reading and understanding:
+#
+# - https://oauth2-proxy.github.io/oauth2-proxy/#architecture
+# - https://kubernetes.github.io/ingress-nginx/examples/auth/oauth-external-auth/
+# - https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview
+# - https://kubernetes.io/docs/concepts/services-networking/ingress/
+# - https://elastisys.io/compliantkubernetes/user-guide/network-model/
+#
+# 2. Configure oauth2-proxy by adjusting the command-line arguments and/or
+# environment variables below. At the very least, you need to change
+# - OAUTH2_PROXY_CLIENT_ID
+# - OAUTH2_PROXY_CLIENT_SECRET
+# - OAUTH2_PROXY_COOKIE_SECRET
+#
+# 3. Replace __INGRESS_HOST__ and __INGRESS_SECRET__.
+#
+# 4. kubectl apply -f oauth2-proxy.yaml
+#
+# 5. Go back to the Ingress of your application and make sure you have the
+# right Ingress annotations. If you don't know which ones are meant, go back to
+# step 1.
+#
+# Note: The provided example will forward the JWT token to your application in
+# the 'Authorization' header. Make sure to decide if this is what you want.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: oauth2-proxy
+  name: oauth2-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: oauth2-proxy
+  template:
+    metadata:
+      labels:
+        k8s-app: oauth2-proxy
+    spec:
+      containers:
+      - args:
+        - --provider=google
+        - --email-domain=elastisys.com
+        - --upstream=file:///dev/null
+        - --http-address=0.0.0.0:4180
+        - --set-authorization-header
+        env:
+        - name: OAUTH2_PROXY_CLIENT_ID
+          value: i-didnt-read-the-docs-above
+        - name: OAUTH2_PROXY_CLIENT_SECRET
+          value: i-didnt-read-the-docs-above
+        # docker run -ti --rm python:3-alpine python -c 'import secrets,base64; print(base64.b64encode(base64.b64encode(secrets.token_bytes(16))));'
+        - name: OAUTH2_PROXY_COOKIE_SECRET
+          value: i-didnt-read-the-docs-above
+        image: quay.io/oauth2-proxy/oauth2-proxy:latest
+        imagePullPolicy: Always
+        name: oauth2-proxy
+        ports:
+        - containerPort: 4180
+          protocol: TCP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100M
+          limits:
+            cpu: 100m
+            memory: 100M
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: oauth2-proxy
+  name: oauth2-proxy
+spec:
+  ports:
+  - name: http
+    port: 4180
+    protocol: TCP
+    targetPort: 4180
+  selector:
+    k8s-app: oauth2-proxy
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: oauth2-proxy
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: __INGRESS_HOST__
+    http:
+      paths:
+      - path: /oauth2
+        pathType: Prefix
+        backend:
+          service:
+            name: oauth2-proxy
+            port:
+              number: 4180
+  tls:
+  - hosts:
+    - __INGRESS_HOST__
+    secretName: __INGRESS_SECRET__

--- a/user-demo/deploy/oauth2-proxy.yaml
+++ b/user-demo/deploy/oauth2-proxy.yaml
@@ -11,17 +11,22 @@
 # - https://kubernetes.io/docs/concepts/services-networking/ingress/
 # - https://elastisys.io/compliantkubernetes/user-guide/network-model/
 #
-# 2. Configure oauth2-proxy by adjusting the command-line arguments and/or
+# 2. Ask your Compliant Kubernetes administrator to allowlist the following
+# container registry:
+#
+# - quay.io/oauth2-proxy/oauth2-proxy
+#
+# 3. Configure oauth2-proxy by adjusting the command-line arguments and/or
 # environment variables below. At the very least, you need to change
 # - OAUTH2_PROXY_CLIENT_ID
 # - OAUTH2_PROXY_CLIENT_SECRET
 # - OAUTH2_PROXY_COOKIE_SECRET
 #
-# 3. Replace __INGRESS_HOST__ and __INGRESS_SECRET__.
+# 4. Replace __INGRESS_HOST__ and __INGRESS_SECRET__.
 #
-# 4. kubectl apply -f oauth2-proxy.yaml
+# 5. kubectl apply -f oauth2-proxy.yaml
 #
-# 5. Go back to the Ingress of your application and make sure you have the
+# 6. Go back to the Ingress of your application and make sure you have the
 # right Ingress annotations. If you don't know which ones are meant, go back to
 # step 1.
 #


### PR DESCRIPTION
Ingress authentication example via `oauth2-proxy` as asked by a few application developers.

Works out-of-the-box with Compliant Kubernetes, with two minor deviations:

- oauth2-proxy needs resource requests and limits.
- oauth2-proxy image needs to be allowlisted.

Note to reviewers: The link `https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/oauth2-proxy.yaml` should become available after merging. This is absolute on purpose, to ensure the user is redirected from the public docs to the GitHub project.