### PR TITLE
Add bsi controls

### DIFF
--- a/docs/compliantkubernetes/adr/0022-use-dedicated-nodes-for-additional-services.md
+++ b/docs/compliantkubernetes/adr/0022-use-dedicated-nodes-for-additional-services.md
@@ -1,6 +1,6 @@
 ---
 tags:
-- BSI APP.4.4.A14
+- BSI IT-Grundschutz APP.4.4.A14
 ---
 # Use Dedicated Nodes for Additional Services
 

--- a/docs/compliantkubernetes/adr/0022-use-dedicated-nodes-for-additional-services.md
+++ b/docs/compliantkubernetes/adr/0022-use-dedicated-nodes-for-additional-services.md
@@ -1,3 +1,7 @@
+---
+tags:
+- BSI APP.4.4.A14
+---
 # Use Dedicated Nodes for Additional Services
 
 * Status: accepted

--- a/docs/compliantkubernetes/ciso-guide/backup.md
+++ b/docs/compliantkubernetes/ciso-guide/backup.md
@@ -2,6 +2,7 @@
 tags:
 - ISO 27001 A.12.3.1
 - ISO 27001 A.17.1.1
+- BSI APP.4.4.A5
 ---
 
 # Backup Dashboard

--- a/docs/compliantkubernetes/ciso-guide/backup.md
+++ b/docs/compliantkubernetes/ciso-guide/backup.md
@@ -2,7 +2,7 @@
 tags:
 - ISO 27001 A.12.3.1
 - ISO 27001 A.17.1.1
-- BSI APP.4.4.A5
+- BSI IT-Grundschutz APP.4.4.A5
 ---
 
 # Backup Dashboard

--- a/docs/compliantkubernetes/operator-manual/maintenance.md
+++ b/docs/compliantkubernetes/operator-manual/maintenance.md
@@ -1,6 +1,7 @@
 ---
 tags:
 - ISO 27001 A.12.6.1
+- BSI APP.4.4.A21
 ---
 # Maintaining and Upgrading your Compliant Kubernetes environment.
 

--- a/docs/compliantkubernetes/operator-manual/maintenance.md
+++ b/docs/compliantkubernetes/operator-manual/maintenance.md
@@ -1,7 +1,7 @@
 ---
 tags:
 - ISO 27001 A.12.6.1
-- BSI APP.4.4.A21
+- BSI IT-Grundschutz APP.4.4.A21
 ---
 # Maintaining and Upgrading your Compliant Kubernetes environment.
 

--- a/docs/compliantkubernetes/user-guide/additional-services/index.md
+++ b/docs/compliantkubernetes/user-guide/additional-services/index.md
@@ -1,3 +1,7 @@
+---
+tags:
+- BSI APP.4.4.A16
+---
 Additional Services
 ===================
 

--- a/docs/compliantkubernetes/user-guide/additional-services/index.md
+++ b/docs/compliantkubernetes/user-guide/additional-services/index.md
@@ -1,6 +1,6 @@
 ---
 tags:
-- BSI APP.4.4.A16
+- BSI IT-Grundschutz APP.4.4.A16
 ---
 Additional Services
 ===================

--- a/docs/compliantkubernetes/user-guide/backup.md
+++ b/docs/compliantkubernetes/user-guide/backup.md
@@ -2,6 +2,7 @@
 description: Backing up data in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
 tags:
 - ISO 27001 A.12.3.1
+- BSI APP.4.4.A5
 ---
 
 # Backups

--- a/docs/compliantkubernetes/user-guide/backup.md
+++ b/docs/compliantkubernetes/user-guide/backup.md
@@ -2,7 +2,7 @@
 description: Backing up data in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
 tags:
 - ISO 27001 A.12.3.1
-- BSI APP.4.4.A5
+- BSI IT-Grundschutz APP.4.4.A5
 ---
 
 # Backups

--- a/docs/compliantkubernetes/user-guide/ci-cd.md
+++ b/docs/compliantkubernetes/user-guide/ci-cd.md
@@ -2,6 +2,7 @@
 description: Integrating with CI/CD in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
 tags:
 - BSI APP.4.4.A2
+- BSI APP.4.4.A10
 ---
 
 CI/CD Integration

--- a/docs/compliantkubernetes/user-guide/ci-cd.md
+++ b/docs/compliantkubernetes/user-guide/ci-cd.md
@@ -1,8 +1,8 @@
 ---
 description: Integrating with CI/CD in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
 tags:
-- BSI APP.4.4.A2
-- BSI APP.4.4.A10
+- BSI IT-Grundschutz APP.4.4.A2
+- BSI IT-Grundschutz APP.4.4.A10
 ---
 
 CI/CD Integration

--- a/docs/compliantkubernetes/user-guide/ci-cd.md
+++ b/docs/compliantkubernetes/user-guide/ci-cd.md
@@ -1,5 +1,7 @@
 ---
 description: Integrating with CI/CD in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
+tags:
+- BSI APP.4.4.A2
 ---
 
 CI/CD Integration

--- a/docs/compliantkubernetes/user-guide/delegation.md
+++ b/docs/compliantkubernetes/user-guide/delegation.md
@@ -2,6 +2,7 @@
 description: How to delegate and work with permissions in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
 tags:
 - ISO 27001 A.9.4.1
+- APP.4.4.A3
 ---
 
 # How to Delegate?

--- a/docs/compliantkubernetes/user-guide/delegation.md
+++ b/docs/compliantkubernetes/user-guide/delegation.md
@@ -2,7 +2,7 @@
 description: How to delegate and work with permissions in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
 tags:
 - ISO 27001 A.9.4.1
-- APP.4.4.A3
+- BSI APP.4.4.A3
 ---
 
 # How to Delegate?

--- a/docs/compliantkubernetes/user-guide/delegation.md
+++ b/docs/compliantkubernetes/user-guide/delegation.md
@@ -2,7 +2,7 @@
 description: How to delegate and work with permissions in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
 tags:
 - ISO 27001 A.9.4.1
-- BSI APP.4.4.A3
+- BSI IT-Grundschutz APP.4.4.A3
 ---
 
 # How to Delegate?

--- a/docs/compliantkubernetes/user-guide/demarcation.md
+++ b/docs/compliantkubernetes/user-guide/demarcation.md
@@ -1,5 +1,7 @@
 ---
 description: The demarcation between what users can and cannot do in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
+tags:
+- APP.4.4.A3
 ---
 
 Can I?

--- a/docs/compliantkubernetes/user-guide/demarcation.md
+++ b/docs/compliantkubernetes/user-guide/demarcation.md
@@ -1,7 +1,7 @@
 ---
 description: The demarcation between what users can and cannot do in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
 tags:
-- APP.4.4.A3
+- BSI APP.4.4.A3
 ---
 
 Can I?

--- a/docs/compliantkubernetes/user-guide/demarcation.md
+++ b/docs/compliantkubernetes/user-guide/demarcation.md
@@ -1,7 +1,7 @@
 ---
 description: The demarcation between what users can and cannot do in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
 tags:
-- BSI APP.4.4.A3
+- BSI IT-Grundschutz APP.4.4.A3
 ---
 
 Can I?

--- a/docs/compliantkubernetes/user-guide/network-model.md
+++ b/docs/compliantkubernetes/user-guide/network-model.md
@@ -5,6 +5,8 @@ tags:
 - ISO 27001 A.13.1.1
 - ISO 27001 A.13.1.2
 - ISO 27001 A.13.1.3
+- BSI APP.4.4.A7
+- BSI APP.4.4.A18
 ---
 
 Network Model

--- a/docs/compliantkubernetes/user-guide/network-model.md
+++ b/docs/compliantkubernetes/user-guide/network-model.md
@@ -5,8 +5,8 @@ tags:
 - ISO 27001 A.13.1.1
 - ISO 27001 A.13.1.2
 - ISO 27001 A.13.1.3
-- BSI APP.4.4.A7
-- BSI APP.4.4.A18
+- BSI IT-Grundschutz APP.4.4.A7
+- BSI IT-Grundschutz APP.4.4.A18
 ---
 
 Network Model

--- a/docs/compliantkubernetes/user-guide/prepare-application.md
+++ b/docs/compliantkubernetes/user-guide/prepare-application.md
@@ -2,6 +2,7 @@
 description: How to prepare your application for Elastisys Compliant Kubernetes, the security-focused kubernetes distribution.
 tags:
 - ISO 27001 A.12.6.1
+- BSI APP.4.4.A21
 ---
 
 # Prepare Your Application

--- a/docs/compliantkubernetes/user-guide/prepare-application.md
+++ b/docs/compliantkubernetes/user-guide/prepare-application.md
@@ -2,7 +2,7 @@
 description: How to prepare your application for Elastisys Compliant Kubernetes, the security-focused kubernetes distribution.
 tags:
 - ISO 27001 A.12.6.1
-- BSI APP.4.4.A21
+- BSI IT-Grundschutz APP.4.4.A21
 ---
 
 # Prepare Your Application

--- a/docs/compliantkubernetes/user-guide/safeguards/enforce-networkpolicies.md
+++ b/docs/compliantkubernetes/user-guide/safeguards/enforce-networkpolicies.md
@@ -3,8 +3,8 @@ tags:
 - ISO 27001 A.13.1.1
 - ISO 27001 A.13.1.2
 - ISO 27001 A.13.1.3
-- BSI APP.4.4.A7
-- BSI APP.4.4.A18
+- BSI IT-Grundschutz APP.4.4.A7
+- BSI IT-Grundschutz APP.4.4.A18
 ---
 # Reduce blast radius: NetworkPolicies
 

--- a/docs/compliantkubernetes/user-guide/safeguards/enforce-networkpolicies.md
+++ b/docs/compliantkubernetes/user-guide/safeguards/enforce-networkpolicies.md
@@ -3,6 +3,8 @@ tags:
 - ISO 27001 A.13.1.1
 - ISO 27001 A.13.1.2
 - ISO 27001 A.13.1.3
+- BSI APP.4.4.A7
+- BSI APP.4.4.A18
 ---
 # Reduce blast radius: NetworkPolicies
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,7 +123,7 @@ nav:
     - 'FAQ': 'compliantkubernetes/operator-manual/faq.md'
   - 'For CISOs':
     - 'Overview': 'compliantkubernetes/ciso-guide/index.md'
-    - 'ISO 27001 Controls': 'compliantkubernetes/ciso-guide/controls.md'
+    - 'ISO 27001 and BSI Controls': 'compliantkubernetes/ciso-guide/controls.md'
     - 'Audit Logs': 'compliantkubernetes/ciso-guide/audit-logs.md'
     - 'Backup': 'compliantkubernetes/ciso-guide/backup.md'
     - 'Cryptography': 'compliantkubernetes/ciso-guide/cryptography.md'


### PR DESCRIPTION
Fixes #363 

I went through "APP.4.4 Kubernetes" and added "quick wins". They are currently part of the ISO 27001 page, because that is what is easier to do within the documentation project. Happy to fix this in another issues.

There are a few controls that I didn't touch:

- APP.4.4.A1 Planung der Separierung der Anwendungen (B), i.e., "use separate clusters for production and testing", this is something that we should cover in our ToS.
- APP.4.4.A6 Initialisierung von Pods (S), this is something application developers need to do.
- APP.4.4.A11 Überwachung der Container (S), i.e., add liveliness and readiness probes, this is something application developers need to do.
- APP.4.4.A12 Absicherung der Infrastruktur-Anwendungen (S), i.e., infrastructure security, this is an operational concern. Unsure where to put this in the public docs.
- APP.4.4.A13 Automatisierte Auditierung der Konfiguration (H), we do this as part of QA.
- APP.4.4.A17 Attestierung von Nodes (H), i.e., "use TPMs", this is something our providers need to offer.
- APP.4.4.A20 Verschlüsselte Datenhaltung bei Pods (H), again dealt with from below.

Need to run, cheers!