### PR TITLE
Clarify ISO 27001 A.14.2.4

### DIFF
--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,12 +1,14 @@
 ---
 tags:
   - ISO 27001 A.14.1.1
+  - ISO 27001 A.14.2.4
 ---
 # Architectural Decision Log
 
 ## Mapping to ISO 27001 Controls
 
 * A.14.1.1 "Information security requirements analysis and specification"
+* A.14.2.4 "Restrictions on Changes to Software Packages"
 
 ## What are architectural decisions?
 


### PR DESCRIPTION
Our internal audit revealed that we haven't made it clear that our arch process maps to ISO 27001 A.14.2.4 "Restrictions on Changes to Software Packages".

This patch clarifies it.