### PR TITLE
Separate controls

### DIFF
--- a/docs/ciso-guide/controls/bsi-it-grundschutz.md
+++ b/docs/ciso-guide/controls/bsi-it-grundschutz.md
@@ -1,0 +1,39 @@
+# BSI IT-Grundschutz Controls
+
+Click on the links below to navigate the documentation by control.
+
+[TAGS]
+
+## Other IT-Grundschutz Controls
+
+### APP.4.4.A17 Attestierung von Nodes (H)
+
+The Kubespray layer in Compliant Kubernetes ensures that Data Plane Nodes and Control Plane Nodes are mutually authenticated via mutual TLS.
+
+## BSI IT-Grundschutz Controls outside the scope of Compliant Kubernetes
+
+Pending official translation into English, the controls are written in German.
+
+### APP.4.4.A1 Planung der Separierung der Anwendungen (B)
+
+Compliant Kubernetes recommends to setting up at least two separate environments: one for testing and one for production.
+
+### APP.4.4.A6 Initialisierung von Pods (S)
+
+Application developers must make sure that initialization happens in [init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/).
+
+### APP.4.4.A11 Überwachung der Container (S)
+
+Application developers must ensure that their application has a liveliness and readiness probe, which are configured in the Deployment. This is illustrated by our [user demo](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/templates/deployment.yaml).
+
+### APP.4.4.A12 Absicherung der Infrastruktur-Anwendungen (S)
+
+This requirement essentially states that the Compliant Kubernetes environments are only as secure as the infrastructure around them. Make sure you have a proper IT policy in place. Regularly review the systems where you store backups and configuration of Compliant Kubernetes.
+
+### APP.4.4.A13 Automatisierte Auditierung der Konfiguration (H)
+
+Compliant Kubernetes administrators must regularly audit the configuration of their environments. We recommend doing this on a quarterly basis.
+
+### APP.4.4.A20 Verschlüsselte Datenhaltung bei Pods (H)
+
+Compliant Kubernetes recommends disk encryption to be provided at the infrastructure level. If you have this requirement, check for full-disk encryption via the [provider audit](../../operator-manual/provider-manual).

--- a/docs/ciso-guide/controls/hipaa.md
+++ b/docs/ciso-guide/controls/hipaa.md
@@ -1,42 +1,8 @@
-# ISO 27001, BSI IT-Grundschutz and HIPAA Controls
+# HIPAA Controls
 
 Click on the links below to navigate the documentation by control.
 
 [TAGS]
-
-## Other IT-Grundschutz Controls
-
-### APP.4.4.A17 Attestierung von Nodes (H)
-
-The Kubespray layer in Compliant Kubernetes ensures that Data Plane Nodes and Control Plane Nodes are mutually authenticated via mutual TLS.
-
-## BSI IT-Grundschutz Controls outside the scope of Compliant Kubernetes
-
-Pending official translation into English, the controls are written in German.
-
-### APP.4.4.A1 Planung der Separierung der Anwendungen (B)
-
-Compliant Kubernetes recommends to setting up at least two separate environments: one for testing and one for production.
-
-### APP.4.4.A6 Initialisierung von Pods (S)
-
-Application developers must make sure that initialization happens in [init containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/).
-
-### APP.4.4.A11 Überwachung der Container (S)
-
-Application developers must ensure that their application has a liveliness and readiness probe, which are configured in the Deployment. This is illustrated by our [user demo](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/templates/deployment.yaml).
-
-### APP.4.4.A12 Absicherung der Infrastruktur-Anwendungen (S)
-
-This requirement essentially states that the Compliant Kubernetes environments are only as secure as the infrastructure around them. Make sure you have a proper IT policy in place. Regularly review the systems where you store backups and configuration of Compliant Kubernetes.
-
-### APP.4.4.A13 Automatisierte Auditierung der Konfiguration (H)
-
-Compliant Kubernetes administrators must regularly audit the configuration of their environments. We recommend doing this on a quarterly basis.
-
-### APP.4.4.A20 Verschlüsselte Datenhaltung bei Pods (H)
-
-Compliant Kubernetes recommends disk encryption to be provided at the infrastructure level. If you have this requirement, check for full-disk encryption via the [provider audit](../../operator-manual/provider-manual).
 
 ## Other HIPAA Controls
 

--- a/docs/ciso-guide/controls/iso-27001.md
+++ b/docs/ciso-guide/controls/iso-27001.md
@@ -1,0 +1,5 @@
+# ISO 27001 Controls
+
+Click on the links below to navigate the documentation by control.
+
+[TAGS]

--- a/mkdocs-ciso-controls/.gitignore
+++ b/mkdocs-ciso-controls/.gitignore
@@ -1,0 +1,27 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST

--- a/mkdocs-ciso-controls/README.md
+++ b/mkdocs-ciso-controls/README.md
@@ -7,6 +7,7 @@ This is a PoC solving the following use-case. The Compliant Kubernetes documenta
 tags:
 - ISO 27001 A13.1
 - HIPAA S13
+- BSI IT-Grundschutz APP.X
 ```
 
 The goal of this plugin is to:
@@ -22,15 +23,14 @@ In `mkdocs.yaml`:
 ```
 plugins:
   - ciso-controls:
-      root_url: /ciso-guide/controls/
-      control_sources:
-        - 'ISO 27001'
-        - 'HIPAA'
-        - 'BSI IT-Grundschutz'
+      root_url: ciso-guide/controls/
 ```
 
-Tag indexes will be generated at:
+For the example above, the following files are expected to exist:
 
-* `/ciso-guide/controls/iso-27001`;
-* `/ciso-guide/controls/hipaa`;
-* `/ciso-guide/controls/bsi-it-grundschutz`.
+* `ciso-guide/controls/iso-27001.md`;
+* `ciso-guide/controls/bsi-it-grundschutz.md`;
+* `ciso-guide/controls/hipaa.md`.
+
+These files are expected to contain the string `[TAGS]`, which will be replaced with an index to all tags prefixed with the name of the page.
+

--- a/mkdocs-ciso-controls/README.md
+++ b/mkdocs-ciso-controls/README.md
@@ -1,0 +1,36 @@
+# CISO Control Plugin for Mkdocs
+
+This is a PoC solving the following use-case. The Compliant Kubernetes documentation uses tags to capture various Information Security Management System (ISMS) controls, such as:
+
+```
+# In the YAML frontmatter of the page
+tags:
+- ISO 27001 A13.1
+- HIPAA S13
+```
+
+The goal of this plugin is to:
+
+1. Create tag indexes for each requirement source. In the example above "ISO 27001" and "HIPAA" is each a requirement source.
+
+2. Create bi-directional links between tag indexes and pages.
+
+## Usage
+
+In `mkdocs.yaml`:
+
+```
+plugins:
+  - ciso-controls:
+      root_url: /ciso-guide/controls/
+      control_sources:
+        - 'ISO 27001'
+        - 'HIPAA'
+        - 'BSI IT-Grundschutz'
+```
+
+Tag indexes will be generated at:
+
+* `/ciso-guide/controls/iso-27001`;
+* `/ciso-guide/controls/hipaa`;
+* `/ciso-guide/controls/bsi-it-grundschutz`.

--- a/mkdocs-ciso-controls/ciso_controls/__init__.py
+++ b/mkdocs-ciso-controls/ciso_controls/__init__.py
@@ -1,0 +1,48 @@
+from collections import defaultdict
+
+from markdown.extensions.toc import slugify
+import mkdocs
+
+class CisoControlsPlugin(mkdocs.plugins.BasePlugin):
+    config_scheme = (
+        ("root_url", mkdocs.config.config_options.Type(str, default="/controls/")),
+        ("control_sources", mkdocs.config.config_options.Type(list, default=[])),
+    )
+
+    def on_config(self, config):
+         self.tags = defaultdict(list)
+         self.root_url = self.config.get('root_url')
+         self.control_sources = self.config.get('control_sources')
+
+    def on_pre_build(*args, **kwargs):
+        return
+
+    def on_nav(*args, **kwargs):
+        return
+
+    def on_page_markdown(self, markdown, page, config, files):
+        # TODO: Render tag index
+        # Add page to tags index
+        for tag in page.meta.get("tags", []):
+            self.tags[tag].append(page)
+
+    def on_page_context(self, context, page, config, nav):
+        # Inject tags into page (after search and before minification)
+        if "tags" in page.meta:
+            context["tags"] = [
+                self._render_tag(tag)
+                    for tag in page.meta["tags"]
+            ]
+            print(context["tags"])
+
+    # Render the given tag, linking to the tags index (if enabled)
+    def _render_tag(self, tag):
+        url = None
+        for control_source in self.control_sources:
+            if tag.startswith(control_source):
+                url = self.root_url + \
+                    slugify(control_source, '-') + "#" + \
+                    slugify(tag, '-')
+        if not url:
+            raise Exception("Unrecognized control source")
+        return dict(name = tag, type = type, url = url)

--- a/mkdocs-ciso-controls/ciso_controls/__init__.py
+++ b/mkdocs-ciso-controls/ciso_controls/__init__.py
@@ -1,30 +1,46 @@
+# Inspired by:
+# - https://github.com/squidfunk/mkdocs-material/tree/8.2.16/material/plugins/tags
+# - https://github.com/aklajnert/mkdocs-simple-hooks/blob/v0.1.5/mkdocs_simple_hooks/__init__.py
+
 from collections import defaultdict
+import logging
+import os
+import sys
 
 from markdown.extensions.toc import slugify
 import mkdocs
 
 class CisoControlsPlugin(mkdocs.plugins.BasePlugin):
     config_scheme = (
-        ("root_url", mkdocs.config.config_options.Type(str, default="/controls/")),
-        ("control_sources", mkdocs.config.config_options.Type(list, default=[])),
+        ("root_url", mkdocs.config.config_options.Type(str, default="controls/")),
     )
 
     def on_config(self, config):
-         self.tags = defaultdict(list)
-         self.root_url = self.config.get('root_url')
-         self.control_sources = self.config.get('control_sources')
+        self.tags = { } # shape: Dict[tags_index, Dict[tag, list of pages]]
+        self.root_url = self.config.get('root_url')
 
-    def on_pre_build(*args, **kwargs):
-        return
-
-    def on_nav(*args, **kwargs):
-        return
+    # Move tags indexes to the end to ensure we first collect all page tags
+    def on_nav(self, nav, files, **kwargs):
+        tags_indexes = []
+        for filename, file in files.src_paths.items():
+            if file.url.startswith(self.root_url):
+                tags_indexes.append(file)
+        for file in tags_indexes:
+            files.remove(file)
+            files.append(file)
+            tags_index = file.name
+            self.tags[tags_index] = defaultdict(list)
+            log.info(f'Found tags index URL: {file.url}')
 
     def on_page_markdown(self, markdown, page, config, files):
-        # TODO: Render tag index
+        if page.url.startswith(self.root_url):
+            log.info(f"Rendering tags index: {page.file.url}")
+            return self.__render_tag_index(markdown, page)
+
         # Add page to tags index
         for tag in page.meta.get("tags", []):
-            self.tags[tag].append(page)
+            tags_index = self._tag_to_tags_index(tag)
+            self.tags[tags_index][tag].append(page)
 
     def on_page_context(self, context, page, config, nav):
         # Inject tags into page (after search and before minification)
@@ -33,16 +49,64 @@ class CisoControlsPlugin(mkdocs.plugins.BasePlugin):
                 self._render_tag(tag)
                     for tag in page.meta["tags"]
             ]
-            print(context["tags"])
 
-    # Render the given tag, linking to the tags index (if enabled)
+    # Our slugify
+    def slugify(self, name):
+        return slugify(name, '-')
+
+    # Map a tag to a tags index
+    def _tag_to_tags_index(self, tag):
+        slugified_tag = self.slugify(tag)
+        for tags_index in self.tags.keys():
+            if slugified_tag.startswith(tags_index):
+                return tags_index
+        log.info(
+            'Collected the following tags indexes: ' +
+            ' '.join(self.tags.keys()))
+        log.error(f'No tags index for tag: {tag}')
+        sys.exit()
+
+    # Render tags index
+    def __render_tag_index(self, markdown, page):
+        if not "[TAGS]" in markdown:
+            markdown += "\n[TAGS]"
+
+        tags_index = page.file.name
+        tags = self.tags[tags_index]
+
+        # Replace placeholder in Markdown with rendered tags index
+        return markdown.replace("[TAGS]", "\n".join([
+            self.__render_tag_links(*args, self_page=page)
+                for args in sorted(tags.items())
+        ]))
+
+    # Render the given tag and links to all pages with occurrences
+    def __render_tag_links(self, tag, pages, self_page):
+        content = [f"## <span class=\"md-tag\">{tag}</span>", ""]
+        for page in pages:
+            url = mkdocs.utils.get_relative_url(
+                page.file.src_path.replace(os.path.sep, "/"),
+                self_page.file.src_path.replace(os.path.sep, "/")
+            )
+
+            # Ensure forward slashes, as we have to use the path of the source
+            # file which contains the operating system's path separator.
+            content.append("- [{}]({})".format(
+                page.meta.get("title", page.title),
+                url
+            ))
+
+        # Return rendered tag links
+        return "\n".join(content)
+
+    # Render the given tag, linking to the tags index
     def _render_tag(self, tag):
-        url = None
-        for control_source in self.control_sources:
-            if tag.startswith(control_source):
-                url = self.root_url + \
-                    slugify(control_source, '-') + "#" + \
-                    slugify(tag, '-')
-        if not url:
-            raise Exception("Unrecognized control source")
+        tags_index = self._tag_to_tags_index(tag)
+        url = self.root_url + \
+            self.slugify(tags_index) + "#" + \
+            self.slugify(tag)
         return dict(name = tag, type = type, url = url)
+
+# Set up logging
+log = logging.getLogger("mkdocs")
+log.addFilter(mkdocs.commands.build.DuplicateFilter())

--- a/mkdocs-ciso-controls/setup.py
+++ b/mkdocs-ciso-controls/setup.py
@@ -1,0 +1,37 @@
+from setuptools import find_packages
+from setuptools import setup
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setup(
+    name="mkdocs-ciso-controls",
+    version="0.0.1",
+    author="Cristian Klein",
+    author_email="cristian.klein@elastisys.com",
+    description="Use tags to capture ISMS controls and group them by source.",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    license="MIT",
+    packages=find_packages(),
+    install_requires=["mkdocs>=1.2"],
+    include_package_data=True,
+    zip_safe=False,
+    entry_points={
+        "mkdocs.plugins": [
+            "ciso-controls = ciso_controls:CisoControlsPlugin"
+        ]
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Intended Audience :: Developers",
+        "Topic :: Documentation",
+    ],
+)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,11 +49,7 @@ plugins:
       javascript_dir: js       # the directory to put the version selector's JS
       canonical_version: null
   - ciso-controls:
-      root_url: /ciso-guide/controls/
-      control_sources:
-        - 'ISO 27001'
-        - 'HIPAA'
-        - 'BSI IT-Grundschutz'
+      root_url: ciso-guide/controls/
 
 markdown_extensions:
   - attr_list
@@ -137,7 +133,10 @@ nav:
     - 'FAQ': 'operator-manual/faq.md'
   - 'For CISOs':
     - 'Overview': 'ciso-guide/index.md'
-    - 'ISO 27001, BSI IT-Grundschutz and HIPAA': 'ciso-guide/controls.md'
+    - 'Controls by Regulation/Standard':
+      - 'ISO 27001': 'ciso-guide/controls/iso-27001.md'
+      - 'HIPAA': 'ciso-guide/controls/hipaa.md'
+      - 'BSI IT-Grundschutz': 'ciso-guide/controls/bsi-it-grundschutz.md'
     - 'Audit Logs': 'ciso-guide/audit-logs.md'
     - 'Backup': 'ciso-guide/backup.md'
     - 'Cryptography': 'ciso-guide/cryptography.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,8 +48,12 @@ plugins:
       css_dir: css             # the directory to put the version selector's CSS
       javascript_dir: js       # the directory to put the version selector's JS
       canonical_version: null
-  - tags:
-      tags_file: ciso-guide/controls.md
+  - ciso-controls:
+      root_url: /ciso-guide/controls/
+      control_sources:
+        - 'ISO 27001'
+        - 'HIPAA'
+        - 'BSI IT-Grundschutz'
 
 markdown_extensions:
   - attr_list

--- a/overrides/partials/content.html
+++ b/overrides/partials/content.html
@@ -1,0 +1,51 @@
+<!--
+  Copyright (c) 2016-2023 Martin Donath <martin.donath@squidfunk.com>
+  Copyright (c) 2023 Cristian Klein <cristian.klein@elastisys.com>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+<!-- Tags -->
+{% include "partials/tags.html" %}
+
+<!-- Actions -->
+{% include "partials/actions.html" %}
+
+<!--
+  Check whether the content starts with a level 1 headline. If it doesn't, the
+  page title (or respectively site name) is used as the main headline.
+-->
+{% set first = page.toc | first %}
+{% if first and first.level != 1 %}
+  <h1>{{ page.title | d(config.site_name, true)}}</h1>
+{% endif %}
+
+<!-- Page content -->
+{{ page.content }}
+
+<!-- Source file information -->
+{% if page.meta and (
+  page.meta.git_revision_date_localized or
+  page.meta.revision_date
+) %}
+  {% include "partials/source-file.html" %}
+{% endif %}
+
+<!-- Was this page helpful? -->
+{% include "partials/feedback.html" %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ pymdown-extensions>=9.0
 mkdocs-material-extensions>=1.0
 mkdocs-include-markdown-plugin>=2.8
 mike>=1.1.2
+./mkdocs-ciso-controls


### PR DESCRIPTION
Fixes #461 and #443

Implementation is "hobby" quality, but the result should be sufficient for our needs.

Contributor Experience-wise, I'd say that this implementation is somewhat better than [`tags_extra_files`](https://squidfunk.github.io/mkdocs-material/setup/setting-up-tags/?h=tags#+tags.tags_extra_files), since the mapping from tags to tag identifiers (what we "tags indexes") is automatically done by matching the prefix of each tag.

Throw tomatoes!

![image](https://user-images.githubusercontent.com/1660833/211913844-b63763ed-fb92-4956-b873-26ad423c1b0b.png)
