### PR TITLE
Link to dotcom

### DIFF
--- a/docs/img/git-alt.svg
+++ b/docs/img/git-alt.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 448 512"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="git-alt.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="0.4609375"
+     inkscape:cx="195.79661"
+     inkscape:cy="256"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <!--! Font Awesome Free 6.2.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc. -->
+  <path
+     d="M439.55 236.05L244 40.45a28.87 28.87 0 0 0-40.81 0l-40.66 40.63 51.52 51.52c27.06-9.14 52.68 16.77 43.39 43.68l49.66 49.66c34.23-11.8 61.18 31 35.47 56.69-26.49 26.49-70.21-2.87-56-37.34L240.22 199v121.85c25.3 12.54 22.26 41.85 9.08 55a34.34 34.34 0 0 1-48.55 0c-17.57-17.6-11.07-46.91 11.25-56v-123c-20.8-8.51-24.6-30.74-18.64-45L142.57 101 8.45 235.14a28.86 28.86 0 0 0 0 40.81l195.61 195.6a28.86 28.86 0 0 0 40.8 0l194.69-194.69a28.86 28.86 0 0 0 0-40.81z"
+     id="path2"
+     style="stroke:none;stroke-opacity:1;fill:#ffffff;fill-opacity:1" />
+</svg>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -2,3 +2,41 @@
     font-size: 1.3em;
     font-family: 'Poppins', sans-serif;
 }
+
+.menu-callout {
+  background-color: var(--esys-orange-01);
+  border: none;
+  color: white;
+  padding: 5px 10px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 14px;
+  transition-duration: 0.4s;
+  font-family: 'Poppins', sans-serif;
+}
+
+.menu-callout:hover {
+  background-color: var(--esys-orange-04);
+}
+
+.header-links {
+    display: block;
+    list-style-type: none;
+    margin-block-start: 0px;
+    margin-block-end: 0px;
+    padding: 0;
+    padding-inline-start: 0;
+}
+
+.header-links li {
+    display: inline;
+}
+
+header .header-links li {
+    margin-left: 2em;
+}
+
+.header-links li:first-child {
+    margin-left: 0px;
+}

--- a/overrides/partials/source.html
+++ b/overrides/partials/source.html
@@ -1,12 +1,8 @@
 {% import "partials/language.html" as lang with context %}
 
-<a
-  href="{{ config.repo_url }}"
-  title="{{ lang.t('source.link.title') }}"
-  style="display: block; font-size: .65rem; line-height: 1.2; white-space: nowrap; -webkit-backface-visibility: hidden; backface-visibility: hidden; transition: opacity 250ms;"
->
-  <div class="md-source__icon md-icon">
-    {% set icon = config.theme.icon.repo or "fontawesome/brands/git-alt" %}
-    {% include ".icons/" ~ icon ~ ".svg" %}
-  </div>
-</a>
+<ul class="header-links">
+  <li>
+    <a href="{{ config.repo_url }}"><img width="25px" src="img/git-alt.svg" /></a></li>
+  <li><a href="https://elastisys.com/" class="menu-callout">Try out Managed<br/>Compliant Kubernetes</a></li>
+</ul>
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@
 # IN THE SOFTWARE.
 
 # Direct dependencies
-mkdocs>=1.2
+mkdocs>=1.4
 mkdocs-material>=8.2
 Pygments>=2.10
 markdown>=3.2


### PR DESCRIPTION
Solves https://github.com/elastisys/marketing/issues/42 by adding a link to the elastisys.com website, using a prominent button-like element in the header.

Desktop view:

![image](https://user-images.githubusercontent.com/1425662/214494321-86346c45-184c-41dd-b1f1-3ff5cb960fb4.png)

Mobile view:

![image](https://user-images.githubusercontent.com/1425662/214494382-e63318e2-4143-421e-9e6f-e745c0dd2afa.png)
