### PR TITLE
fix(docs): broken link in deploy demo docs

### DIFF
--- a/docs/user-guide/kubernetes-api.md
+++ b/docs/user-guide/kubernetes-api.md
@@ -116,7 +116,7 @@ git clone https://github.com/elastisys/compliantkubernetes/
 cd compliantkubernetes/user-demo
 ```
 
-Ensure you use the right registry project and image tag, i.e., those that you pushed in the [previous example](/user-guide/registry#running-example):
+Ensure you use the right registry project and image tag, i.e., those that you pushed in the [previous example](#build-and-push-the-image)
 
 ```bash
 REGISTRY_PROJECT=demo


### PR DESCRIPTION
Found a link that did not work, in the "Step 2: Deploy" page on the docs. Now it should work.