### PR TITLE
Allow example CI-CD role to read certificates

### DIFF
--- a/user-demo/deploy/ci-cd-role.yaml
+++ b/user-demo/deploy/ci-cd-role.yaml
@@ -85,3 +85,11 @@ rules:
     - patch
     - update
     - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
Useful to allow the CI-CD pipeline to inspect the success of the deployment, as we recommend in our "starter kit":
https://github.com/elastisys/ck8s-starter-nodejs