### PR TITLE
docs: added the port instead of the name for proxy urls

### DIFF
--- a/docs/user-guide/alerts.md
+++ b/docs/user-guide/alerts.md
@@ -45,7 +45,7 @@ Make sure to configure **and test** a receiver for you alerts, e.g., Slack or Op
 If you want to access AlertManager, for example to confirm that its configuration was picked up correctly, or to configure silences, proceed as follows:
 
 1. Type: `kubectl proxy`.
-2. Open [this link](http://127.0.0.1:8001/api/v1/namespaces/alertmanager/services/alertmanager-operated:web/proxy/) in your browser.
+2. Open [this link](http://127.0.0.1:8001/api/v1/namespaces/alertmanager/services/alertmanager-operated:9093/proxy/) in your browser.
 
 ## Configuring alerts
 

--- a/docs/user-guide/metrics.md
+++ b/docs/user-guide/metrics.md
@@ -51,7 +51,7 @@ Compliant Kubernetes installs the prometheus-operator by default. The Prometheus
 #### Accessing Prometheus
 If you want to access the web interface of Prometheus, proceed as follows:
     1. Type: `kubectl proxy`
-    2. Open [this link](http://127.0.0.1:8001/api/v1/namespaces/monitoring/services/kube-prometheus-stack-prometheus:web/proxy/) in your browser
+    2. Open [this link](http://127.0.0.1:8001/api/v1/namespaces/monitoring/services/kube-prometheus-stack-prometheus:9090/proxy/) in your browser
 
 The Prometheus UI is only available by default starting in Compliant Kubernetes version 0.26.
 


### PR DESCRIPTION
As the port name will change for prometheus and alertmanager, in the next version of kube-promethus-stack, we said that it mighty be better to use the port for the customer facing documents.