### PR TITLE
Add GDPR controls

### DIFF
--- a/docs/ciso-guide/controls/gdpr.md
+++ b/docs/ciso-guide/controls/gdpr.md
@@ -24,7 +24,7 @@ When it comes to security, GDPR is rather broad and non-prescriptive.
 Pretty much everything we do in Compliant Kubernetes is done to secure data.
 This includes, for instance, that we perform vulnerability scanning both at rest and at runtime, process logs in a separate cluster controlled with restrictive access controls to make them tamper-proof from hacked applications, and that we put safeguards in place to make developers enforce network segregation per application component. 
 And much more.
-In fact, we could pretty much link every single page to GDPR Art. 32, but that would be rather noisy.
+In fact, we could pretty much link every single page to GDPR Art. 32, but that would be rather noisy!
 
 Hence, if you need a more precise understanding on how Compliant Kubernetes protects personal data as required by GDPR Art. 32, please look at our [ISO 27001 Controls](../iso-27001), which links to both more technical controls, and continuous confidentiality, integrity, availability and resilience of processing processes, such as our go-live checklist. 
 

--- a/docs/ciso-guide/controls/gdpr.md
+++ b/docs/ciso-guide/controls/gdpr.md
@@ -22,6 +22,8 @@ If you process [personal data](https://gdpr.fan/a4) in the EU/EEA, you need to f
 
 When it comes to security, GDPR is rather broad and non-prescriptive.
 Pretty much everything we do in Compliant Kubernetes is done to secure data.
+This includes, for instance, that we perform vulnerability scanning both at rest and at runtime, process logs in a separate cluster controlled with restrictive access controls to make them tamper-proof from hacked applications, and that we put safeguards in place to make developers enforce network segregation per application component. 
+And much more.
 In fact, we could pretty much link every single page to GDPR Art. 32, but that would be rather noisy.
 
 Hence, if you need a more precise understanding on how Compliant Kubernetes protects personal data as required by GDPR Art. 32, please look at [ISO 27001 Controls](../iso-27001).

--- a/docs/ciso-guide/controls/gdpr.md
+++ b/docs/ciso-guide/controls/gdpr.md
@@ -34,5 +34,5 @@ Hence, if you need a more precise understanding on how Compliant Kubernetes prot
 
 * [What is personal data?](https://gdpr.fan/a4)
 * [Art. 28 GDPR Processor](https://gdpr.fan/a28)
-* [Art. 17 GDPR Right to erasure (‘right to be forgotten’)](https://gdpr.fan/a17)
+* [Art. 17 GDPR Right to erasure ("right to be forgotten")](https://gdpr.fan/a17)
 * [Art. 32 GDPR Security of processing](https://gdpr.fan/a32)

--- a/docs/ciso-guide/controls/gdpr.md
+++ b/docs/ciso-guide/controls/gdpr.md
@@ -1,0 +1,36 @@
+# GDPR (Regulation (EU) 2016/679)
+
+{%
+   include-markdown '_common.include'
+   start='<!--legal-disclaimer-start-->'
+   end='<!--legal-disclaimer-end-->'
+%}
+
+!!!note
+    Fully implementing GDPR entails a lot of work, like:
+
+    * Assigning a DPO;
+    * Documenting Records of Processing Activities;
+    * Writing Privacy Policies;
+    * Signing Data Protection Agreements with your suppliers.
+
+    This page only points you to the GDPR concerns relevant for Compliant Kubernetes.
+
+If you process [personal data](https://gdpr.fan/a4) in the EU/EEA, you need to follow GDPR.
+
+## GDPR Art. 32 Security of Processing
+
+When it comes to security GDPR is rather broad and non-prescription.
+Pretty much everything we do in Compliant Kubernetes is done to secure data.
+In fact, we could pretty much link every single page to GDPR Art. 32, but that would be rather noisy.
+
+Hence, if you need a more precise understanding on how Compliant Kubernetes protects personal data as required by GDPR Art. 32, please look at [ISO 27001 Controls](../iso-27001).
+
+[TAGS]
+
+## Further reading
+
+* [What is personal data?](https://gdpr.fan/a4)
+* [Art. 28 GDPR Processor](https://gdpr.fan/a28)
+* [Art. 17 GDPR Right to erasure (‘right to be forgotten’)](https://gdpr.fan/a17)
+* [Art. 32 GDPR Security of processing](https://gdpr.fan/a32)

--- a/docs/ciso-guide/controls/gdpr.md
+++ b/docs/ciso-guide/controls/gdpr.md
@@ -22,11 +22,11 @@ If you process [personal data](https://gdpr.fan/a4) in the EU/EEA, you need to f
 
 When it comes to security, GDPR is rather broad and non-prescriptive.
 Pretty much everything we do in Compliant Kubernetes is done to secure data.
-This includes, for instance, that we perform vulnerability scanning both at rest and at runtime, process logs in a separate cluster controlled with restrictive access controls to make them tamper-proof from hacked applications, and that we put safeguards in place to make developers enforce network segregation per application component. 
+This includes, for instance, that we perform vulnerability scanning both at rest and at runtime, process logs in a separate cluster controlled with restrictive access controls to make them tamper-proof from hacked applications, and that we put safeguards in place to make developers enforce network segregation per application component.
 And much more.
 In fact, we could pretty much link every single page to GDPR Art. 32, but that would be rather noisy!
 
-Hence, if you need a more precise understanding on how Compliant Kubernetes protects personal data as required by GDPR Art. 32, please look at our [ISO 27001 Controls](../iso-27001), which links to both more technical controls, and continuous confidentiality, integrity, availability and resilience of processing processes, such as our go-live checklist. 
+Hence, if you need a more precise understanding on how Compliant Kubernetes protects personal data as required by GDPR Art. 32, please look at our [ISO 27001 Controls](../iso-27001), which links to both more technical controls, and continuous confidentiality, integrity, availability and resilience of processing processes, such as our go-live checklist.
 
 [TAGS]
 

--- a/docs/ciso-guide/controls/gdpr.md
+++ b/docs/ciso-guide/controls/gdpr.md
@@ -20,7 +20,7 @@ If you process [personal data](https://gdpr.fan/a4) in the EU/EEA, you need to f
 
 ## GDPR Art. 32 Security of Processing
 
-When it comes to security GDPR is rather broad and non-prescription.
+When it comes to security, GDPR is rather broad and non-prescriptive.
 Pretty much everything we do in Compliant Kubernetes is done to secure data.
 In fact, we could pretty much link every single page to GDPR Art. 32, but that would be rather noisy.
 

--- a/docs/ciso-guide/controls/gdpr.md
+++ b/docs/ciso-guide/controls/gdpr.md
@@ -26,7 +26,7 @@ This includes, for instance, that we perform vulnerability scanning both at rest
 And much more.
 In fact, we could pretty much link every single page to GDPR Art. 32, but that would be rather noisy.
 
-Hence, if you need a more precise understanding on how Compliant Kubernetes protects personal data as required by GDPR Art. 32, please look at [ISO 27001 Controls](../iso-27001).
+Hence, if you need a more precise understanding on how Compliant Kubernetes protects personal data as required by GDPR Art. 32, please look at our [ISO 27001 Controls](../iso-27001), which links to both more technical controls, and continuous confidentiality, integrity, availability and resilience of processing processes, such as our go-live checklist. 
 
 [TAGS]
 

--- a/docs/operator-manual/provider-audit.md
+++ b/docs/operator-manual/provider-audit.md
@@ -15,6 +15,7 @@ tags:
 - MSBFS 2020:7 4 kap. 21 §
 - HSLF-FS 2016:40 3 kap. 9 § Upphandling och utveckling
 - HSLF-FS 2016:40 3 kap. 14 § Fysiskt skydd av informationssystem
+- GDPR Art. 28 Processor
 ---
 # Cloud Provider Audit
 

--- a/docs/user-guide/backup.md
+++ b/docs/user-guide/backup.md
@@ -7,7 +7,7 @@ tags:
 - MSBFS 2020:7 4 kap. 14 §
 - MSBFS 2020:7 4 kap. 15 §
 - HSLF-FS 2016:40 3 kap. 12 § Säkerhetskopiering
-- GDPR Art. 17 Right to erasure (‘right to be forgotten’)
+- GDPR Art. 17 Right to erasure ("right to be forgotten")
 ---
 
 # Backups

--- a/docs/user-guide/backup.md
+++ b/docs/user-guide/backup.md
@@ -7,6 +7,7 @@ tags:
 - MSBFS 2020:7 4 kap. 14 §
 - MSBFS 2020:7 4 kap. 15 §
 - HSLF-FS 2016:40 3 kap. 12 § Säkerhetskopiering
+- GDPR Art. 17 Right to erasure (‘right to be forgotten’)
 ---
 
 # Backups

--- a/docs/user-guide/long-term-log-retention.md
+++ b/docs/user-guide/long-term-log-retention.md
@@ -1,6 +1,7 @@
 ---
 tags:
 - HIPAA S48 - Audit Controls - § 164.312(b)
+- GDPR Art. 17 Right to erasure (‘right to be forgotten’)
 ---
 # Long-term log retention
 

--- a/docs/user-guide/long-term-log-retention.md
+++ b/docs/user-guide/long-term-log-retention.md
@@ -1,7 +1,7 @@
 ---
 tags:
 - HIPAA S48 - Audit Controls - § 164.312(b)
-- GDPR Art. 17 Right to erasure (‘right to be forgotten’)
+- GDPR Art. 17 Right to erasure ("right to be forgotten")
 ---
 # Long-term log retention
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
     - 'ISO 27001': 'ciso-guide/controls/iso-27001.md'
     - 'HSLF-FS 2016:40': 'ciso-guide/controls/hslf-fs-201640.md'
     - 'MSBFS 2020:7': 'ciso-guide/controls/msbfs-20207.md'
+    - 'GDPR': 'ciso-guide/controls/gdpr.md'
     - 'HIPAA': 'ciso-guide/controls/hipaa.md'
     - 'BSI IT-Grundschutz': 'ciso-guide/controls/bsi-it-grundschutz.md'
     - 'CISO Dashboards':


### PR DESCRIPTION
As requested by Commercial, we are now also mapping GDPR "controls" to Compliant Kubernetes documentation pages.

Adding @simonekman for approval, @llarsson for wordsmithing and @emmasundqvist for awareness.

![image](https://user-images.githubusercontent.com/1660833/226648398-c4bf582b-1247-4a7d-bdbc-31fe05d188a2.png)
