### PR TITLE
Add use of cryptography

### DIFF
--- a/docs/operator-manual/credentials.md
+++ b/docs/operator-manual/credentials.md
@@ -55,6 +55,8 @@ SSH Keys
     * Accessing Nodes via SSH
 * Do not use for:
     * Giving a system access to a Git repository. Create a separate SSH key only for that purpose instead.
+* Important considerations:
+    * When generating an SSH key, see [Cryptography](cryptography.md).
 
 PGP Keys
 --------
@@ -68,6 +70,8 @@ PGP Keys
     * Encrypting/decrypting individual credentials. These are meant to be individual and never shared.
     * Encrypting/decrypting SSH key. These are meant to be individual and never shared. Prefer [protecting your SSH key with a passphrase](https://martin.kleppmann.com/2013/05/24/improving-security-of-ssh-private-keys.html) or storing it on a [YubiKey](https://en.wikipedia.org/wiki/YubiKey).
     * Encrypting non-sensitive information. This leads to a culture of "security by obscurity" in which people over-rely on encryption. Prefer being mindful about what data you store and why. If unsure, prefer not storing credentials, as Cloud Provider Credentials and SSH keys should be enough to restore any access.
+* Important considerations:
+    * When generating a GPG key, see [Cryptography](cryptography.md).
 
 Cloud Controller (Integration) Credentials
 ------------------------------------------

--- a/docs/operator-manual/cryptography.md
+++ b/docs/operator-manual/cryptography.md
@@ -1,0 +1,40 @@
+---
+tags:
+- MSBFS 2020:7 4 kap. 9 §
+- ISO 27001 A.10 Cryptography
+- HIPAA S47 - Access Control - Encryption and Decryption - § 164.312(a)(2)(iv)
+---
+# Use of Cryptography
+
+Compliant Kubernetes recommends the ECRYPT-CSA "near term use".
+The key cryptographic parameters are listed below.
+
+## Recommended Strengths
+
+| Cryptographic Structure  | Size |
+|--------------------------|------|
+| Symmetric                |  128 |
+| Factoring Modulus        | 3072 |
+| Discrete Logarithm       |  256/3072 |
+| Elliptic Group           |  256 |
+| Hash                     |  256 |
+
+## Recommended Algorithms
+
+| Function             | Algorithm              |
+|----------------------|------------------------|
+| Block Ciphers        | AES<br/>Camellia<br/>Serpent |
+| Hash Functions       | SHA-2 (256, 384, 512, 512/256)<br />SHA-3 (256, 384, 512, SHAKE128, SHAKE256)<br />Whirlpool (512)<br />BLAKE (256, 584, 512) |
+| Public Key Primitive | RSA (>3072) <br/> DSA (>256/3072) <br/> ECDSA (>256) |
+
+!!!note
+    Compliant Kubernetes might use RSA 2048 when provisioning certificates via cert-manager and LetsEncrypt, which is lower than ECRYPT-CSA recommends for near-term use.
+    There is ongoing discussions to use RSA 4096 in website certificates (see discussions on [LetsEncrypt's own R3 certificate](https://community.letsencrypt.org/t/why-does-let-s-encrypt-r3s-cert-use-lower-rsa-than-the-root-cert/189339)).
+    Given that the certificate expires after 3 months, we assessed that this situation is **okay for now**.
+
+    The Compliant Kubernetes closely follows developments and discussions in the field and will take action when required.
+
+## Further Reading
+
+* [ECRYPT–CSA D5.4 Algorithms, Key Size and Protocols Report (2018)](https://ec.europa.eu/research/participants/documents/downloadPublic?documentIds=080166e5ba203b9b&appId=PPGMS)
+* [BlueCrypt Cryptographic Key Length Recommendation](https://www.keylength.com/en/3/)

--- a/docs/operator-manual/cryptography.md
+++ b/docs/operator-manual/cryptography.md
@@ -28,11 +28,13 @@ The key cryptographic parameters are listed below.
 | Public Key Primitive | RSA (>3072) <br/> DSA (>256/3072) <br/> ECDSA (>256) |
 
 !!!note
-    Compliant Kubernetes might use RSA 2048 when provisioning certificates via cert-manager and LetsEncrypt, which is lower than ECRYPT-CSA recommends for near-term use.
-    There is ongoing discussions to use RSA 4096 in website certificates (see discussions on [LetsEncrypt's own R3 certificate](https://community.letsencrypt.org/t/why-does-let-s-encrypt-r3s-cert-use-lower-rsa-than-the-root-cert/189339)).
-    Given that the certificate expires after 3 months, we assessed that this situation is **okay for now**.
+    For HTTPS traffic, Compliant Kubernetes uses [TLS 1.3](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.3).
+    TLS 1.3 mandates [forward secrecy](https://en.wikipedia.org/wiki/Forward_secrecy).
+    In other words, an attacker cannot decrypt past HTTPS transmissions even if the TLS certificate (private key) is compromised.
 
-    The Compliant Kubernetes closely follows developments and discussions in the field and will take action when required.
+    Compliant Kubernetes uses RSA 2048 when provisioning HTTPS certificates, which is lower than the present recommendation.
+    However, these certificates have a short expiration time of 3 months.
+    Hence, given the forward secrecy of TLS 1.3 and the short expiration time, **usage of RSA 2048 for HTTPS certificates does not add a security risk.**
 
 ## Further Reading
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,6 +133,7 @@ nav:
       - 'User Alerts': 'operator-manual/user-alerts.md'
     - 'Disaster Recovery': 'operator-manual/disaster-recovery.md'
     - 'Breaking the Glass': 'operator-manual/break-glass.md'
+    - 'Use of Cryptography': 'operator-manual/cryptography.md'
     - 'Use of Credentials': 'operator-manual/credentials.md'
     - 'Capacity Management': 'operator-manual/capacity-management.md'
     - 'Maintenance': 'operator-manual/maintenance.md'


### PR DESCRIPTION
As discussed during the arch meeting. We make it official that the Compliant Kubernetes project recommends ECRYPT-CSA's cryptographic recommendations. This is what we mandate at Elastisys. We need this for fulfilling various data protection controls, as shown in the docs.