### PR TITLE
add job ttl as safeguard

### DIFF
--- a/docs/user-guide/safeguards/enforce-job-ttl.md
+++ b/docs/user-guide/safeguards/enforce-job-ttl.md
@@ -1,0 +1,13 @@
+---
+tags: []
+---
+# Improve platform stability: Job TTL
+
+In Kubernetes, Jobs that are not managed by a higher-level resource such as a Cronjob, will most likely not get cleaned up automatically as Jobs do not have a default time-to-live, TTL, configured.
+In worst case the number of finished jobs could accumulate to such a volume that it might impact the stability of the Kubernetes cluster.
+
+However, by default in Compliant Kubernetes, Jobs that do not explicitly set a TTL (`spec.ttlSecondsAfterFinished`) automatically get a TTL of 7 days.
+
+## Further Reading
+
+* [Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/#clean-up-finished-jobs-automatically)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
       - 'Enforce Resources': 'user-guide/safeguards/enforce-resources.md'
       - 'Enforce Trusted Registries': 'user-guide/safeguards/enforce-trusted-registries.md'
       - 'Enforce No Latest Tag': 'user-guide/safeguards/enforce-no-latest-tag.md'
+      - 'Enforce Job TTL': 'user-guide/safeguards/enforce-job-ttl.md'
     - 'Additional Services':
       - 'Overview': 'user-guide/additional-services/index.md'
       - 'PostgreSQL': 'user-guide/additional-services/postgresql.md'


### PR DESCRIPTION
Add a new safeguard page for why we automatically set TTL on jobs.