### PR TITLE
Fix prepare-application links

### DIFF
--- a/docs/user-guide/prepare-application.md
+++ b/docs/user-guide/prepare-application.md
@@ -10,9 +10,9 @@ tags:
 <!--user-demo-overview-start-->
 To make the most out of Compliant Kubernetes, prepare your application so it features:
 
-- some REST endpoints: [NodeJS](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/app.js#L32), [.NET](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo-dotnet/Program.cs#L19);
-- structured logging: [NodeJS](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/app.js#L13), [.NET](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo-dotnet/Program.cs#L45);
-- metrics endpoint: [NodeJS](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/app.js#L28), [.NET](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo-dotnet/Program.cs#L44);
+- some REST endpoints: [NodeJS](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/app.js#L38), [.NET](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo-dotnet/Program.cs#L19);
+- structured logging: [NodeJS](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/app.js#L18), [.NET](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo-dotnet/Program.cs#L45);
+- metrics endpoint: [NodeJS](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/app.js#L34), [.NET](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo-dotnet/Program.cs#L44);
 - Dockerfile, which showcases:
     - How to run as non-root: [NodeJS](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/Dockerfile#L10-L13), [.NET](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo-dotnet/Dockerfile#L17);
 - [Helm Chart](https://github.com/elastisys/compliantkubernetes/tree/main/user-demo/deploy/ck8s-user-demo), which showcases:


### PR DESCRIPTION
Noticed that the links on [this page](https://elastisys.io/compliantkubernetes-v0.26/user-guide/prepare-application/) were pointing to the wrong lines in the NodeJS user-demo file after the [addition of Jaeger](https://github.com/elastisys/compliantkubernetes/commit/6f61ab1e478fa11ba1e95295634e67877886f066#diff-d9663a04700e06e8966f17ef5a5972910d643ef231bacc6ad16ecb246da38276).