### PR TITLE
Fix links

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,22 @@ repos:
         entry: 'image[^>]* xlink:href="https'
         language: pygrep
         files: '.*[.]svg$'
+    -   id: use-relative-urls
+        name: Use relative URLs for internal links
+        # Why? Mkdocs wants you to: https://www.mkdocs.org/user-guide/writing-your-docs/#linking-to-pages
+        entry: '\[[^\]]*\][(][/].*[)]'
+        language: pygrep
+        files: '.*[.]md$'
+    -   id: use-relative-urls-to-files
+        # Why? This ensures the docs are readable from GitHub and allows mkdocs
+        # to do some internal link checking.
+        name: Internal links should point to files
+        # NOTE: I'm unsure the rule above can be precisely implemented using a
+        # regex. What I'm essentially ask here is:
+        # - link should not start with anchor `#`;
+        # - ignore leading `../..` from relative links;
+        # - there should be `:` (as in `https://`) or `.` (as in `index.md`)
+        #   somewhere in the link.
+        entry: '\[[^\]]*\][(][^#][.\/]*[^.:]*[)]'
+        language: pygrep
+        files: '.*[.]md$'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@
 Please observe a stable URL policy. This means:
 
 * Try to avoid breaking URLs.
-* If you need to break URLs, make sure you set up redirects. (See [example](docs/compliantkubernetes/watch-demos.md).)
+* If you need to break URLs, make sure you set up redirects. (Search for `redirects` in [mkdocs.yml](mkdocs.yml).)
 
 ## Code Snippets
 
@@ -97,7 +97,7 @@ Files ending in `*.drawio.svg` are produced using [diagrams.net](https://www.dia
 6. Select "Links: In new window".
 6. Leave everything else as default.
 
-To facilitate editing architecture diagrams, import the [Compliant Kubernetes DrawIO library](docs/compliantkubernetes/img/ck8s-library.drawio.xml).
+To facilitate editing architecture diagrams, import the [Compliant Kubernetes DrawIO library](docs/img/ck8s-library.drawio.xml).
 
 ### From graphviz
 

--- a/docs/adr/0019-push-metrics-via-thanos.md
+++ b/docs/adr/0019-push-metrics-via-thanos.md
@@ -15,7 +15,7 @@ Currently, the service cluster exposes several end-points for workload clusters:
 
 InfluxDB has served us really well over the years. However, as we enter a new era of growth, it no longer satisfies our needs. In particular:
 
-* It is not community-driven (see [ADR-0015 We believe in community-driven open source](0015-we-believe-in-community-driven-open-source)).
+* It is not community-driven (see [ADR-0015 We believe in community-driven open source](0015-we-believe-in-community-driven-open-source.md)).
 * The open-source version cannot be run replicated, hence it is a single point of failure.
 * It is rather capacity hungry, eating as much as 2 CPUs and 15 Gi in a standard package environment.
 * It is unsuitable for long-term metrics storage, which we need -- among others -- for proper capacity management.

--- a/docs/adr/0034-how-to-run-multiple-ams-packages-of-the-same-type.md
+++ b/docs/adr/0034-how-to-run-multiple-ams-packages-of-the-same-type.md
@@ -40,7 +40,7 @@ Chosen options: 2
 1. Always scale horizontally and place each package on its own set of dedicated nodes.
     * "Add additional label `elastisys.io/ams-cluster-name` to a set of nodes dedicated to a specific package"
     * "Do not taint the nodes."
-Respect [ADR-0022](0022-use-dedicated-nodes-for-additional-services) and add the `elastisys.io/node-type` taint and label.
+Respect [ADR-0022](0022-use-dedicated-nodes-for-additional-services.md) and add the `elastisys.io/node-type` taint and label.
 
 ### Positive Consequences
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -35,7 +35,7 @@ An architectural decision generally starts with one of the following:
 
 ## How are architectural decisions captured?
 
-Architectural decisions are captured via [Architectural Decision Records](#adrs) or the [tech radar](/compliantkubernetes/tech-radar/).
+Architectural decisions are captured via [Architectural Decision Records](#adrs) or the [tech radar](../tech-radar/index.html).
 Both are stored in Git, hence a decision log is also captured as part of the Git commit messages.
 
 ## How are architectural decisions taken?
@@ -58,7 +58,7 @@ Before taking in any new component to Compliant Kubernetes, we investigate and e
 * **community-driven open-source projects**, to reduce the risk of a component becoming abandoned, changing its license or changing direction in the interest of a single entity; as far as possible, we choose [CNCF projects](https://landscape.cncf.io/?project=hosted) (preferably graduated ones) or projects which are governed by at least 3 different entities;
 * **projects with a good security track record**, to avoid unexpected security vulnerabilities or delays in fixing security vulnerabilities; as far as possible, we choose projects with a clear security disclosure process and a clear security announcement process;
 * **projects that are popular**, both from a usage and contribution perspective; as far as possible, we choose projects featuring well-known users and many contributors;
-* **projects that rely on technologies that our team is already trained on**, to reduce the risk of requiring a lot of (initial or ongoing) training; as far as possible, we choose projects that overlap with the projects already on our [tech radar](../developer-guide/tech-radar);
+* **projects that rely on technologies that our team is already trained on**, to reduce the risk of requiring a lot of (initial or ongoing) training; as far as possible, we choose projects that overlap with the projects already on our [tech radar](../tech-radar/index.html);
 * **projects that are simple to install and manage**, to reduce required training and burden on administrators.
 
 Often, it is not possible to fulfill the above criteria. In that case, we take the following mitigations:

--- a/docs/ciso-guide/audit-logs.md
+++ b/docs/ciso-guide/audit-logs.md
@@ -8,7 +8,7 @@ tags:
 ---
 # Audit Logs
 
-To help comply with various data protection regulations, Compliant Kubernetes comes built-in with audit logs, which can be accessed via [OpenSearch Dashboard](../../user-guide/logs).
+To help comply with various data protection regulations, Compliant Kubernetes comes built-in with audit logs, which can be accessed via [OpenSearch Dashboard](../user-guide/logs.md).
 
 
 ## What are audit logs?
@@ -42,7 +42,7 @@ Further audit logs can be configured on a case-by-case basis, as described below
 The audit logs are stored in the `kubeaudit*` index pattern.
 The audit logs cover calls to the Kubernetes API, specifically **who** did **what** and **when** on **which** Kubernetes cluster.
 
-Thanks to integration with [your Identity Provider](../../user-guide/kubernetes-api/#authentication-and-access-control-in-compliant-kubernetes) (IdP), if who is a person, their email address will be shown. If who is a system -- e.g., a CI/CD pipeline -- the name of the ServiceAccount is recorded.
+Thanks to integration with [your Identity Provider](../user-guide/kubernetes-api.md#authentication-and-access-control-in-compliant-kubernetes) (IdP), if who is a person, their email address will be shown. If who is a system -- e.g., a CI/CD pipeline -- the name of the ServiceAccount is recorded.
 
 Your change management or incident management process should ensure that you also cover **why**.
 
@@ -71,7 +71,7 @@ The Kubernetes Audit Logs capture user access to additional services, i.e., `kub
 
 **Prefer audit logs in your application to capture audit-worthy events**, such as login, logout, patient record access, patient record change, etc. Resist the temptation to enable audit logging too "low" in the stack. Messages like "Redis client connected" are plenty and add little value to your data protection posture.
 
-Out of all additional services, audit logging for the [database](/compliantkubernetes/user-guide/additional-services/postgresql) makes the most sense. It can be enabled via [pgaudit](https://github.com/pgaudit/pgaudit/blob/master/README.md). Make sure you discuss your auditing requirements with the service-specific administrator, to ensure you find the best risk-reduction-to-implementation-cost trade-off. Typically, you want to discuss:
+Out of all additional services, audit logging for the [database](../user-guide/additional-services/postgresql.md) makes the most sense. It can be enabled via [pgaudit](https://github.com/pgaudit/pgaudit/blob/master/README.md). Make sure you discuss your auditing requirements with the service-specific administrator, to ensure you find the best risk-reduction-to-implementation-cost trade-off. Typically, you want to discuss:
 
 - which databases and tables are audited: e.g., audit `app.users`, but not `app.emailsSent`;
 - what operations are audited: e.g., audit `INSERT/UPDATE/DELETE`, but not `SELECT`;

--- a/docs/ciso-guide/controls/bsi-it-grundschutz.md
+++ b/docs/ciso-guide/controls/bsi-it-grundschutz.md
@@ -36,4 +36,4 @@ Compliant Kubernetes administrators must regularly audit the configuration of th
 
 ### APP.4.4.A20 Verschlüsselte Datenhaltung bei Pods (H)
 
-Compliant Kubernetes recommends disk encryption to be provided at the infrastructure level. If you have this requirement, check for full-disk encryption via the [provider audit](../operator-manual/provider-audit.md).
+Compliant Kubernetes recommends disk encryption to be provided at the infrastructure level. If you have this requirement, check for full-disk encryption via the [provider audit](../../operator-manual/provider-audit.md).

--- a/docs/ciso-guide/controls/bsi-it-grundschutz.md
+++ b/docs/ciso-guide/controls/bsi-it-grundschutz.md
@@ -36,4 +36,4 @@ Compliant Kubernetes administrators must regularly audit the configuration of th
 
 ### APP.4.4.A20 Verschlüsselte Datenhaltung bei Pods (H)
 
-Compliant Kubernetes recommends disk encryption to be provided at the infrastructure level. If you have this requirement, check for full-disk encryption via the [provider audit](../../operator-manual/provider-manual).
+Compliant Kubernetes recommends disk encryption to be provided at the infrastructure level. If you have this requirement, check for full-disk encryption via the [provider audit](../operator-manual/provider-audit.md).

--- a/docs/ciso-guide/controls/gdpr.md
+++ b/docs/ciso-guide/controls/gdpr.md
@@ -26,7 +26,7 @@ This includes, for instance, that we perform vulnerability scanning both at rest
 And much more.
 In fact, we could pretty much link every single page to GDPR Art. 32, but that would be rather noisy!
 
-Hence, if you need a more precise understanding on how Compliant Kubernetes protects personal data as required by GDPR Art. 32, please look at our [ISO 27001 Controls](../iso-27001), which links to both more technical controls, and continuous confidentiality, integrity, availability and resilience of processing processes, such as our go-live checklist.
+Hence, if you need a more precise understanding on how Compliant Kubernetes protects personal data as required by GDPR Art. 32, please look at our [ISO 27001 Controls](iso-27001.md), which links to both more technical controls, and continuous confidentiality, integrity, availability and resilience of processing processes, such as our go-live checklist.
 
 [TAGS]
 

--- a/docs/ciso-guide/controls/hslf-fs-201640.md
+++ b/docs/ciso-guide/controls/hslf-fs-201640.md
@@ -16,7 +16,7 @@ If you are a Swedish healthcare provider, you likely process patient data.
 Patient data includes GDPR personal data and patient records.
 HSLF-FS 2016:40 recommends following ISO 27001.
 
-Please look at the [ISO 27001 controls](../iso-27001) to understand how Compliant Kubernetes helps you keep patient data private and secure.
+Please look at the [ISO 27001 controls](iso-27001.md) to understand how Compliant Kubernetes helps you keep patient data private and secure.
 
 [TAGS]
 

--- a/docs/ciso-guide/faq.md
+++ b/docs/ciso-guide/faq.md
@@ -11,16 +11,16 @@ tags:
 
 Elastisys hereby confirms that Compliant Kubernetes and its Additional Managed Services (AMS) are NOT putting application developers (users) in a situation which obliges them to make their software or source code running on Compliant Kubernetes available to the public.
 
-Should we at Elastisys become aware of such an issue existing, we will immediately rectify the situation by replacing problematic components. You can read more about how we take architectural decisions [here](../../adr).
+Should we at Elastisys become aware of such an issue existing, we will immediately rectify the situation by replacing problematic components. You can read more about how we take architectural decisions [here](../adr/index.md).
 
 As evidence, that the architectural decision process works – in particular when it comes to licensing issues – here are some decisions we took:
 
 * We decided only to offer TimescaleDB Apache 2 Edition (licensed under Apache 2.0) and NOT TimescaleDB “Community Edition” (licensed under the Timescale license). The Timescale license contains some problematic clauses and is, to our knowledge, not tested in court. You can read more about the subtle differences between the TimescaleDB versions [by opening this link](https://docs.timescale.com/timescaledb/latest/timescaledb-edition-comparison/).
 * We replaced Elasticsearch with OpenSearch (licensed under Apache 2.0), when Elasticsearch changed to the Elastic license. You can read more about the context [by opening this link](https://opensearch.org/faq/).
-* We replaced InfluxDB with Thanos. This was due to the fact that the open-source version was too limiting. You can read more about this decision [by opening this link](../../adr/0019-push-metrics-via-thanos/).
+* We replaced InfluxDB with Thanos. This was due to the fact that the open-source version was too limiting. You can read more about this decision [by opening this link](../adr/0019-push-metrics-via-thanos.md).
 * We made a risk assessment regarding Grafana, and determined that its AGPL license does not pose a problem. You can read more about our assessment below.
 
-You can read more about our commitment to community-driven open-source [by opening this link](../../adr/0015-we-believe-in-community-driven-open-source/).
+You can read more about our commitment to community-driven open-source [by opening this link](../adr/0015-we-believe-in-community-driven-open-source.md).
 
 ## Will GrafanaLabs change to AGPL licenses affect Compliant Kubernetes?
 

--- a/docs/ciso-guide/gdpr-art-17.md
+++ b/docs/ciso-guide/gdpr-art-17.md
@@ -43,6 +43,6 @@ Once you have these in place, we recommend you proceed as follows when receiving
 
 ## Further Reading
 
-- [Audit Logs](../audit-logs)
-- [Application Logs](../../user-guide/logs)
-- [Backups](../../user-guide/backup)
+- [Audit Logs](audit-logs.md)
+- [Application Logs](../user-guide/logs.md)
+- [Backups](../user-guide/backup.md)

--- a/docs/ciso-guide/log-review.md
+++ b/docs/ciso-guide/log-review.md
@@ -60,7 +60,7 @@ By *review period*, we mean the time elapsed since the last review of the logs, 
 
 Aim for a review which is both **wide** and **deep**. By wide we mean that you should vary the time interval, time point, filters, etc., when reviewing log entries. By deep we mean that you should actually read and try to understand a sample of logs.
 
-1. Open up a browser and open the Compliant Kubernetes [logs](/compliantkubernetes/user-guide/logs/) of the cluster you are reviewing. This functionality is currently offered by OpenSearch.
+1. Open up a browser and open the Compliant Kubernetes [logs](../user-guide/logs.md) of the cluster you are reviewing. This functionality is currently offered by OpenSearch.
 2. Search for the following keywords on all indices -- i.e., search over each index pattern -- over the last review period: `error`, `failed`, `failure`, `deny`, `denied`, `blocked`, `invalid`, `expired`, `unable`, `unauthorized`, `bad`, `401`, `403`, `500`, `unknown`. Sample a few keywords you recently encountered during your work, e.g., `already installed` or `not found`; be creative and unpredictable.
 3. Vary the time point, the time interval, filters, etc.
 4. Go *wide*: For each query (index pattern, keyword, timepoint, time interval and filter combination), look at the timeline and see if there is an unexpected increase or decrease in the count of log lines. If you find any, focus your attention on those.

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,12 +27,12 @@ Elastisys Compliant Kubernetes is an open source, Certified Kubernetes distribut
 
 Getting started guides:
 
-* [for application developers](user-guide/prepare/)
-* [for Kubernetes administrators](operator-manual/)
-* [for CISOs (Chief Information Security Officers)](ciso-guide/)
+* [for application developers](user-guide/prepare.md)
+* [for Kubernetes administrators](operator-manual/index.md)
+* [for CISOs (Chief Information Security Officers)](ciso-guide/index.md)
 
 ## Would you like to contribute?
 
 We want to build the next generation of cloud native technology where data security and privacy is the default setting.
 
-Join us on our mission as a contributor? Go to the [guide for contributors](contributor-guide).
+Join us on our mission as a contributor? Go to the [guide for contributors](contributor-guide/index.md).

--- a/docs/operator-manual/capacity-management.md
+++ b/docs/operator-manual/capacity-management.md
@@ -42,14 +42,14 @@ That was very information dense, so let's break it down.
 * **Why within 3 days?** This should ensure sufficient time to act on the capacity shortage, without ruining anyone's weekend.
 
 !!!note
-    Compliant Kubernetes can be configured to [require resource requests](/user-guide/safeguards/#avoid-downtime-with-resource-requests) for all Pods.
+    Compliant Kubernetes can be configured to [require resource requests](../user-guide/safeguards/enforce-resources.md) for all Pods.
 
 !!!important
     Nodes dedicated for data services, such as PostgreSQL, are excluded from Kubernetes requests to allocatable calculation.
 
 ### How?
 
-[Add a new Node](/operator-manual/troubleshooting/#node-seems-really-not-fine-i-want-a-new-one) of the same type as the other Nodes in the cluster.
+[Add a new Node](../operator-manual/troubleshooting.md#node-seems-really-not-fine-i-want-a-new-one) of the same type as the other Nodes in the cluster.
 
 If the cluster has 6 Nodes, consider consolidating to 3 Nodes of twice-the-size -- in number of CPUs or memory or both -- if the infrastructure cost is reduced.
 Before doing this, get in touch with application developers to ensure they don't have Kubernetes scheduling constraints that would cause issues on the consolidated environment.

--- a/docs/operator-manual/configure.md
+++ b/docs/operator-manual/configure.md
@@ -1,6 +1,6 @@
 # Advanced Configuration
 
-You have already been exposed to some of Compliant Kubernetes's configuration options while creating a cluster. If not, read that section first (e.g., [On Exoscale](/compliantkubernetes/operator-manual/exoscale/)).
+You have already been exposed to some of Compliant Kubernetes's configuration options while creating a cluster. If not, read [that section](on-prem-standard.md) first.
 
 This section will outline some advanced configuration topics.
 

--- a/docs/operator-manual/credentials.md
+++ b/docs/operator-manual/credentials.md
@@ -43,7 +43,7 @@ Cloud Provider (Infrastructure) Credentials
     * Creating and destroying buckets via helper scripts
 * Do not use for:
     * Kubernetes [cloud-controller integration](https://github.com/kubernetes-sigs/kubespray/blob/master/inventory/sample/group_vars/all/openstack.yml#L38), use [Cloud Controller Credentials](#cloud-controller-integration-credentials) instead.
-    * Access to object storage / S3 bucket, use [backup credentials](backup-and-long-term-logging-credentials) instead.
+    * Access to object storage / S3 bucket, use [backup credentials](#backup-and-long-term-logging-credentials) instead.
 
 SSH Keys
 --------

--- a/docs/operator-manual/troubleshooting.md
+++ b/docs/operator-manual/troubleshooting.md
@@ -4,9 +4,9 @@ Help! Something is wrong with my Compliant Kubernetes cluster. Fear no more, thi
 
 This guide assumes that:
 
-* You have [pre-requisites](operator-manual/getting-started/) installed.
+* You have [pre-requisites](getting-started.md) installed.
 * Your environment variables, in particular `CK8S_CONFIG_PATH` is set.
-* Your config folder (e.g. [for OpenStack](/operator-manual/openstack/#initialize-configuration-folder)) is available.
+* Your config folder is available.
 * `compliantkubernetes-apps` and `compliantkubernetes-kubespray` is available.
 
 ## I have no clue where to start

--- a/docs/operator-manual/user-alerts.md
+++ b/docs/operator-manual/user-alerts.md
@@ -1,6 +1,6 @@
 # Enabling user alerts
 
-This is administrator-facing documentation associated with [this user guide](/user-guide/alerts/). Please read that one first.
+This is administrator-facing documentation associated with [this user guide](../user-guide/alerts.md). Please read that one first.
 
 !!!important
     Alertmanager should no longer be access via an Ingress, since this circumvents access control and audit logs. Please find the updated access method in the user guide linked above.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,1 @@
-{%
-    include "release-notes/ck8s.md"
-    start="<!--apps-release-notes-start-->"
-    end="<!--apps-release-notes-end-->"
-%}
+See [Compliant Kubernetes Release Notes](release-notes/ck8s.md).

--- a/docs/release-notes/ck8s.md
+++ b/docs/release-notes/ck8s.md
@@ -328,7 +328,7 @@ Released 2022-02-01
   *Note that recent versions of official Elasticsearch clients and tools will not work with OpenSearch as they employ a product check, compatible versions can be found [here](https://opensearch.org/docs/latest/clients/index/).*
 
 - **Enforcing OPA policies by default.**<br/>
-  Provides [strict safeguards](user-guide/safeguards/index.md) by default.
+  Provides [strict safeguards](../user-guide/safeguards/index.md) by default.
 
 - **Allowing viewers to inspect and temporarily edit panels in Grafana.**<br/>
   Gives more insight to the metrics and data shown.

--- a/docs/release-notes/ck8s.md
+++ b/docs/release-notes/ck8s.md
@@ -328,7 +328,7 @@ Released 2022-02-01
   *Note that recent versions of official Elasticsearch clients and tools will not work with OpenSearch as they employ a product check, compatible versions can be found [here](https://opensearch.org/docs/latest/clients/index/).*
 
 - **Enforcing OPA policies by default.**<br/>
-  Provides [strict safeguards](/compliantkubernetes/user-guide/safeguards/) by default.
+  Provides [strict safeguards](user-guide/safeguards/index.md) by default.
 
 - **Allowing viewers to inspect and temporarily edit panels in Grafana.**<br/>
   Gives more insight to the metrics and data shown.

--- a/docs/user-guide/additional-services/postgresql.md
+++ b/docs/user-guide/additional-services/postgresql.md
@@ -21,7 +21,7 @@ Compliant Kubernetes recommends the [Zalando PostgreSQL operator](https://postgr
 
 ## Install Prerequisites
 
-Before continuing, make sure you have access to the Kubernetes API, as describe [here](/compliantkubernetes/user-guide/setup/).
+Before continuing, make sure you have access to the Kubernetes API, as describe [here](../setup.md).
 
 Make sure to install the PostgreSQL client on your workstation. On Ubuntu, this can be achieved as follows:
 

--- a/docs/user-guide/additional-services/rabbitmq.md
+++ b/docs/user-guide/additional-services/rabbitmq.md
@@ -19,7 +19,7 @@ Compliant Kubernetes recommends the [RabbitMQ Cluster Operator for Kubernetes](h
 
 ## Accessing a RabbitMQ Cluster
 
-Before continuing, make sure you have access to the Kubernetes API, as describe [here](/compliantkubernetes/user-guide/setup/).
+Before continuing, make sure you have access to the Kubernetes API, as describe [here](../setup.md).
 
 Make sure to install the RabbitMQ client on your workstation. On Ubuntu, this can be achieved as follows:
 

--- a/docs/user-guide/additional-services/redis.md
+++ b/docs/user-guide/additional-services/redis.md
@@ -18,7 +18,7 @@ Ask your service-specific administrator to install a Redis cluster inside your C
 
     > Redis is designed to be accessed by trusted clients inside trusted environments.
 
-    For improved security, discuss with your service-specific administrator what Pods and/or Namespaces need access to the Redis cluster. They can then set up the necessary [NetworkPolicies](/compliantkubernetes/user-guide/safeguards/enforce-networkpolicies/).
+    For improved security, discuss with your service-specific administrator what Pods and/or Namespaces need access to the Redis cluster. They can then set up the necessary [NetworkPolicies](../safeguards/enforce-networkpolicies.md).
 
 !!!important "Important: No Disaster Recovery"
 
@@ -31,7 +31,7 @@ Compliant Kubernetes recommends the [Spotahome operator](https://github.com/spot
 
 ## Install Prerequisites
 
-Before continuing, make sure you have access to the Kubernetes API, as describe [here](/compliantkubernetes/user-guide/setup/).
+Before continuing, make sure you have access to the Kubernetes API, as describe [here](../setup.md).
 
 Make sure to install the Redis client on your workstation. On Ubuntu, this can be achieved as follows:
 

--- a/docs/user-guide/alerts.md
+++ b/docs/user-guide/alerts.md
@@ -49,7 +49,7 @@ If you want to access AlertManager, for example to confirm that its configuratio
 
 ## Configuring alerts
 
-Before setting up an alert, you must first [collect metrics](../metrics) from your application by setting up either ServiceMonitors or PodMonitors. In general ServiceMonitors are recommended over PodMonitors, and it is the most common way to configure metrics collection.
+Before setting up an alert, you must first [collect metrics](metrics.md) from your application by setting up either ServiceMonitors or PodMonitors. In general ServiceMonitors are recommended over PodMonitors, and it is the most common way to configure metrics collection.
 
 Then create a `PrometheusRule` following the examples below or the upstream documentation with an expression that evaluates to the condition to alert on. Prometheus will pick them up, evaluate them, and then send notifications to AlertManager.
 
@@ -69,7 +69,7 @@ The user demo already includes a [PrometheusRule](https://github.com/elastisys/c
 
 The screenshot below gives an example of the application alert, as seen in AlertManager.
 
-![Example of User Demo Alerts](/compliantkubernetes/img/user-demo-alerts.png)
+![Example of User Demo Alerts](../img/user-demo-alerts.png)
 
 <!--user-demo-alerts-end-->
 

--- a/docs/user-guide/ci-cd.md
+++ b/docs/user-guide/ci-cd.md
@@ -144,7 +144,7 @@ Note that, `KUBECONFIG`s -- especially the token -- **must** be treated as a sec
 
 Please find a concrete example for GitHub Actions [here](https://github.com/elastisys/compliantkubernetes/blob/main/.github/workflows/user-demo.yml.example). Below is the produced output:
 
-![GitHub Actions Example Output](/compliantkubernetes/user-guide/img/github-actions-screenshot.png)
+![GitHub Actions Example Output](img/github-actions-screenshot.png)
 
 Flux v1
 -------

--- a/docs/user-guide/continous-development.md
+++ b/docs/user-guide/continous-development.md
@@ -47,11 +47,11 @@ Skaffold finds you will be prompted to specify how to build them, or if they are
 The first image Skaffold finds is busybox, however this image is not built from this project, so choose
 `None (image not built from these sources)`
 
-![Skaffold init Output1](/compliantkubernetes/user-guide/img/skaffold-busybox.png)
+![Skaffold init Output1](img/skaffold-busybox.png)
 
 The second image Skaffold finds is the user-demo image and this image is built from the Dockerfile.
 
-![Skaffold init Output2](/compliantkubernetes/user-guide/img/skaffold-user-demo.png)
+![Skaffold init Output2](img/skaffold-user-demo.png)
 
 Skaffold then asks for which resources we want to create Kubernetes resources, but as the image already has a Helm Chart
 this can be skipped by pressing enter.
@@ -110,7 +110,7 @@ skaffold dev --port-forward
 When the application has been built and deployed to the cluster Skaffold shows which URL to access,
 shows the logs of the application, and starts listening for changes in the source-files.
 
-![Skaffold Output1](/compliantkubernetes/user-guide/img/skaffold-output1.png)
+![Skaffold Output1](img/skaffold-output1.png)
 
 When visiting the URL to the application or the portforwarded URL the following output can be seen:
 

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -118,7 +118,7 @@ You can read more about this issue [here](https://github.com/kubernetes/kubernet
 
 Compliant Kubernetes encrypts everything at rest, including Kubernetes resources, PersistentVolumeClaims, logs, metrics and backups, **if the underlying cloud provider supports it**.
 
-Get in touch with your administrator to check the status. They are responsible for performing a [provider audit](/compliantkubernetes/operator-manual/provider-audit).
+Get in touch with your administrator to check the status. They are responsible for performing a [provider audit](../operator-manual/provider-audit.md).
 
 !!!important "Why does Compliant Kubernetes not offer encryption-at-rest at the platform level?"
 
@@ -126,11 +126,11 @@ Get in touch with your administrator to check the status. They are responsible f
 
     We are frequently asked why we don't simply do full-disk encryption at the VM level, using something like [cryptsetup](https://linux.die.net/man/8/cryptsetup). Let us explain our rationale.
 
-    The reason why people want encryption-at-rest is to add another safeguard to data confidentiality. Encryption-at-rest is a must-have for laptops, as they can easily be stolen or get lost. However, it is a nice-to-have addition for servers, which are supposed to be in a physically protected data-center, with disks being safely disposed. This is verified during a [provider audit](/compliantkubernets/operator-manual/provider-audit).
+    The reason why people want encryption-at-rest is to add another safeguard to data confidentiality. Encryption-at-rest is a must-have for laptops, as they can easily be stolen or get lost. However, it is a nice-to-have addition for servers, which are supposed to be in a physically protected data-center, with disks being safely disposed. This is verified during a [provider audit](../operator-manual/provider-audit.md).
 
     At any rate, if encryption-at-rest is deployed it must: (a) actually safeguard data confidentiality; (b) without prohibitive costs in terms of administration.
 
-    A Compliant Kubernetes environment may comprise as many as 10 Nodes, i.e., VMs. These Nodes need to be frequently rebooted, to ensure Operating System (OS) security patches are applied. This is especially important for Linux kernel, container runtime (Docker) and Kubernetes security patches. Thanks to the power of Kubernetes, a carefully engineered and deployed application can tolerate such reboots with zero downtime. (See the [go-live checklist](../go-live).)
+    A Compliant Kubernetes environment may comprise as many as 10 Nodes, i.e., VMs. These Nodes need to be frequently rebooted, to ensure Operating System (OS) security patches are applied. This is especially important for Linux kernel, container runtime (Docker) and Kubernetes security patches. Thanks to the power of Kubernetes, a carefully engineered and deployed application can tolerate such reboots with zero downtime. (See the [go-live checklist](go-live.md).)
 
     The challenge is how to deliver the disk encryption key to the VM when they are booting. Let us explore a few options:
 

--- a/docs/user-guide/kubernetes-ui.md
+++ b/docs/user-guide/kubernetes-ui.md
@@ -31,7 +31,7 @@ sudo dpkg -i lens.deb
 
 ### Note for macOS and Linux users
 
-If you followed the [Install Prerequisites](../setup/) steps of this documentation, you have probably installed the `oidc-login` plugin to `kubectl` via `krew`. If so, Lens will not be able to find it. That makes Lens fail to authenticate via Dex, the OpenID Connect provider in Compliant Kubernetes.
+If you followed the [Install Prerequisites](setup.md) steps of this documentation, you have probably installed the `oidc-login` plugin to `kubectl` via `krew`. If so, Lens will not be able to find it. That makes Lens fail to authenticate via Dex, the OpenID Connect provider in Compliant Kubernetes.
 
 You have two options for making the `oidc-login` plugin findable by Lens:
 

--- a/docs/user-guide/logs.md
+++ b/docs/user-guide/logs.md
@@ -180,7 +180,7 @@ As a first step, review your application change management policy to reduce the 
 Second, ask your administrator to re-index the affected indices.
 
 !!!note
-    Re-indexing requires a lot of permissions, including creating and deleting indices, and changing Index templates. This may interfere with audit logs and [compromise platform security](/compliantkubernetes/user-guide/demarcation/). Therefore, to ensure platform security, re-indexing can only be performed by Compliant Kubernetes administrators.
+    Re-indexing requires a lot of permissions, including creating and deleting indices, and changing Index templates. This may interfere with audit logs and [compromise platform security](demarcation.md). Therefore, to ensure platform security, re-indexing can only be performed by Compliant Kubernetes administrators.
 
 ## Running Example
 
@@ -190,7 +190,7 @@ The user demo application already includes structured logging: For each HTTP req
 
 The screenshot below gives an example of log entries produced by the user demo application. It was obtained by using the index pattern `kubernetes*` and the filter `kubernetes.labels.app_kubernetes_io/instance:myapp`.
 
-![Example of User Demo Logs](/compliantkubernetes/img/user-demo-logs.jpeg)
+![Example of User Demo Logs](../img/user-demo-logs.jpeg)
 
 !!!note
     You may want to save frequently used searches as dashboards. Compliant Kubernetes saves and backs these up for you.

--- a/docs/user-guide/metrics.md
+++ b/docs/user-guide/metrics.md
@@ -88,7 +88,7 @@ The user demo already includes a [ServiceMonitor](https://github.com/elastisys/c
 
 The screenshot below shows Grafana in "Explore" mode (the compass icon to the left) featuring the query `rate(http_request_duration_seconds_count[1m])`. It shows the request rate for the user demo application for each path and status code. As can be seen in the graph, the `/users` endpoint is getting more traffic than the other endpoints.
 
-![Example of User Demo Metrics](/compliantkubernetes/img/user-demo-metrics.jpeg)
+![Example of User Demo Metrics](../img/user-demo-metrics.jpeg)
 
 The "Explore" mode is great for developing queries and exploring the data set. If you want to save a query so you can refer back to it, you can create a Dashboard instead. Dashboards consist of multiple Panels, each of which, can display the results of running queries. Learn more [about Grafana panels](https://grafana.com/docs/grafana/latest/panels/).
 

--- a/docs/user-guide/network-model.md
+++ b/docs/user-guide/network-model.md
@@ -34,9 +34,9 @@ The diagram above present a useful model when reasoning about networking in Comp
 
 ## Private Network
 
-Your application Pods, as well as Pods of [additional services](/compliantkubernetes/user-guide/additional-services/), can communicate on a secure private network, via [RFC1918](https://datatracker.ietf.org/doc/html/rfc1918) private IP addresses. It is analogous to a [VPC](https://en.wikipedia.org/wiki/Virtual_private_cloud) in VM-based workloads.
+Your application Pods, as well as Pods of [additional services](additional-services/index.md), can communicate on a secure private network, via [RFC1918](https://datatracker.ietf.org/doc/html/rfc1918) private IP addresses. It is analogous to a [VPC](https://en.wikipedia.org/wiki/Virtual_private_cloud) in VM-based workloads.
 
-In Compliant Kubernetes, it is the responsibility of the administrator to ensure the in-cluster private network is secure and trusted, either by performing an [infrastructure audit](/compliantkubernetes/operator-manual/provider-audit/) or deploying [Pod-to-Pod encryption](https://elastisys.com/redundancy-across-data-centers-with-kubernetes-wireguard-and-rook/).
+In Compliant Kubernetes, it is the responsibility of the administrator to ensure the in-cluster private network is secure and trusted, either by performing an [infrastructure audit](../operator-manual/provider-audit.md) or deploying [Pod-to-Pod encryption](https://elastisys.com/redundancy-across-data-centers-with-kubernetes-wireguard-and-rook/).
 
 You should use NetworkPolicies to segregate your Pods. This improves your security posture by reducing the blast radius in case parts of your application are under attack.
 
@@ -49,7 +49,7 @@ You should use NetworkPolicies to segregate your Pods. This improves your securi
 
 The private network also features a private DNS. A Service `my-svc` in the namespace `my-namespace` can be accessed from within the Kubernetes cluster as `my-svc.my-namespace`.
 
-IP addresses of Pods are not stable. For example, the rollout of a new container image creates new Pods, which will have new IP addresses. Therefore, you should always use private DNS names of Services to connect your application Pods, as well as to connect your application to [additional services](/compliantkubernetes/user-guide/additional-services/).
+IP addresses of Pods are not stable. For example, the rollout of a new container image creates new Pods, which will have new IP addresses. Therefore, you should always use private DNS names of Services to connect your application Pods, as well as to connect your application to [additional services](additional-services/index.md).
 
 ## Ingress
 

--- a/docs/user-guide/prepare-application.md
+++ b/docs/user-guide/prepare-application.md
@@ -43,7 +43,7 @@ cd compliantkubernetes/user-demo
 
     * A.12.6.1 Management of Technical Vulnerabilities
 
-Compliant Kubernetes recommends **against** [PodDisruptionBudgets (PDBs)](https://kubernetes.io/docs/tasks/run-application/configure-pdb/). PDBs can easily be misconfigured to block draining Nodes, which interferes with automatic OS patching and compromises the security posture of the environment. Instead, prefer engineering your application to deal with disruptions. The user demo already showcases how to achieve this with replication and topologySpreadConstraints. Make sure to move state, even soft state, to [specialized services](/compliantkubernetes/user-guide/additional-services/).
+Compliant Kubernetes recommends **against** [PodDisruptionBudgets (PDBs)](https://kubernetes.io/docs/tasks/run-application/configure-pdb/). PDBs can easily be misconfigured to block draining Nodes, which interferes with automatic OS patching and compromises the security posture of the environment. Instead, prefer engineering your application to deal with disruptions. The user demo already showcases how to achieve this with replication and topologySpreadConstraints. Make sure to move state, even soft state, to [specialized services](additional-services/index.md).
 
 Further reading:
 

--- a/docs/user-guide/safeguards/enforce-networkpolicies.md
+++ b/docs/user-guide/safeguards/enforce-networkpolicies.md
@@ -14,8 +14,8 @@ tags:
     * A.13.1.3 Segregation in Networks
 
 !!!important
-    * This safeguard is enabled by default with the enforcement action `deny` since [Compliant Kubernetes apps v0.19.0](/compliantkubernetes/release-notes/#v0190). As a result, resources that violate this policy will not be created.
-    * The default enforcement action for this safeguard has been changed to `warn` instead of `deny` since [Compliant Kubernetes apps v0.29.0](/compliantkubernetes/release-notes/#v0290). As a result, resources that violate this policy will generate warning messages, but will still be created.
+    * This safeguard is enabled by default with the enforcement action `deny` since [Compliant Kubernetes apps v0.19.0](../../release-notes.md#v0190). As a result, resources that violate this policy will not be created.
+    * The default enforcement action for this safeguard has been changed to `warn` instead of `deny` since [Compliant Kubernetes apps v0.29.0](../../release-notes.md#v0290). As a result, resources that violate this policy will generate warning messages, but will still be created.
 
 NetworkPolicies are useful in two cases: segregating tenants hosted in the same environment and further segregating application components. Both help you achieve better data protection.
 

--- a/docs/user-guide/safeguards/enforce-no-latest-tag.md
+++ b/docs/user-guide/safeguards/enforce-no-latest-tag.md
@@ -14,7 +14,7 @@ tags:
     * A.14.2.4 Restrictions on Changes to Software Packages
 
 !!!important
-    This safeguard is enabled by default with the enforcement action `deny` since [Compliant Kubernetes apps v0.29.0](/compliantkubernetes/release-notes/#v0290). As a result, resources that violate this policy will not be created.
+    This safeguard is enabled by default with the enforcement action `deny` since [Compliant Kubernetes apps v0.29.0](../../release-notes.md#v0290). As a result, resources that violate this policy will not be created.
 
 Using the `:latest` tag can lead to inconsistent deployments, where it is difficult to rollback. In Compliant Kubernetes we suggest using explicit tags for your container images. This way you know that image version `v1.0.0` will be deployed if you are using the `:v1.0.0` tag.
 

--- a/docs/user-guide/safeguards/enforce-resources.md
+++ b/docs/user-guide/safeguards/enforce-resources.md
@@ -21,7 +21,7 @@ Note to contributors: Aim for the following format.
     * A.12.1.3 Capacity Management
 
 !!!important
-    This safeguard is enabled by default with the enforcement action `deny` since [Compliant Kubernetes apps v0.19.0](/compliantkubernetes/release-notes/#v0190). As a result, resources that violate this policy will not be created.
+    This safeguard is enabled by default with the enforcement action `deny` since [Compliant Kubernetes apps v0.19.0](../../release-notes.md#v0190). As a result, resources that violate this policy will not be created.
 
 ## Problem
 

--- a/docs/user-guide/safeguards/enforce-trusted-registries.md
+++ b/docs/user-guide/safeguards/enforce-trusted-registries.md
@@ -21,12 +21,12 @@ Note to contributors: Aim for the following format.
     * A.12.6.1 Management of Technical Vulnerabilities
 
 !!!important
-    * This safeguard is enabled by default with the enforcement action `deny` since [Compliant Kubernetes apps v0.19.0](/compliantkubernetes/release-notes/#v0190). As a result, resources that violate this policy will not be created.
-    * The default enforcement action for this safeguard has been changed to `warn` instead of `deny` since [Compliant Kubernetes apps v0.29.0](/compliantkubernetes/release-notes/#v0290). As a result, resources that violate this policy will generate warning messages, but will still be created.
+    * This safeguard is enabled by default with the enforcement action `deny` since [Compliant Kubernetes apps v0.19.0](../../release-notes.md#v0190). As a result, resources that violate this policy will not be created.
+    * The default enforcement action for this safeguard has been changed to `warn` instead of `deny` since [Compliant Kubernetes apps v0.29.0](../../release-notes.md#v0290). As a result, resources that violate this policy will generate warning messages, but will still be created.
 
 ## Problem
 
-A healthy security posture requires you to ensure your code has no known vulnerabilities. Compliant Kubernetes comes with a [registry](/compliantkubernetes/user-guide/registry/) which includes vulnerability scanning of container images. It can even be configured to prevent the Kubernetes cluster from pulling images with vulnerabilities above a set criticality. This is a per-project setting, so you could, for example, have a stricter policy for publicly facing application components -- e.g., the front office -- and a less strict policy for internal application components -- e.g., the back office.
+A healthy security posture requires you to ensure your code has no known vulnerabilities. Compliant Kubernetes comes with a [registry](../registry.md) which includes vulnerability scanning of container images. It can even be configured to prevent the Kubernetes cluster from pulling images with vulnerabilities above a set criticality. This is a per-project setting, so you could, for example, have a stricter policy for publicly facing application components -- e.g., the front office -- and a less strict policy for internal application components -- e.g., the back office.
 
 Public container registry, such as Docker Hub and Quay, might not stick to the vulnerability management you require, perhaps being at times too strict or too loose.
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -30,7 +30,7 @@ Check your Pods for excessive resource usage:
 kubectl top pod
 ```
 
-Inspect [application logs](../logs) and [metrics](../metrics).
+Inspect [application logs](logs.md) and [metrics](metrics.md).
 
 ## Are my Deployments fine?
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ plugins:
         'operator-manual/openstack.md': 'operator-manual/on-prem-standard.md'
         'operator-manual/ovh-managed-kubernetes.md': 'operator-manual/on-prem-standard.md'
         'operator-manual/safespring.md': 'operator-manual/on-prem-standard.md'
+        'release-notes.md': 'release-notes/ck8s.md'
 
 markdown_extensions:
   - attr_list


### PR DESCRIPTION
Fixes #570 

There are several ways to describe links in Markdown:

1. Absolute URL, e.g., `https://some-external-website.io`
2. Absolute path, e.g., `/compliantkubernetes/hello/`
3. Relative path, e.g., `../hello`.

Furthermore, for 3, you can have:

3a: Relative path to a URL, e.g., `../hello`.
3b: Relative path to a file, e.g., `../hello.md`.

Mkdocs wants you to use 1 for external links and 3b for internal links. If you use 2 or 3a for internal links, mkdocs's internal link checker won't report errors.

This PR does two things:

A. It makes sure all internal links are a relative path to a file.
B. It adds a pre-commit hook to make sure we don't do this mistake again.