### PR TITLE
Fixed small indent issue in Keycloak docs

### DIFF
--- a/docs/user-guide/self-service-guide/keycloak.md
+++ b/docs/user-guide/self-service-guide/keycloak.md
@@ -106,6 +106,6 @@ For more information about using Keycloak to secure/protect your applications, s
 - [Reverse Proxy](https://www.keycloak.org/server/reverseproxy)
     - [Ingress Nginx](https://kubernetes.github.io/ingress-nginx/examples/auth/oauth-external-auth/)
     - [Oauth2-Proxy](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/oauth_provider/#keycloak-oidc-auth-provider)
-      - Note: the “oidc-issuer-url” may be outdated in the guide. See [this issue.](https://stackoverflow.com/questions/70577004/keycloak-could-not-find-resource-for-full-path)
-      - Note: Keycloak realm steps may be different if you are using the new admin console. Instructions for that can be found on their [github](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/docs/docs/configuration/auth.md#keycloak-oidc-auth-provider).
+        - Note: the “oidc-issuer-url” may be outdated in the guide. See [this issue.](https://stackoverflow.com/questions/70577004/keycloak-could-not-find-resource-for-full-path)
+        - Note: Keycloak realm steps may be different if you are using the new admin console. Instructions for that can be found on their [github](https://github.com/oauth2-proxy/oauth2-proxy/blob/master/docs/docs/configuration/auth.md#keycloak-oidc-auth-provider).
 - [Securing your applications](https://www.keycloak.org/docs/latest/securing_apps/index.html)


### PR DESCRIPTION
Looked fine in md, did not render properly in mkdocs.
Previous:
![image](https://github.com/elastisys/compliantkubernetes/assets/91016401/a524189d-51a9-436c-8a7f-47e6df9ef0ec)
Fixed:
![image](https://github.com/elastisys/compliantkubernetes/assets/91016401/0a829815-e502-4588-b173-2fb036bcb654)
