### PR TITLE
Add resource requests to ferretdb deployment manifest

### DIFF
--- a/docs/user-guide/self-service-guide/ferretdb.md
+++ b/docs/user-guide/self-service-guide/ferretdb.md
@@ -64,6 +64,10 @@ spec:
             secretKeyRef:
               name: ferretdb-postgres-credentials
               key: ferretdb-url
+        resources:
+          requests:
+            cpu: "5m"
+            memory: "15M"
         securityContext:
           capabilities:
             drop:


### PR DESCRIPTION
Deployment manifest for FerretDB was missing resource requests which is enforced in CK8s.