### PR TITLE
Fix: Highlight external links with Firefox

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -42,9 +42,15 @@ header .header-links li {
 }
 
 /* Highlight external links */
-a[href*="//"]:not([href*="elastisys."]):not(:has(img,div,figure,svg)):after {
+a[href*="//"]:not([href*="elastisys."])::after {
     content: ' ↗';
 }
-a[href*="//"]:not([href*="elastisys."]):has(img, div, figure, svg) {
+
+/* Firefox does not support the :has pseudo-selector.
+ * Fortunately, we only have one image link in the docs */
+.header-links a[href*="//"]:not([href*="elastisys."])::after {
+    content: '';
+}
+.header-links a[href*="//"]:not([href*="elastisys."]) {
     border-bottom: 2px dashed #a8b1be;
 }


### PR DESCRIPTION
The latest Firefox (103) has the `:has()` pseudo-class disabled behind a feature flag. Therefore, our previous CSS selectors didn't work on Firefox.

This commit avoids needing to use `:has()`. On the downside, external links from images are only selected when present in the header.

https://developer.mozilla.org/en-US/docs/Web/CSS/:has#browser_compatibility

Fixes #594 