### PR TITLE
Re-add the Table-of-Contents on the right sidebar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,8 +41,8 @@ theme:
     scheme: elastisys
   features:
     - content.code.annotate
-    - toc.integrate
     - content.tabs.link
+    - navigation.top
 
 extra_css:
   - stylesheets/branding.css
@@ -85,7 +85,6 @@ markdown_extensions:
       alternate_style: true
   - toc:
       permalink: true
-      toc_depth: 0
   - pymdownx.tasklist:
       custom_checkbox: true
 


### PR DESCRIPTION
At least the Troubleshooting page (for Administrators) is in desperate need of a Table of Contents to help navigation.

Before:
![Screenshot from 2023-05-19 14-00-04](https://github.com/elastisys/compliantkubernetes/assets/1660833/63fd70b6-bdf9-4f1a-924b-4f04bd9d9586)

After:
![Screenshot from 2023-05-19 14-00-10](https://github.com/elastisys/compliantkubernetes/assets/1660833/ae4b6695-4ff4-4b12-a91f-fb2a0949f4de)
