### PR TITLE
Fix user-demo links in go-live doc

### DIFF
--- a/docs/user-guide/go-live.md
+++ b/docs/user-guide/go-live.md
@@ -17,7 +17,7 @@ To move from production anxiety to production karma, here is a checklist to go t
     * **Why?** This ensures that enough capacity was allocated for the environment.
     * **How?** Set up a synthetic workload generator or replay a relevant workload. Ask the administrator to monitor your environment's capacity usage, including that related to components necessary for application logs and application metrics.
     * **Desired outcome**: Allocated capacity is sufficient.
-    * **Possible resolution**: Ensure the application has proper resource requests and limits (see our [user demo as an example](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L42-L51)).
+    * **Possible resolution**: Ensure the application has proper resource requests and limits (see our [user demo as an example](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L51-L60)).
 - [ ] Load testing was performed while updating the application.
     * **Why?** This ensures that the application can be updated without downtime.
     * **How?** Make a trivial change to your application, e.g., add "Lorem ipsum" in the output of some API, and redeploy.
@@ -28,17 +28,17 @@ To move from production anxiety to production karma, here is a checklist to go t
     * **How?** As above, but now ask the administrator to perform a rolling reboot of Nodes.
     * **Desired outcome**: The measured downtime (due to Pod migration) during Node failure or drain is acceptable. Capacity is sufficient to tolerate one Node failure or drain.
     * **Possible resolution**:
-        * Ensure the application has proper resource requests and limits (see our [user demo for an example](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L42-L51)).
+        * Ensure the application has proper resource requests and limits (see our [user demo for an example](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L51-L60)).
         * Ensure the application has at least two replicas (see our [user demo for an example](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L5)).
-        * Ensure the application has `topologySpreadConstraints` to ensure Pods do not end up on the same Node (see our [user demo for an example](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L76-L82)).
+        * Ensure the application has `topologySpreadConstraints` to ensure Pods do not end up on the same Node (see our [user demo for an example](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L84-L90)).
 - [ ] [For multi-Zone environments] Load testing was performed while failing an entire Zone:
     * **Why?** If a multi-Zone environment was requested, then the additional resilience must be tested. Otherwise, Zone failure may cause application downtime.
     * **How?** As above, but now ask the administrator to fail an entire Zone.
     * **Desired outcome**: The measured downtime (due to Pod migration) during Zode failure is acceptable. Capacity is sufficient to tolerate one Zode failure.
     * **Possible resolution**:
-        * Ensure the application has proper resource requests and limits (see our [user demo for an example](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L42-L51)).
+        * Ensure the application has proper resource requests and limits (see our [user demo for an example](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L51-L60)).
         * Ensure the application has at least two replicas (see our [user demo for an example](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L5)).
-        * Ensure the application has `topologySpreadConstraints` to ensure Pods do not end up on the same Zone (see our [user demo for an example](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L76-L82)).
+        * Ensure the application has `topologySpreadConstraints` to ensure Pods do not end up on the same Zone (see our [user demo for an example](https://github.com/elastisys/compliantkubernetes/blob/main/user-demo/deploy/ck8s-user-demo/values.yaml#L84-L90)).
 - [ ] Disaster recovery testing was performed:
     * **Why?** This ensures that the application and platform team agreed on who backs up what, instead of ending up thinking that "backing up this thingy" is the other team's problem.
     * **How?** Ask the administrator to destroy the environment and restore from off-site backups. Check if your application is back up and its data is restored as expected.


### PR DESCRIPTION
Found some links in the [go-live checklist](https://elastisys.io/compliantkubernetes/user-guide/go-live/) page which were not up to date with the current version of the user-demo Helm chart. This PR should fix these.