### PR TITLE
Fix include path

### DIFF
--- a/docs/ciso-guide/controls/gdpr.md
+++ b/docs/ciso-guide/controls/gdpr.md
@@ -1,7 +1,7 @@
 # GDPR (Regulation (EU) 2016/679)
 
 {%
-   include-markdown '_common.include'
+   include-markdown './_common.include'
    start='<!--legal-disclaimer-start-->'
    end='<!--legal-disclaimer-end-->'
 %}

--- a/docs/ciso-guide/controls/hipaa.md
+++ b/docs/ciso-guide/controls/hipaa.md
@@ -1,7 +1,7 @@
 # HIPAA Controls
 
 {%
-   include-markdown '_common.include'
+   include-markdown './_common.include'
    start='<!--legal-disclaimer-start-->'
    end='<!--legal-disclaimer-end-->'
 %}

--- a/docs/ciso-guide/controls/hslf-fs-201640.md
+++ b/docs/ciso-guide/controls/hslf-fs-201640.md
@@ -1,12 +1,12 @@
 # Swedish Patient Data Act (HSLF-FS 2016:40)
 
 {%
-   include-markdown '_common.include'
+   include-markdown './_common.include'
    start='<!--legal-disclaimer-start-->'
    end='<!--legal-disclaimer-end-->'
 %}
 {%
-   include-markdown '_common.include'
+   include-markdown './_common.include'
    start='<!--controls-note-start-->'
    end='<!--controls-note-end-->'
 %}

--- a/docs/ciso-guide/controls/iso-27001.md
+++ b/docs/ciso-guide/controls/iso-27001.md
@@ -1,7 +1,7 @@
 # ISO 27001 Controls
 
 {%
-   include-markdown '_common.include'
+   include-markdown './_common.include'
    start='<!--controls-note-start-->'
    end='<!--controls-note-end-->'
 %}

--- a/docs/ciso-guide/controls/msbfs-20207.md
+++ b/docs/ciso-guide/controls/msbfs-20207.md
@@ -1,12 +1,12 @@
 # MSBFS 2020:7 Controls
 
 {%
-   include-markdown '_common.include'
+   include-markdown './_common.include'
    start='<!--legal-disclaimer-start-->'
    end='<!--legal-disclaimer-end-->'
 %}
 {%
-   include-markdown '_common.include'
+   include-markdown './_common.include'
    start='<!--controls-note-start-->'
    end='<!--controls-note-end-->'
 %}

--- a/docs/user-guide/additional-services/timescaledb.md
+++ b/docs/user-guide/additional-services/timescaledb.md
@@ -43,7 +43,7 @@ This means that your administrator will be setting up a complete PostgreSQL clus
 If you want to use TimescaleDB on your Compliant Kubernetes cluster, ask your administrator to [provision a new standard PostgreSQL cluster](timescaledb.md#provision-a-new-postgresql-cluster) inside your Compliant Kubernetes environment. Then set up the TimescaleDB extension.
 
 {%
-    include "postgresql.md"
+    include "./postgresql.md"
     start="<!--postgresql-setup-start-->"
     end="<!--postgresql-setup-end-->"
 %}

--- a/docs/user-guide/deploy.md
+++ b/docs/user-guide/deploy.md
@@ -17,7 +17,7 @@ We have versions of it for [Node JS](https://github.com/elastisys/compliantkuber
 ## Push Your Container Images
 
 {%
-    include "registry.md"
+    include "./registry.md"
     start="<!--user-demo-registry-start-->"
     end="<!--user-demo-registry-end-->"
 %}
@@ -25,7 +25,7 @@ We have versions of it for [Node JS](https://github.com/elastisys/compliantkuber
 ## Deploy Your Application
 
 {%
-    include "kubernetes-api.md"
+    include "./kubernetes-api.md"
     start="<!--user-demo-kubernetes-api-start-->"
     end="<!--user-demo-kubernetes-api-end-->"
 %}
@@ -33,7 +33,7 @@ We have versions of it for [Node JS](https://github.com/elastisys/compliantkuber
 ## View Application Logs
 
 {%
-    include "logs.md"
+    include "./logs.md"
     start="<!--user-demo-logs-start-->"
     end="<!--user-demo-logs-end-->"
 %}

--- a/docs/user-guide/operate.md
+++ b/docs/user-guide/operate.md
@@ -22,7 +22,7 @@ But Prometheus can also be instructed to collect specific metrics from your own 
 To instruct Promethus on how to do this, you create a [ServiceMonitor](https://blog.container-solutions.com/prometheus-operator-beginners-guide). This is a Kubernetes resource that configures Prometheus and specifies how to collect metrics from a particular application.
 
 {%
-    include "metrics.md"
+    include "./metrics.md"
     start="<!--user-demo-metrics-start-->"
     end="<!--user-demo-metrics-end-->"
 %}
@@ -39,7 +39,7 @@ Visualizing monitoring metrics is one thing. Sometimes, you may need to act on w
 If you wish to create rules based on application-specific monitoring metrics, you must first create appropriate ServiceMonitors as described above.
 
 {%
-    include "alerts.md"
+    include "./alerts.md"
     start="<!--user-demo-alerts-start-->"
     end="<!--user-demo-alerts-end-->"
 %}
@@ -63,13 +63,13 @@ Not having sufficient capacity is also a kind of disaster, albeit, one that is e
 ### Back up Application Data
 
 {%
-    include "backup.md"
+    include "./backup.md"
     start="<!--user-demo-backup-start-->"
     end="<!--user-demo-backup-end-->"
 %}
 
 {%
-    include "backup.md"
+    include "./backup.md"
     start="<!--user-demo-restore-start-->"
     end="<!--user-demo-restore-end-->"
 %}

--- a/docs/user-guide/prepare.md
+++ b/docs/user-guide/prepare.md
@@ -100,7 +100,7 @@ However, there are some restrictions in place for security reasons. In particula
 There are additional safeguards in place that reflect the security posture of Elastisys Compliant Kubernetes that impact your application. These prevent users from doing potentially unsafe things. In particular, users are not allowed to:
 
 {%
-    include "demarcation.md"
+    include "./demarcation.md"
     start="<!--safeguards-start-->"
     end="<!--safeguards-end-->"
 %}

--- a/docs/user-guide/self-managed-services/ferretdb.md
+++ b/docs/user-guide/self-managed-services/ferretdb.md
@@ -1,7 +1,7 @@
 # FerretDB® (self-managed)
 
 {%
-   include-markdown '_common.include'
+   include-markdown './_common.include'
    start='<!--disclaimer-start-->'
    end='<!--disclaimer-end-->'
 %}

--- a/docs/user-guide/self-managed-services/keycloak.md
+++ b/docs/user-guide/self-managed-services/keycloak.md
@@ -2,7 +2,7 @@ Keycloak™ (self-managed)
 ===========
 
 {%
-   include-markdown '_common.include'
+   include-markdown './_common.include'
    start='<!--disclaimer-start-->'
    end='<!--disclaimer-end-->'
 %}


### PR DESCRIPTION
mkdocs-include-markdown-plugin recently changed the way it resolves paths. Specifically:

```
- Local files:
  - Absolute paths (starting with a path separator).
  - Relative from the file that includes them (starting with `./` or `../`).
  - Relative from the _docs/_ directory. 
```

Hence a path like `_common.include` is now interpreted as relative to the _docs/_ directory.

This commit adds `./` in front of all paths, so that they are correctly interpreted as relative to the file where the include macro is used.

Further reading:
- https://github.com/mondeja/mkdocs-include-markdown-plugin/commit/eb9f6ed90d8da15bf2e23b9b88dced2d8f5391f6#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5