### PR TITLE
Add social cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.swp
 site/
+
+# Used by the social plugin
+# https://squidfunk.github.io/mkdocs-material/setup/setting-up-social-cards/
+.cache

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ theme:
     - content.code.annotate
     - content.code.copy
     - content.tabs.link
+    - navigation.footer
     - navigation.top
 
 extra_css:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,10 @@ extra_css:
   - stylesheets/extra.css
 
 plugins:
+  - social:
+      cards_layout_options:
+        background_color: "#334768"
+        font_family: Poppins
   - include-markdown
   - search
   - mike:

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,7 @@ mkdocs-include-markdown-plugin>=2.8
 mkdocs-redirects
 mike>=1.1.2
 ./mkdocs-ciso-controls
+
+# Required by mkdocs-material's social plugin
+cairosvg
+pillow


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

I just discovered that `mkdocs-material`, the tech that fuels `elastisys.io`, includes a social plugin. Said plugin can generate a social card for each page, which includes our logo, the page title and page description.

I'm copy-pasting some examples below.

If we want to background image then we need to sponsor mkdocs-material with at least $125/months. I feel that no background image is good enough for now, and we should revisit sponsorship later.

What do you think?

![fdc6146cecc9f607ab26648ed778f2d2](https://github.com/elastisys/compliantkubernetes/assets/1660833/a3477a72-bcab-4238-b4a5-d9b7105a0340)
![fa43fc8c656007a2144222c529e9267a](https://github.com/elastisys/compliantkubernetes/assets/1660833/fcff3551-7b2a-4dfa-a5a3-119906b39c66)
