### PR TITLE
Use codespell on pre-commit

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,3 +1,4 @@
+aks
 Vårdgivaren
 ska
 vid

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,0 @@
-[codespell]
-count =
-summary =
-skip = ./site,*.svg,*.xml,*.dot,./docs/compliantkubernetes/ciso-guide/*.md,.git
-ignore-words-list = aks,

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,9 +12,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - uses: pre-commit/action@v2.0.0
-      - uses: codespell-project/actions-codespell@master
-        with:
-          ignore_words_file: .codespellignore
       - name: Test docs
         run: |
           python3 -m pip install -r ./requirements.txt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,17 @@ repos:
       - id: check-added-large-files
       - id: check-merge-conflict
       - id: no-commit-to-branch
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.4
+    hooks:
+      - id: codespell
+        name: check spelling
+        args:
+          - -I
+          - .codespellignore
+        exclude: ^(site/.*|.*\.dot|.*\.svg|.*\.xml)$
+
   - repo: local
     hooks:
       - id: svg-must-embed


### PR DESCRIPTION
Because I'm tired of fixing spelling issues *after* I've pushed changes. :sweat_smile: 
And this is also the method we use everywhere else.