### PR TITLE
Fix link to Microsoft's IdP

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -135,7 +135,12 @@ See also:
 
 ## Identity Provider
 
-An Identity Provider (IdP) is a system that offers user authentication as a service. Examples include [Keycloak](https://www.keycloak.org/), [Azure Active Directory](https://azure.microsoft.com/en-us/products/active-directory), [Google Identity](https://developers.google.com/identity/openid-connect/openid-connect#setredirecturi) and [jumpcloud](https://jumpcloud.com/).
+An Identity Provider (IdP) is a system that offers user authentication as a service. Examples include:
+
+- [Keycloak](https://www.keycloak.org/)
+- [Microsoft Entra ID](https://www.microsoft.com/en-us/security/business/identity-access/microsoft-entra-id) previously known as Azure Active Directory
+- [Google Identity](https://developers.google.com/identity/openid-connect/openid-connect#setredirecturi)
+- [jumpcloud](https://jumpcloud.com/)
 
 Usage notes:
 


### PR DESCRIPTION
Microsoft renamed Azure Active Directory to Microsoft Entra ID. The old link to Azure Active Directory is now a redirect.

@davidumea @llarsson @aarnq How should we deal when URLs change with a proper redirect?

I see the following options (please vote or propose another option):

1. As today, issue a PR with reviewers.
    - Good, because it raises awareness to everyone.
    - Good, because it respects our processes.
    - Bad, because it grabs a lot of attention for little value.
2. Bypass PR and fix link directly on `main`.
    - Good, because it creates less attention noise.
    - Bad, because it bypasses our processes.
3. Let's silence redirect warnings.
    - Good, because it reduces attention noise.
    - Good, because it respects our processes.
    - Bad, because we miss out on interesting signals from the ecosystem.
 4. Check links on a daily basis, but check redirects only monthly.
    - Good, because good trade-off between quality and noise.

⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.
