### PR TITLE
Fix example to configure alertmanager

### DIFF
--- a/docs/user-guide/alerts.md
+++ b/docs/user-guide/alerts.md
@@ -26,13 +26,16 @@ User alerts are handled by a project called [AlertManager](https://prometheus.io
 User alerts are configured via the Secret `alertmanager-alertmanager` located in the `alertmanager` namespace. This configuration file is specified [here](https://prometheus.io/docs/alerting/latest/configuration/#configuration-file).
 
 ```bash
-# retrieve the old configuration
+# retrieve the old configuration:
 kubectl get -n alertmanager secret alertmanager-alertmanager -o jsonpath='{.data.alertmanager\.yaml}' | base64 -d > alertmanager.yaml
 
 # edit alertmanager.yaml as needed
 
-# patch the new configuration
-kubectl patch -n alertmanager secret alertmanager-alertmanager -p "'{\"data\":{\"alertmanager.yaml\":\"$(base64 -w 0 < alertmanager.yaml)\"}}'"
+# patch the new configuration:
+kubectl patch -n alertmanager secret alertmanager-alertmanager -p "{\"data\":{\"alertmanager.yaml\":\"$(base64 -w 0 < alertmanager.yaml)\"}}"
+
+# mac users may need to omit -w 0 arguments to base64:
+kubectl patch -n alertmanager secret alertmanager-alertmanager -p "{\"data\":{\"alertmanager.yaml\":\"$(base64 < alertmanager.yaml)\"}}"
 ```
 
 Make sure to configure **and test** a receiver for you alerts, e.g., Slack or OpsGenie.


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Now I don't have a Mac to test with but I was told that it didn't work with the arguments to `base64` so I added it as a second example.