### PR TITLE
Ignore redirect warnings

### DIFF
--- a/linkchecker.conf
+++ b/linkchecker.conf
@@ -6,12 +6,7 @@ checkextern=1
 ignore=
     \/\/localhost
     \/\/127.0.0.1
-    # The URLs below trigger a redirect to a login page. linkchecker warns on redirects.
-    # The redirected URLs look really ugly, so we prefer the ones below.
-    https://admin.google.com
-    https://console.cloud.google.com
-    https://console.developers.google.com/
-    https://elastisys.atlassian.net/servicedesk/
+ignorewarnings=http-redirected
 
 # NOTE: Currently generates a lot of warnings!
 #[AnchorCheck]


### PR DESCRIPTION
Permanently fixes pipeline failures, like [this one](https://github.com/elastisys/compliantkubernetes/actions/runs/6624459612/job/17993479875#step:4:26).

Whoever disagrees with this PR is free to take responsibility to fixing 301 and 302 on `elastisys.io`. I did it 5 times in October alone. :smile: 

⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.
