### PR TITLE
Replace inline Matomo with its tag manager

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -2,7 +2,18 @@
 
 {% block analytics %}
 
-<!-- Matomo -->
+<!-- Matomo Tag Manager -->
+<script>
+  var _mtm = window._mtm = window._mtm || [];
+  _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+  (function() {
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src='https://matomo.elastisys.com/js/container_fGrcdd2P.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Tag Manager -->
+
+<!-- Matomo
 <script>
   var _paq = window._paq = window._paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
@@ -16,7 +27,8 @@
     g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
-<!-- End Matomo Code -->
+
+End Matomo Code -->
 {% endblock %}
 
 {% block extrahead %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -13,22 +13,6 @@
 </script>
 <!-- End Matomo Tag Manager -->
 
-<!-- Matomo
-<script>
-  var _paq = window._paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="https://matomo.elastisys.com/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '2']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-
-End Matomo Code -->
 {% endblock %}
 
 {% block extrahead %}


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

As per request from analytics partner, this PR replaces the Matomo script loader with the Matomo Tag Manager script loader. This enables one to configure more Matomo-related things directly via Matomo, I believe.