### PR TITLE
Fix typo in argocd related docs

### DIFF
--- a/docs/adr/0030-run-argocd-on-elastisys-nodes.md
+++ b/docs/adr/0030-run-argocd-on-elastisys-nodes.md
@@ -14,7 +14,7 @@ Where should we run ArgoCD?
 * We want to deliver a stable and secure platform.
 * We want to deliver an affordable adittional managed service and avoid resource waste.
 * ArgoCD has a small footprint, e.g., 200m CPU and 0.5GB RAM for one of our largest deployments.
-* Want want to keep application Nodes "light", so the application team knows what capacity is available for their application.
+* We want to keep application Nodes "light", so the application team knows what capacity is available for their application.
 
 ## Considered Options
 

--- a/docs/ciso-guide/nis2.md
+++ b/docs/ciso-guide/nis2.md
@@ -14,18 +14,18 @@ description: Overview of what the Network and Information Security Directive 2 (
 The [NIS2 Directive](https://digital-strategy.ec.europa.eu/en/policies/nis2-directive){:target="_blank"} stands as a comprehensive EU-wide cybersecurity legislation, aimed at elevating the overall state of cybersecurity across the European Union.
 Imposing legal measures, it serves to fortify the digital landscape in the region.
 
-Initiated in 2016, the EU's cybersecurity regulations underwent a substantial transformation with the enactment of the NIS2 Directive in 2023. 
-This update was imperative to adapt to the expanding realm of digitization and the continuously evolving cybersecurity threats. 
+Initiated in 2016, the EU's cybersecurity regulations underwent a substantial transformation with the enactment of the NIS2 Directive in 2023.
+This update was imperative to adapt to the expanding realm of digitization and the continuously evolving cybersecurity threats.
 The directive's enhancements extend the applicability of cybersecurity regulations to novel sectors and entities, thereby enhancing the resilience and response capabilities of public and private bodies, competent authorities, and the entire EU.
 
-The NIS2 Directive, officially titled the Directive on measures for a high common level of cybersecurity across the Union, imposes legal requisites to augment cybersecurity throughout the EU. 
-Its key provisions encompass ensuring the preparedness of Member States, mandating the establishment of essential capabilities like a Computer Security Incident Response Team (CSIRT) and a competent national network and information systems (NIS) authority. 
+The NIS2 Directive, officially titled the Directive on measures for a high common level of cybersecurity across the Union, imposes legal requisites to augment cybersecurity throughout the EU.
+Its key provisions encompass ensuring the preparedness of Member States, mandating the establishment of essential capabilities like a Computer Security Incident Response Team (CSIRT) and a competent national network and information systems (NIS) authority.
 Furthermore, it promotes cooperation among Member States through the establishment of a Cooperation Group, fostering strategic collaboration and information exchange.
 
-The directive seeks to instill a culture of security across critical sectors vital for the economy and society, heavily reliant on information and communication technologies (ICTs). 
+The directive seeks to instill a culture of security across critical sectors vital for the economy and society, heavily reliant on information and communication technologies (ICTs).
 These sectors include energy, transport, water, banking, financial market infrastructures, healthcare, and digital infrastructure.
 
-To uphold the directive's objectives, businesses identified by Member States as operators of essential services in the specified sectors must implement suitable security measures and promptly report significant incidents to relevant national authorities. 
+To uphold the directive's objectives, businesses identified by Member States as operators of essential services in the specified sectors must implement suitable security measures and promptly report significant incidents to relevant national authorities.
 Similarly, key digital service providers, such as search engines, cloud computing services, and online marketplaces, are obligated to adhere to the security and notification requirements outlined in the directive.
 
 ## Which sectors are covered by the NIS2 Directive?
@@ -37,7 +37,7 @@ It is clear that many use-cases where Compliant Kubernetes has been successfully
 The [official FAQ](https://digital-strategy.ec.europa.eu/en/faqs/directive-measures-high-common-level-cybersecurity-across-union-nis2-directive-faqs){:target="_blank"} lists the sectors in scope as follows:
 
 > Sectors of high criticality: energy (electricity, district heating and cooling, oil, gas and hydrogen); transport (air, rail, water and road); banking; financial market infrastructures; health including  manufacture of pharmaceutical products including vaccines; drinking water; waste water; digital infrastructure (internet exchange points; DNS service providers; TLD name registries; cloud computing service providers; data centre service providers; content delivery networks; trust service providers; providers of  public electronic communications networks and publicly available electronic communications services); ICT service management (managed service providers and managed security service providers), public administration and space.
-> 
+>
 > Other critical sectors: postal and courier services; waste management; chemicals; food; manufacturing of medical devices, computers and electronics, machinery and equipment, motor vehicles, trailers and semi-trailers and other transport equipment; digital providers (online market places, online search engines, and social networking service platforms) and research organisations.
 
 ## How does the NIS2 Directive relate to Compliant Kubernetes?


### PR DESCRIPTION
There is a typo in the [Run ArgoCD on the Elastisys nodes](https://elastisys.io/compliantkubernetes/adr/0030-run-argocd-on-elastisys-nodes/) and some linting issues. This PR solves it. 

⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.
