### PR TITLE
Fix: change link to changelog (pun intended)

### DIFF
--- a/docs/operator-manual/maintenance.md
+++ b/docs/operator-manual/maintenance.md
@@ -52,7 +52,7 @@ Compliant Kubernetes consists of a multitude of open source components that inte
 In order to free you of the burden of keeping track of when to upgrade the various components, new versions of Complaint Kubernetes are regularly release.
 When a new version is released, it becomes available as a [tagged release](https://github.com/elastisys/compliantkubernetes-apps/tags) in the GitHub repo.
 
-> Before upgrading to a new release, please review the [changelog](https://github.com/elastisys/compliantkubernetes-apps/blob/main/CHANGELOG.md) if possible, apply the upgrade to a staging environment before upgrading any environments with production data.
+> Before upgrading to a new release, please review the [changelog](https://github.com/elastisys/compliantkubernetes-apps/tree/main/changelog) if possible, apply the upgrade to a staging environment before upgrading any environments with production data.
 
 ### Prerequisites
 


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

The changelog URL changed as a result of [this commit](https://github.com/elastisys/compliantkubernetes-apps/commit/49d066dcb628a3d43ed21c62a09981616284818a). I don't usually buzz people with PRs on fixing links, but in this case I want to make sure I understood the intention going forward correctly.

Thanks for reviewing and confirming!