### PR TITLE
Update user-demo HPA apiVersion

### DIFF
--- a/user-demo/deploy/ck8s-user-demo/templates/hpa.yaml
+++ b/user-demo/deploy/ck8s-user-demo/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "ck8s-user-demo.fullname" . }}
@@ -17,12 +17,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
   {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

The HPA manifest for the user-demo Helm chart was not up to date with current Kubernetes versions (the api version changed in v1.23). This PR addresses this issue.