### PR TITLE
Update docs with recent ck8s release changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,18 +42,19 @@ Code snippets should be written in a way that is transparent, predictable and fl
 
 Examples:
 
-```
+```bash
 ## Config snippet, almost always requires human input
 export CK8S_ENVIRONMENT_NAME=my-environment-name
 #export CK8S_FLAVOR=[dev|prod] # defaults to dev
 export CK8S_CONFIG_PATH=~/.ck8s/my-cluster-path
 export CK8S_CLOUD_PROVIDER=# [exoscale|safespring|citycloud|aws|baremetal]
 export CK8S_PGP_FP=<your GPG key fingerprint>  # retrieve with gpg --list-secret-keys
-./bin/ck8s init
+export CLUSTERS=( "sc" "wc" )
+./bin/ck8s init both
 
 ## Apply snippets
 # Good, because administrator can review command, change command as necessary, review its effects and approves those effects
-for CLUSTER in ${SERVICE_CLUSTER} "${WORKLOAD_CLUSTERS[@]}"; do
+for CLUSTER in "${CLUSTERS[@]}"; do
     pushd inventory/$CLUSTER
     terraform init ../../contrib/terraform/exoscale
     terraform apply \
@@ -64,7 +65,6 @@ for CLUSTER in ${SERVICE_CLUSTER} "${WORKLOAD_CLUSTERS[@]}"; do
 done
 
 # Okay
-ln -sf $CK8S_CONFIG_PATH/.state/kube_config_${SERVICE_CLUSTER}.yaml $CK8S_CONFIG_PATH/.state/kube_config_sc.yaml
 ./bin/ck8s apply sc  # Respond "n" if you get a WARN
 
 # Bad, because the effects are difficult to predict and adjust
@@ -90,12 +90,12 @@ kubectl delete all --all --all-namespaces
 Files ending in `*.drawio.svg` are produced using [diagrams.net](https://www.diagrams.net/). They are exported as follows:
 
 1. File -> Export As -> SVG
-2. Change "zoom" to 100%.
-3. Enable "Embed Images".
-4. Enable "Embed Fonts".
-5. Enable "Include a copy of my diagram".
-6. Select "Links: In new window".
-6. Leave everything else as default.
+1. Change "zoom" to 100%.
+1. Enable "Embed Images".
+1. Enable "Embed Fonts".
+1. Enable "Include a copy of my diagram".
+1. Select "Links: In new window".
+1. Leave everything else as default.
 
 To facilitate editing architecture diagrams, import the [Compliant Kubernetes DrawIO library](docs/img/ck8s-library.drawio.xml).
 
@@ -103,13 +103,13 @@ To facilitate editing architecture diagrams, import the [Compliant Kubernetes Dr
 
 Other diagrams are produced in graphviz. To regenerate them, edit the relevant `dot` file, then type:
 
-```
+```bash
 make -C docs/img
 ```
 
 For "live preview" open the output file (e.g., SVG or PNG) in a viewer supporting live refresh (e.g., eog), then type:
 
-```
+```bash
 make -C docs/img preview
 ```
 

--- a/docs/operator-manual/maintenance.md
+++ b/docs/operator-manual/maintenance.md
@@ -43,7 +43,7 @@ There is a playbook in the compliantkubernetes-kubespray repo that can assist wi
 It will cordon and reboot the nodes one by one.
 
 ```bash
-./bin/ck8s-kubespray reboot-nodes <prefix> [--extra-vars manual_prompt=true] [<options>]
+./bin/ck8s-kubespray reboot-nodes <wc|sc> [--extra-vars manual_prompt=true] [<options>]
 ```
 
 ### Upgrading the Compliant Kubernetes application stack
@@ -92,7 +92,7 @@ Then check the release notes for each version in between to see if there are any
     This will take a backup into `backups/` before modifying any files.
 
     ```bash
-    ./bin/ck8s init
+    ./bin/ck8s init both
     ```
 
 1. Check if there is a [migration document](https://github.com/elastisys/compliantkubernetes-apps/tree/main/migration) for the release you want to upgrade to, (e.g. [for upgrade to 0.11.0](https://github.com/elastisys/compliantkubernetes-apps/blob/5d8f4f1b3cc053b3b515711549ab80df9617f2f4/migration/v0.10.x-v0.11.x/upgrade-apps.md) ) and follow the instructions there.


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Since the apps and kubespray scripts have been modified in recent releases so that certain commands now take an argument (e.g. `ck8s init` now needs to run with a cluster argument: `ck8s init both`), this PR addresses these changes in the public docs. This PR also looks to force wc and sc cluster names which has also been updated in the ck8s apps and kubespray repos.

The on-prem template has been refactored to use the `common.md` to try and have a standard file for how ck8s-apps should be deployed, in which the on-prem template can extend upon.

Some other various fixes have been added in this PR as well, such as removing deprecated code, changing some markdown alerts that better match the text flavor, and extending the OIDC configuration part in the on-prem template to (hopefully) better explain how to configure respective cluster with Dex and an IdP.

- Fixes https://github.com/elastisys/compliantkubernetes/issues/679

