### PR TITLE
Updated requirements to include setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ PyYAML==6.0.1
 pyyaml_env_tag==0.1
 regex==2023.12.25
 requests==2.31.0
+setuptools==69.5.1
 six==1.16.0
 tinycss2==1.2.1
 urllib3==2.2.1


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](docs/glossary.md) and did my best to use those terms.

Added setuptools to requirements.
Fixes a bug where pkg_resources module isn't installed in venv and crashes on some versions of python.