### PR TITLE
docs: renamed titles of troubleshooting pages

### DIFF
--- a/docs/operator-manual/troubleshooting.md
+++ b/docs/operator-manual/troubleshooting.md
@@ -1,4 +1,4 @@
-# Troubleshooting Tools
+# Troubleshooting For Platform Administrators
 
 {%
     include "./common.md"

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -2,7 +2,7 @@
 description: Troubleshooting help for Application Developers on Elastisys Compliant Kubernetes, the security-hardened Kubernetes distribution
 ---
 
-# Troubleshooting
+# Troubleshooting For Application Developers
 
 Going through these basic troubleshooting steps should help you as an Application Developer identify where a problem may lie. If any of these steps do not give the expected "fine" output, use `kubectl describe` to investigate.
 


### PR DESCRIPTION
… searching

⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](docs/glossary.md) and did my best to use those terms.

Changed the title of the two different troubleshooting pages to make it easier to understand which is which when searching "troubleshoot" in search bar.