### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,16 @@
+# By default, this whole repo should be reviewed by the goto-public-docs.
+* @elastisys/goto-public-docs
+
+# Specific files fall under QA.
+/.github/                           @elastisys/goto-public-docs @elastisys/qa
+/ci/                                @elastisys/goto-public-docs @elastisys/qa
+/scripts/                           @elastisys/goto-public-docs @elastisys/qa
+/.codespellignore                   @elastisys/goto-public-docs @elastisys/qa
+/.editorconfig                      @elastisys/goto-public-docs @elastisys/qa
+/.eslintrc.yml                      @elastisys/goto-public-docs @elastisys/qa
+/.markdownlint.yaml                 @elastisys/goto-public-docs @elastisys/qa
+/.pre-commit-config.yaml            @elastisys/goto-public-docs @elastisys/qa
+/.vale.ini                          @elastisys/goto-public-docs @elastisys/qa
+/linkchecker.conf                   @elastisys/goto-public-docs @elastisys/qa
+/package.json                       @elastisys/goto-public-docs @elastisys/qa
+/requirements-linkchecker.txt       @elastisys/goto-public-docs @elastisys/qa


### PR DESCRIPTION
During the product team meeting on 2024-05-23, we decided to try and use CODEOWNERS to match code to goto areas.

This PR does this for the public docs. It is meant as a "let's try it out" and not a perfect solution. We'll likely need to adjust CODEOWNERS as we go.

⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](docs/glossary.md) and did my best to use those terms.
