### PR TITLE
Revert "New design as per new brand book"

### DIFF
--- a/docs/img/marchitecture.svg
+++ b/docs/img/marchitecture.svg
@@ -1,2557 +1,4441 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="2e3" height="1700" version="1.0" viewBox="0 0 1500 1275" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" zoomAndPan="magnify">
-<defs>
-<clipPath id="ac">
-<path d="m47.199 53.27h447.36v182.36h-447.36z"/>
-</clipPath>
-<clipPath id="bg">
-<path d="m62.199 53.27h417.29c3.9805 0 7.793 1.5781 10.609 4.3945 2.8125 2.8125 4.3906 6.625 4.3906 10.605v152.36c0 3.9805-1.5781 7.793-4.3906 10.609-2.8164 2.8125-6.6289 4.3906-10.609 4.3906h-417.29c-3.9805 0-7.793-1.5781-10.609-4.3906-2.8125-2.8164-4.3906-6.6289-4.3906-10.609v-152.36c0-3.9805 1.5781-7.793 4.3906-10.605 2.8164-2.8164 6.6289-4.3945 10.609-4.3945z"/>
-</clipPath>
-<clipPath id="r">
-<path d="m146.64 142.5h108.36v59.656h-108.36z"/>
-</clipPath>
-<clipPath id="ab">
-<path d="m155.64 142.5h90.219c2.3867 0 4.6797 0.94922 6.3672 2.6367s2.6328 3.9766 2.6328 6.3633v41.656c0 2.3867-0.94531 4.6758-2.6328 6.3633s-3.9805 2.6367-6.3672 2.6367h-90.219c-2.3867 0-4.6758-0.94922-6.3633-2.6367s-2.6367-3.9766-2.6367-6.3633v-41.656c0-2.3867 0.94922-4.6758 2.6367-6.3633s3.9766-2.6367 6.3633-2.6367z"/>
-</clipPath>
-<clipPath id="bb">
-<path d="m284.8 142.5h112.79v59.656h-112.79z"/>
-</clipPath>
-<clipPath id="ad">
-<path d="m293.8 142.5h94.645c2.3867 0 4.6758 0.94922 6.3633 2.6367s2.6367 3.9766 2.6367 6.3633v41.656c0 2.3867-0.94922 4.6758-2.6367 6.3633s-3.9766 2.6367-6.3633 2.6367h-94.645c-2.3867 0-4.6758-0.94922-6.3633-2.6367s-2.6367-3.9766-2.6367-6.3633v-41.656c0-2.3867 0.94922-4.6758 2.6367-6.3633s3.9766-2.6367 6.3633-2.6367z"/>
-</clipPath>
-<clipPath id="am">
-<path d="m530.3 53.27h439.52v182.36h-439.52z"/>
-</clipPath>
-<clipPath id="az">
-<path d="m545.3 53.27h409.39c3.9805 0 7.793 1.5781 10.609 4.3945 2.8125 2.8125 4.3906 6.625 4.3906 10.605v152.36c0 3.9805-1.5781 7.793-4.3906 10.609-2.8164 2.8125-6.6289 4.3906-10.609 4.3906h-409.39c-3.9805 0-7.793-1.5781-10.609-4.3906-2.8125-2.8164-4.3906-6.6289-4.3906-10.609v-152.36c0-3.9805 1.5781-7.793 4.3906-10.605 2.8164-2.8164 6.6289-4.3945 10.609-4.3945z"/>
-</clipPath>
-<clipPath id="u">
-<path d="m567.82 142.5h121.88v59.656h-121.88z"/>
-</clipPath>
-<clipPath id="ah">
-<path d="m576.82 142.5h103.73c2.3867 0 4.6758 0.94922 6.3633 2.6367s2.6367 3.9766 2.6367 6.3633v41.656c0 2.3867-0.94922 4.6758-2.6367 6.3633s-3.9766 2.6367-6.3633 2.6367h-103.73c-2.3867 0-4.6758-0.94922-6.3633-2.6367s-2.6367-3.9766-2.6367-6.3633v-41.656c0-2.3867 0.94922-4.6758 2.6367-6.3633s3.9766-2.6367 6.3633-2.6367z"/>
-</clipPath>
-<clipPath id="as">
-<path d="m838.38 142.5h96.938v59.656h-96.938z"/>
-</clipPath>
-<clipPath id="bh">
-<path d="m847.38 142.5h78.793c2.3867 0 4.6758 0.94922 6.3633 2.6367s2.6367 3.9766 2.6367 6.3633v41.656c0 2.3867-0.94922 4.6758-2.6367 6.3633s-3.9766 2.6367-6.3633 2.6367h-78.793c-2.3867 0-4.6758-0.94922-6.3633-2.6367-1.6914-1.6875-2.6367-3.9766-2.6367-6.3633v-41.656c0-2.3867 0.94531-4.6758 2.6367-6.3633 1.6875-1.6875 3.9766-2.6367 6.3633-2.6367z"/>
-</clipPath>
-<clipPath id="bw">
-<path d="m1005.7 53.27h447.3v182.36h-447.3z"/>
-</clipPath>
-<clipPath id="aj">
-<path d="m1020.7 53.27h417.11c3.9805 0 7.793 1.5781 10.609 4.3945 2.8125 2.8125 4.3906 6.625 4.3906 10.605v152.36c0 3.9805-1.5781 7.793-4.3906 10.609-2.8164 2.8125-6.6289 4.3906-10.609 4.3906h-417.11c-3.9766 0-7.793-1.5781-10.605-4.3906-2.8125-2.8164-4.3945-6.6289-4.3945-10.609v-152.36c0-3.9805 1.582-7.793 4.3945-10.605 2.8125-2.8164 6.6289-4.3945 10.605-4.3945z"/>
-</clipPath>
-<clipPath id="ai">
-<path d="m1069.3 176.91h203.66v37.848h-203.66z"/>
-</clipPath>
-<clipPath id="bp">
-<path d="m1078.3 176.91h185.65c4.9727 0 9 4.0312 9 9v19.848c0 4.9688-4.0273 9-9 9h-185.65c-4.9727 0-9-4.0312-9-9v-19.848c0-4.9688 4.0273-9 9-9z"/>
-</clipPath>
-<clipPath id="s">
-<path d="m47.199 255h1405.8v488.32h-1405.8z"/>
-</clipPath>
-<clipPath id="aq">
-<path d="m62.199 255h1375.6c3.9805 0 7.793 1.582 10.609 4.3945 2.8125 2.8125 4.3906 6.6289 4.3906 10.605v458.32c0 3.9766-1.5781 7.793-4.3906 10.605-2.8164 2.8125-6.6289 4.3945-10.609 4.3945h-1375.6c-3.9805 0-7.793-1.582-10.609-4.3945-2.8125-2.8125-4.3906-6.6289-4.3906-10.605v-458.32c0-3.9766 1.5781-7.793 4.3906-10.605 2.8164-2.8125 6.6289-4.3945 10.609-4.3945z"/>
-</clipPath>
-<clipPath id="bk">
-<path d="m66.363 621.42h138.64v78.957h-138.64z"/>
-</clipPath>
-<clipPath id="bj">
-<path d="m75.363 621.42h120.62c4.9688 0 9 4.0273 9 9v60.957c0 4.9727-4.0312 9-9 9h-120.62c-4.9688 0-9-4.0273-9-9v-60.957c0-4.9727 4.0312-9 9-9z"/>
-</clipPath>
-<clipPath id="av">
-<path d="m213.23 621.42h140.11v80.062h-140.11z"/>
-</clipPath>
-<clipPath id="o">
-<path d="m222.23 621.42h122.09c4.9727 0 9 4.0273 9 9v62.062c0 4.9727-4.0273 9-9 9h-122.09c-4.9727 0-9-4.0273-9-9v-62.062c0-4.9727 4.0273-9 9-9z"/>
-</clipPath>
-<clipPath id="l">
-<path d="m361.57 621.42h147.31v80.062h-147.31z"/>
-</clipPath>
-<clipPath id="bn">
-<path d="m370.57 621.42h129.22c4.9688 0 9 4.0273 9 9v62.062c0 4.9727-4.0312 9-9 9h-129.22c-4.9688 0-9-4.0273-9-9v-62.062c0-4.9727 4.0312-9 9-9z"/>
-</clipPath>
-<clipPath id="v">
-<path d="m517.04 621.42h149.96v80.062h-149.96z"/>
-</clipPath>
-<clipPath id="m">
-<path d="m526.04 621.42h131.81c4.9688 0 9 4.0273 9 9v62.062c0 4.9727-4.0312 9-9 9h-131.81c-4.9727 0-9-4.0273-9-9v-62.062c0-4.9727 4.0273-9 9-9z"/>
-</clipPath>
-<clipPath id="i">
-<path d="m675.1 621.42h149.89v78.957h-149.89z"/>
-</clipPath>
-<clipPath id="at">
-<path d="m684.1 621.42h131.8c4.9727 0 9 4.0273 9 9v60.957c0 4.9727-4.0273 9-9 9h-131.8c-4.9727 0-9-4.0273-9-9v-60.957c0-4.9727 4.0273-9 9-9z"/>
-</clipPath>
-<clipPath id="bv">
-<path d="m833.15 621.42h140.64v78.957h-140.64z"/>
-</clipPath>
-<clipPath id="af">
-<path d="m842.15 621.42h122.48c4.9688 0 9 4.0273 9 9v60.957c0 4.9727-4.0312 9-9 9h-122.48c-4.9688 0-9-4.0273-9-9v-60.957c0-4.9727 4.0312-9 9-9z"/>
-</clipPath>
-<clipPath id="ak">
-<path d="m981.88 621.42h140.64v78.957h-140.64z"/>
-</clipPath>
-<clipPath id="bt">
-<path d="m990.88 621.42h122.47c4.9727 0 9 4.0273 9 9v60.957c0 4.9727-4.0273 9-9 9h-122.47c-4.9727 0-9-4.0273-9-9v-60.957c0-4.9727 4.0273-9 9-9z"/>
-</clipPath>
-<clipPath id="bc">
-<path d="m1130.6 621.42h140.4v78.957h-140.4z"/>
-</clipPath>
-<clipPath id="z">
-<path d="m1139.6 621.42h122.48c4.9688 0 9 4.0273 9 9v60.957c0 4.9727-4.0312 9-9 9h-122.48c-4.9688 0-9-4.0273-9-9v-60.957c0-4.9727 4.0312-9 9-9z"/>
-</clipPath>
-<clipPath id="f">
-<path d="m1279.3 621.42h159.5v80.062h-159.5z"/>
-</clipPath>
-<clipPath id="j">
-<path d="m1288.3 621.42h141.35c4.9727 0 9 4.0273 9 9v62.062c0 4.9727-4.0273 9-9 9h-141.35c-4.9727 0-9-4.0273-9-9v-62.062c0-4.9727 4.0273-9 9-9z"/>
-</clipPath>
-<clipPath id="bd">
-<path d="m47.199 764.32h1405.8v197.63h-1405.8z"/>
-</clipPath>
-<clipPath id="ae">
-<path d="m62.199 764.32h1375.6c3.9805 0 7.793 1.5781 10.609 4.3945 2.8125 2.8125 4.3906 6.625 4.3906 10.605v167.63c0 3.9766-1.5781 7.793-4.3906 10.605-2.8164 2.8125-6.6289 4.3945-10.609 4.3945h-1375.6c-3.9805 0-7.793-1.582-10.609-4.3945-2.8125-2.8125-4.3906-6.6289-4.3906-10.605v-167.63c0-3.9805 1.5781-7.793 4.3906-10.605 2.8164-2.8164 6.6289-4.3945 10.609-4.3945z"/>
-</clipPath>
-<clipPath id="al">
-<path d="m47.199 982.95h1405.7v192.75h-1405.7z"/>
-</clipPath>
-<clipPath id="bm">
-<path d="m62.199 982.95h1375.6c3.9805 0 7.793 1.582 10.609 4.3945 2.8125 2.8125 4.3906 6.6289 4.3906 10.605v162.75c0 3.9766-1.5781 7.793-4.3906 10.605-2.8164 2.8125-6.6289 4.3945-10.609 4.3945h-1375.6c-3.9805 0-7.793-1.582-10.609-4.3945-2.8125-2.8125-4.3906-6.6289-4.3906-10.605v-162.75c0-3.9766 1.5781-7.793 4.3906-10.605 2.8164-2.8125 6.6289-4.3945 10.609-4.3945z"/>
-</clipPath>
-<clipPath id="ax">
-<path d="m380.72 1060.1h81.016v71.914h-81.016z"/>
-</clipPath>
-<clipPath id="h">
-<path d="m424.29 1062.1 36.984 64.727c0.61719 1.0781 0.61328 2.4023-0.011719 3.4766-0.62109 1.0703-1.7695 1.7344-3.0117 1.7344h-73.879c-1.2422 0-2.3867-0.66406-3.0117-1.7344-0.62109-1.0742-0.62891-2.3984-0.011719-3.4766l36.988-64.727c0.60937-1.0664 1.7461-1.7266 2.9766-1.7266s2.3633 0.66016 2.9766 1.7266z"/>
-</clipPath>
-<clipPath id="y">
-<path d="m1315.1 1212h19.906v18.75h-19.906z"/>
-</clipPath>
-<clipPath id="aw">
-<path d="m1359 1206h94v24.75h-94z"/>
-</clipPath>
-<clipPath id="au">
-<path d="m581.25 380.23h337.65v127.11h-337.65z"/>
-</clipPath>
-<clipPath id="x">
-<path d="m596.25 380.23h307.5c3.9766 0 7.793 1.5781 10.605 4.3906s4.3945 6.6289 4.3945 10.609v97.113c0 3.9805-1.582 7.7969-4.3945 10.609s-6.6289 4.3906-10.605 4.3906h-307.5c-3.9766 0-7.793-1.5781-10.605-4.3906s-4.3945-6.6289-4.3945-10.609v-97.113c0-3.9805 1.582-7.7969 4.3945-10.609s6.6289-4.3906 10.605-4.3906z"/>
-</clipPath>
-<clipPath id="bq">
-<path d="m719.55 142.5h89.016v59.656h-89.016z"/>
-</clipPath>
-<clipPath id="bx">
-<path d="m728.55 142.5h70.832c2.3867 0 4.6758 0.94922 6.3633 2.6367s2.6367 3.9766 2.6367 6.3633v41.656c0 2.3867-0.94922 4.6758-2.6367 6.3633s-3.9766 2.6367-6.3633 2.6367h-70.832c-2.3867 0-4.6758-0.94922-6.3633-2.6367s-2.6367-3.9766-2.6367-6.3633v-41.656c0-2.3867 0.94922-4.6758 2.6367-6.3633s3.9766-2.6367 6.3633-2.6367z"/>
-</clipPath>
-<clipPath id="br">
-<path d="m1069.3 125.99h147.34v37.129h-147.34z"/>
-</clipPath>
-<clipPath id="c">
-<path d="m1078.3 125.99h129.22c4.9688 0 9 4.0312 9 9v19.129c0 4.9688-4.0312 9-9 9h-129.22c-4.9727 0-9-4.0312-9-9v-19.129c0-4.9688 4.0273-9 9-9z"/>
-</clipPath>
-<clipPath id="ap">
-<path d="m1264.6 125.99h124.72v37.129h-124.72z"/>
-</clipPath>
-<clipPath id="e">
-<path d="m1273.6 125.99h106.59c4.9688 0 9 4.0312 9 9v19.129c0 4.9688-4.0312 9-9 9h-106.59c-4.9727 0-9-4.0312-9-9v-19.129c0-4.9688 4.0273-9 9-9z"/>
-</clipPath>
-<clipPath id="bz">
-<path d="m1303 176.91h86.188v37.848h-86.188z"/>
-</clipPath>
-<clipPath id="ar">
-<path d="m1312 176.91h68.16c4.9688 0 9 4.0312 9 9v19.848c0 4.9688-4.0312 9-9 9h-68.16c-4.9688 0-9-4.0312-9-9v-19.848c0-4.9688 4.0312-9 9-9z"/>
-</clipPath>
-<clipPath id="bi">
-<path d="m248.44 858h72.562v58h-72.562z"/>
-</clipPath>
-<clipPath id="bf">
-<path d="m409 900h51v13.988h-51z"/>
-</clipPath>
-<clipPath id="ao">
-<path d="m557.19 837.21h71.812v39.785h-71.812z"/>
-</clipPath>
-<clipPath id="g">
-<path d="m566 876h28v40.715h-28z"/>
-</clipPath>
-<clipPath id="bu">
-<path d="m593 876h28v40.715h-28z"/>
-</clipPath>
-<clipPath id="n">
-<path d="m1016.1 842h71.926v71.988h-71.926z"/>
-</clipPath>
-<clipPath id="aa">
-<path d="m1052 913.16c19.371 0 35.07-15.773 35.07-35.227 0-19.453-15.699-35.227-35.07-35.227-19.371 0-35.07 15.773-35.07 35.227 0 19.453 15.699 35.227 35.07 35.227z"/>
-</clipPath>
-<linearGradient id="p" x1="30.322" x2="30.322" y1="2.5151" y2="62.292" gradientTransform="matrix(1.1841 0 0 1.1786 1016.1 839.74)" gradientUnits="userSpaceOnUse">
-<stop stop-color="#f0f5f9" offset="0"/>
-<stop stop-color="#eff4f9" offset=".0039062"/>
-<stop stop-color="#eef3f8" offset=".0078125"/>
-<stop stop-color="#edf3f8" offset=".011719"/>
-<stop stop-color="#ecf2f8" offset=".015625"/>
-<stop stop-color="#ebf2f7" offset=".019531"/>
-<stop stop-color="#eaf1f7" offset=".023438"/>
-<stop stop-color="#e9f0f6" offset=".027344"/>
-<stop stop-color="#e8f0f6" offset=".03125"/>
-<stop stop-color="#e7eff6" offset=".035156"/>
-<stop stop-color="#e6eef5" offset=".039062"/>
-<stop stop-color="#e5eef5" offset=".042969"/>
-<stop stop-color="#e4edf5" offset=".046875"/>
-<stop stop-color="#e3ecf4" offset=".050781"/>
-<stop stop-color="#e2ecf4" offset=".054688"/>
-<stop stop-color="#e2ebf3" offset=".058594"/>
-<stop stop-color="#e1eaf3" offset=".0625"/>
-<stop stop-color="#e0eaf3" offset=".066406"/>
-<stop stop-color="#dfe9f2" offset=".070312"/>
-<stop stop-color="#dee8f2" offset=".074219"/>
-<stop stop-color="#dde8f2" offset=".078125"/>
-<stop stop-color="#dce7f1" offset=".082031"/>
-<stop stop-color="#dbe7f1" offset=".085938"/>
-<stop stop-color="#dae6f1" offset=".089844"/>
-<stop stop-color="#d9e5f0" offset=".09375"/>
-<stop stop-color="#d8e5f0" offset=".097656"/>
-<stop stop-color="#d7e4ef" offset=".10156"/>
-<stop stop-color="#d6e3ef" offset=".10547"/>
-<stop stop-color="#d5e3ef" offset=".10938"/>
-<stop stop-color="#d4e2ee" offset=".11328"/>
-<stop stop-color="#d3e1ee" offset=".11719"/>
-<stop stop-color="#d2e1ee" offset=".12109"/>
-<stop stop-color="#d1e0ed" offset=".125"/>
-<stop stop-color="#d0dfed" offset=".12891"/>
-<stop stop-color="#cfdfec" offset=".13281"/>
-<stop stop-color="#cedeec" offset=".13672"/>
-<stop stop-color="#cdddec" offset=".14062"/>
-<stop stop-color="#ccddeb" offset=".14453"/>
-<stop stop-color="#cbdceb" offset=".14844"/>
-<stop stop-color="#cadbeb" offset=".15234"/>
-<stop stop-color="#c9dbea" offset=".15625"/>
-<stop stop-color="#c8daea" offset=".16016"/>
-<stop stop-color="#c7daea" offset=".16406"/>
-<stop stop-color="#c6d9e9" offset=".16797"/>
-<stop stop-color="#c5d8e9" offset=".17188"/>
-<stop stop-color="#c4d8e8" offset=".17578"/>
-<stop stop-color="#c4d7e8" offset=".17969"/>
-<stop stop-color="#c3d6e8" offset=".18359"/>
-<stop stop-color="#c2d6e7" offset=".1875"/>
-<stop stop-color="#c1d5e7" offset=".19141"/>
-<stop stop-color="#c0d4e7" offset=".19531"/>
-<stop stop-color="#bfd4e6" offset=".19922"/>
-<stop stop-color="#bed3e6" offset=".20312"/>
-<stop stop-color="#bdd2e6" offset=".20703"/>
-<stop stop-color="#bcd2e5" offset=".21094"/>
-<stop stop-color="#bbd1e5" offset=".21484"/>
-<stop stop-color="#bad0e4" offset=".21875"/>
-<stop stop-color="#b9d0e4" offset=".22266"/>
-<stop stop-color="#b8cfe4" offset=".22656"/>
-<stop stop-color="#b7cee3" offset=".23047"/>
-<stop stop-color="#b6cee3" offset=".23438"/>
-<stop stop-color="#b5cde3" offset=".23828"/>
-<stop stop-color="#b4cde2" offset=".24219"/>
-<stop stop-color="#b3cce2" offset=".24609"/>
-<stop stop-color="#b2cbe1" offset=".25"/>
-<stop stop-color="#b1cbe1" offset=".25391"/>
-<stop stop-color="#b0cae1" offset=".25781"/>
-<stop stop-color="#afc9e0" offset=".26172"/>
-<stop stop-color="#aec9e0" offset=".26562"/>
-<stop stop-color="#adc8e0" offset=".26953"/>
-<stop stop-color="#acc7df" offset=".27344"/>
-<stop stop-color="#abc7df" offset=".27734"/>
-<stop stop-color="#aac6df" offset=".28125"/>
-<stop stop-color="#a9c5de" offset=".28516"/>
-<stop stop-color="#a8c5de" offset=".28906"/>
-<stop stop-color="#a7c4dd" offset=".29297"/>
-<stop stop-color="#a6c3dd" offset=".29688"/>
-<stop stop-color="#a6c3dd" offset=".30078"/>
-<stop stop-color="#a5c2dc" offset=".30469"/>
-<stop stop-color="#a4c1dc" offset=".30859"/>
-<stop stop-color="#a3c1dc" offset=".3125"/>
-<stop stop-color="#a2c0db" offset=".31641"/>
-<stop stop-color="#a1c0db" offset=".32031"/>
-<stop stop-color="#a0bfda" offset=".32422"/>
-<stop stop-color="#9fbeda" offset=".32812"/>
-<stop stop-color="#9ebeda" offset=".33203"/>
-<stop stop-color="#9dbdd9" offset=".33594"/>
-<stop stop-color="#9cbcd9" offset=".33984"/>
-<stop stop-color="#9bbcd9" offset=".34375"/>
-<stop stop-color="#9abbd8" offset=".34766"/>
-<stop stop-color="#99bad8" offset=".35156"/>
-<stop stop-color="#98bad8" offset=".35547"/>
-<stop stop-color="#97b9d7" offset=".35938"/>
-<stop stop-color="#96b8d7" offset=".36328"/>
-<stop stop-color="#95b8d6" offset=".36719"/>
-<stop stop-color="#94b7d6" offset=".37109"/>
-<stop stop-color="#93b6d6" offset=".375"/>
-<stop stop-color="#92b6d5" offset=".37891"/>
-<stop stop-color="#91b5d5" offset=".38281"/>
-<stop stop-color="#90b4d5" offset=".38672"/>
-<stop stop-color="#8fb4d4" offset=".39062"/>
-<stop stop-color="#8eb3d4" offset=".39453"/>
-<stop stop-color="#8db3d3" offset=".39844"/>
-<stop stop-color="#8cb2d3" offset=".40234"/>
-<stop stop-color="#8bb1d3" offset=".40625"/>
-<stop stop-color="#8ab1d2" offset=".41016"/>
-<stop stop-color="#89b0d2" offset=".41406"/>
-<stop stop-color="#88afd2" offset=".41797"/>
-<stop stop-color="#87afd1" offset=".42188"/>
-<stop stop-color="#87aed1" offset=".42578"/>
-<stop stop-color="#86add1" offset=".42969"/>
-<stop stop-color="#85add0" offset=".43359"/>
-<stop stop-color="#84acd0" offset=".4375"/>
-<stop stop-color="#83abcf" offset=".44141"/>
-<stop stop-color="#82abcf" offset=".44531"/>
-<stop stop-color="#81aacf" offset=".44922"/>
-<stop stop-color="#80a9ce" offset=".45312"/>
-<stop stop-color="#7fa9ce" offset=".45703"/>
-<stop stop-color="#7ea8ce" offset=".46094"/>
-<stop stop-color="#7da8cd" offset=".46484"/>
-<stop stop-color="#7ca7cd" offset=".46875"/>
-<stop stop-color="#7ba6cc" offset=".47266"/>
-<stop stop-color="#7aa6cc" offset=".47656"/>
-<stop stop-color="#79a5cc" offset=".48047"/>
-<stop stop-color="#78a4cb" offset=".48438"/>
-<stop stop-color="#77a4cb" offset=".48828"/>
-<stop stop-color="#76a3cb" offset=".49219"/>
-<stop stop-color="#75a2ca" offset=".49609"/>
-<stop stop-color="#74a2ca" offset=".5"/>
-<stop stop-color="#73a1ca" offset=".50391"/>
-<stop stop-color="#72a0c9" offset=".50781"/>
-<stop stop-color="#71a0c9" offset=".51172"/>
-<stop stop-color="#709fc8" offset=".51562"/>
-<stop stop-color="#6f9ec8" offset=".51953"/>
-<stop stop-color="#6e9ec8" offset=".52344"/>
-<stop stop-color="#6d9dc7" offset=".52734"/>
-<stop stop-color="#6c9cc7" offset=".53125"/>
-<stop stop-color="#6b9cc7" offset=".53516"/>
-<stop stop-color="#6a9bc6" offset=".53906"/>
-<stop stop-color="#699bc6" offset=".54297"/>
-<stop stop-color="#699ac6" offset=".54688"/>
-<stop stop-color="#6899c5" offset=".55078"/>
-<stop stop-color="#6799c5" offset=".55469"/>
-<stop stop-color="#6698c4" offset=".55859"/>
-<stop stop-color="#6597c4" offset=".5625"/>
-<stop stop-color="#6497c4" offset=".56641"/>
-<stop stop-color="#6396c3" offset=".57031"/>
-<stop stop-color="#6295c3" offset=".57422"/>
-<stop stop-color="#6195c3" offset=".57812"/>
-<stop stop-color="#6094c2" offset=".58203"/>
-<stop stop-color="#5f93c2" offset=".58594"/>
-<stop stop-color="#5e93c1" offset=".58984"/>
-<stop stop-color="#5d92c1" offset=".59375"/>
-<stop stop-color="#5c91c1" offset=".59766"/>
-<stop stop-color="#5b91c0" offset=".60156"/>
-<stop stop-color="#5a90c0" offset=".60547"/>
-<stop stop-color="#598fc0" offset=".60938"/>
-<stop stop-color="#588fbf" offset=".61328"/>
-<stop stop-color="#578ebf" offset=".61719"/>
-<stop stop-color="#568ebf" offset=".62109"/>
-<stop stop-color="#558dbe" offset=".625"/>
-<stop stop-color="#548cbe" offset=".62891"/>
-<stop stop-color="#538cbd" offset=".63281"/>
-<stop stop-color="#528bbd" offset=".63672"/>
-<stop stop-color="#518abd" offset=".64062"/>
-<stop stop-color="#508abc" offset=".64453"/>
-<stop stop-color="#4f89bc" offset=".64844"/>
-<stop stop-color="#4e88bc" offset=".65234"/>
-<stop stop-color="#4d88bb" offset=".65625"/>
-<stop stop-color="#4c87bb" offset=".66016"/>
-<stop stop-color="#4b86ba" offset=".66406"/>
-<stop stop-color="#4b86ba" offset=".66797"/>
-<stop stop-color="#4a85ba" offset=".67188"/>
-<stop stop-color="#4984b9" offset=".67578"/>
-<stop stop-color="#4884b9" offset=".67969"/>
-<stop stop-color="#4783b9" offset=".68359"/>
-<stop stop-color="#4682b8" offset=".6875"/>
-<stop stop-color="#4582b8" offset=".69141"/>
-<stop stop-color="#4481b8" offset=".69531"/>
-<stop stop-color="#4381b7" offset=".69922"/>
-<stop stop-color="#4280b7" offset=".70312"/>
-<stop stop-color="#417fb6" offset=".70703"/>
-<stop stop-color="#407fb6" offset=".71094"/>
-<stop stop-color="#3f7eb6" offset=".71484"/>
-<stop stop-color="#3e7db5" offset=".71875"/>
-<stop stop-color="#3d7db5" offset=".72266"/>
-<stop stop-color="#3c7cb5" offset=".72656"/>
-<stop stop-color="#3b7bb4" offset=".73047"/>
-<stop stop-color="#3a7bb4" offset=".73438"/>
-<stop stop-color="#397ab3" offset=".73828"/>
-<stop stop-color="#3879b3" offset=".74219"/>
-<stop stop-color="#3779b3" offset=".74609"/>
-<stop stop-color="#3678b2" offset=".75"/>
-<stop stop-color="#3577b2" offset=".75391"/>
-<stop stop-color="#3477b2" offset=".75781"/>
-<stop stop-color="#3376b1" offset=".76172"/>
-<stop stop-color="#3275b1" offset=".76562"/>
-<stop stop-color="#3175b1" offset=".76953"/>
-<stop stop-color="#3074b0" offset=".77344"/>
-<stop stop-color="#2f74b0" offset=".77734"/>
-<stop stop-color="#2e73af" offset=".78125"/>
-<stop stop-color="#2d72af" offset=".78516"/>
-<stop stop-color="#2d72af" offset=".78906"/>
-<stop stop-color="#2c71ae" offset=".79297"/>
-<stop stop-color="#2b70ae" offset=".79688"/>
-<stop stop-color="#2a70ae" offset=".80078"/>
-<stop stop-color="#296fad" offset=".80469"/>
-<stop stop-color="#286ead" offset=".80859"/>
-<stop stop-color="#276eac" offset=".8125"/>
-<stop stop-color="#266dac" offset=".81641"/>
-<stop stop-color="#256cac" offset=".82031"/>
-<stop stop-color="#246cab" offset=".82422"/>
-<stop stop-color="#236bab" offset=".82812"/>
-<stop stop-color="#226aab" offset=".83203"/>
-<stop stop-color="#216aaa" offset=".83594"/>
-<stop stop-color="#2069aa" offset=".83984"/>
-<stop stop-color="#1f69aa" offset=".84375"/>
-<stop stop-color="#1e68a9" offset=".84766"/>
-<stop stop-color="#1d67a9" offset=".85156"/>
-<stop stop-color="#1c67a8" offset=".85547"/>
-<stop stop-color="#1b66a8" offset=".85938"/>
-<stop stop-color="#1a65a8" offset=".86328"/>
-<stop stop-color="#1965a7" offset=".86719"/>
-<stop stop-color="#1864a7" offset=".87109"/>
-<stop stop-color="#1763a7" offset=".875"/>
-<stop stop-color="#1663a6" offset=".87891"/>
-<stop stop-color="#1562a6" offset=".88281"/>
-<stop stop-color="#1461a6" offset=".88672"/>
-<stop stop-color="#1361a5" offset=".89062"/>
-<stop stop-color="#1260a5" offset=".89453"/>
-<stop stop-color="#115fa4" offset=".89844"/>
-<stop stop-color="#105fa4" offset=".90234"/>
-<stop stop-color="#0f5ea4" offset=".90625"/>
-<stop stop-color="#0f5da3" offset=".91016"/>
-<stop stop-color="#0e5da3" offset=".91406"/>
-<stop stop-color="#0d5ca3" offset=".91797"/>
-<stop stop-color="#0c5ca2" offset=".92188"/>
-<stop stop-color="#0b5ba2" offset=".92578"/>
-<stop stop-color="#0a5aa1" offset=".92969"/>
-<stop stop-color="#095aa1" offset=".93359"/>
-<stop stop-color="#0859a1" offset=".9375"/>
-<stop stop-color="#0758a0" offset=".94141"/>
-<stop stop-color="#0658a0" offset=".94531"/>
-<stop stop-color="#0557a0" offset=".94922"/>
-<stop stop-color="#04569f" offset=".95312"/>
-<stop stop-color="#03569f" offset=".95703"/>
-<stop stop-color="#02559f" offset=".96094"/>
-<stop stop-color="#01549e" offset=".96484"/>
-<stop stop-color="#00549e" offset=".96875"/>
-<stop stop-color="#00549e" offset="1"/>
-</linearGradient>
-<clipPath id="bo">
-<path d="m1016.1 841h71.926v72.988h-71.926z"/>
-</clipPath>
-<clipPath id="an">
-<path d="m1052 839.74h16v17.262h-16z"/>
-</clipPath>
-<clipPath id="b">
-<path d="m1069 889h24v24.988h-24z"/>
-</clipPath>
-<clipPath id="a">
-<path d="m1172 860h65.777v53.988h-65.777z"/>
-</clipPath>
-<clipPath id="ag">
-<path d="m0.39844 0.16016h65.379v53.828h-65.379z"/>
-</clipPath>
-<clipPath id="by">
-<path d="m0.43359 12h57.566v4h-57.566z"/>
-</clipPath>
-<clipPath id="q">
-<path d="m0.43359 16h57.566v4h-57.566z"/>
-</clipPath>
-<clipPath id="be">
-<path d="m0.43359 21h57.566v3h-57.566z"/>
-</clipPath>
-<clipPath id="bs">
-<rect width="66" height="54"/>
-</clipPath>
-<clipPath id="d">
-<path d="m0.43359 12h57.566v4h-57.566z"/>
-</clipPath>
-<clipPath id="bl">
-<path d="m0.43359 16h57.566v4h-57.566z"/>
-</clipPath>
-<clipPath id="k">
-<path d="m0.43359 21h57.566v3h-57.566z"/>
-</clipPath>
-<clipPath id="ba">
-<rect width="66" height="54"/>
-</clipPath>
-<clipPath id="ca">
-<rect width="66" height="54"/>
-</clipPath>
-<clipPath id="w">
-<path d="m240 1057h74v79.395h-74z"/>
-</clipPath>
-<clipPath id="t">
-<path d="m313.04 1092c-0.12891-1.3281-0.34766-2.8516-0.78516-4.5508-0.43359-1.6797-1.0898-3.5312-2.0469-5.4453-0.96094-1.918-2.2031-3.8984-3.8164-5.8398-0.62891-0.76172-1.3281-1.5-2.0703-2.2188 1.1133-4.4219-1.3516-8.2539-1.3516-8.2539-4.25-0.26172-6.9492 1.3281-7.9531 2.0469-0.17578-0.066407-0.32812-0.15234-0.5-0.21875-0.71875-0.28516-1.4609-0.56641-2.2461-0.80469-0.76172-0.24219-1.5469-0.45703-2.3555-0.65625-0.80469-0.19531-1.6133-0.34766-2.4414-0.47656-0.15234-0.023438-0.28125-0.042969-0.43359-0.066407-1.8516-5.9258-7.1719-8.4062-7.1719-8.4062-5.9492 3.7656-7.0625 9.0391-7.0625 9.0391s-0.019531 0.10938-0.0625 0.30469c-0.32812 0.085938-0.65625 0.19531-0.98047 0.28125-0.46094 0.13281-0.91797 0.30469-1.3516 0.48047-0.45703 0.17188-0.89453 0.34766-1.3516 0.54297-0.89453 0.39453-1.7891 0.82812-2.6602 1.3086-0.84766 0.47656-1.6797 1-2.4844 1.5469-0.10938-0.042969-0.21875-0.089844-0.21875-0.089844-8.2383-3.1367-15.539 0.63281-15.539 0.63281-0.67578 8.7539 3.293 14.266 4.0742 15.27-0.19531 0.54297-0.36719 1.0859-0.54297 1.6328-0.60938 1.9805-1.0664 4.0078-1.3516 6.1172-0.042969 0.30859-0.085937 0.61328-0.10938 0.91797-7.6289 3.7656-9.8711 11.453-9.8711 11.453 6.3398 7.2969 13.75 7.7539 13.75 7.7539l0.023438-0.019532c0.9375 1.6758 2.0273 3.2656 3.2461 4.7695 0.52344 0.63281 1.0469 1.2188 1.6133 1.8086-2.3086 6.6211 0.32812 12.109 0.32812 12.109 7.0625 0.26172 11.703-3.0938 12.684-3.8555 0.69922 0.23828 1.418 0.45703 2.1367 0.62891 2.1797 0.56641 4.4023 0.89453 6.625 0.98047 0.54297 0.023438 1.1133 0.046876 1.6562 0.023438h0.78516l0.34766-0.023438v0.023438c3.3359 4.7461 9.1758 5.4219 9.1758 5.4219 4.1641-4.375 4.4023-8.7344 4.4023-9.668v-0.066406-0.12891-0.19922c0.87109-0.60938 1.6992-1.2617 2.4844-1.9805 1.6562-1.5039 3.1172-3.2227 4.3398-5.0742 0.10547-0.17578 0.21484-0.34766 0.32422-0.52344 4.707 0.26172 8.043-2.918 8.043-2.918-0.78516-4.9023-3.5742-7.2969-4.1641-7.7539 0 0-0.019532-0.023437-0.0625-0.042969-0.042969-0.023437-0.042969-0.042968-0.042969-0.042968-0.023437-0.023438-0.066406-0.042969-0.10938-0.066407 0.019531-0.30469 0.042969-0.58984 0.0625-0.89453 0.046875-0.51953 0.046875-1.0664 0.046875-1.5898v-0.69531-0.13281l-0.023437-0.32422-0.023438-0.4375c0-0.15234-0.019531-0.28125-0.042969-0.41406-0.019531-0.12891-0.019531-0.28125-0.042969-0.41406l-0.042968-0.41406-0.066406-0.41016c-0.085938-0.54688-0.17578-1.0703-0.30469-1.6133-0.5-2.1133-1.3281-4.1172-2.3984-5.9258-1.0898-1.8047-2.4414-3.3945-3.9883-4.7461-1.5234-1.3516-3.2461-2.4414-5.0352-3.2461-1.8086-0.80469-3.6836-1.3281-5.5547-1.5664-0.9375-0.13281-1.875-0.17578-2.8125-0.15234h-0.4375-0.10938-0.15234l-0.34766 0.019531c-0.12891 0-0.26172 0.023438-0.37109 0.023438-0.48047 0.042968-0.95703 0.10937-1.4141 0.19531-1.875 0.34766-3.6406 1.0234-5.1875 1.9609-1.5508 0.9375-2.8984 2.0898-3.9883 3.3984-1.0898 1.3047-1.9414 2.7656-2.5312 4.2656-0.58594 1.5039-0.91406 3.0742-1 4.5742-0.023437 0.37109-0.023437 0.76172-0.023437 1.1328v0.28516l0.023437 0.30469c0.019531 0.17188 0.019531 0.37109 0.042969 0.54297 0.066406 0.76172 0.21875 1.5039 0.41406 2.1992 0.41406 1.418 1.0664 2.7031 1.875 3.7891 0.80469 1.0898 1.7852 1.9844 2.8086 2.7031 1.0273 0.69531 2.1367 1.1953 3.2266 1.5234 1.0898 0.32812 2.1797 0.45703 3.2031 0.45703h0.37109 0.19531c0.066406 0 0.13281 0 0.19922-0.019531 0.10938 0 0.21484-0.023438 0.32422-0.023438 0.023438 0 0.066407 0 0.089844-0.023438l0.10938-0.019531c0.0625 0 0.12891-0.023437 0.19531-0.023437 0.12891-0.019532 0.23828-0.042969 0.37109-0.0625 0.12891-0.023438 0.23828-0.046875 0.34766-0.089844 0.23828-0.042969 0.45703-0.12891 0.67578-0.19531 0.43359-0.15234 0.87109-0.32813 1.2422-0.52344 0.39062-0.19531 0.74219-0.43359 1.0898-0.65234 0.085937-0.066406 0.19531-0.12891 0.28125-0.21875 0.35156-0.28125 0.41406-0.80469 0.13281-1.1523-0.23828-0.30469-0.67578-0.39453-1.0234-0.19531-0.089844 0.042969-0.17578 0.085938-0.26172 0.12891-0.30469 0.15234-0.61328 0.28516-0.9375 0.39062-0.32812 0.10938-0.67578 0.19922-1.0234 0.26172-0.17578 0.023438-0.35156 0.042969-0.54688 0.066406-0.085938 0-0.17578 0.023438-0.28125 0.023438h-0.26172-0.26172c-0.10938 0-0.21875 0-0.32812-0.023438h-0.023437-0.10938c-0.042969 0-0.10547 0-0.15234-0.023437-0.10938-0.019531-0.19531-0.019531-0.30469-0.042969-0.80469-0.10938-1.6133-0.34766-2.375-0.69531-0.78516-0.34766-1.5234-0.82813-2.1992-1.4375-0.67578-0.60938-1.2656-1.3281-1.7227-2.1562-0.45703-0.82813-0.78516-1.7422-0.9375-2.6992-0.066407-0.48047-0.10938-0.98047-0.085938-1.4609 0-0.12891 0.019531-0.26172 0.019531-0.39062v-0.023437-0.15234c0-0.066406 0.023438-0.12891 0.023438-0.19531 0.019531-0.26172 0.0625-0.52344 0.10938-0.78516 0.36719-2.0898 1.4141-4.1367 3.0273-5.6836 0.41406-0.39062 0.85156-0.74219 1.3086-1.0664 0.45703-0.32812 0.95703-0.60938 1.4805-0.85156 0.52344-0.23828 1.0469-0.43359 1.6133-0.58594 0.54688-0.15234 1.1133-0.24219 1.6992-0.30469 0.28516-0.023438 0.56641-0.046875 0.875-0.046875h0.19531 0.39063 0.023437 0.066406l0.23828 0.023437c0.63281 0.042969 1.2422 0.13281 1.8516 0.28516 1.2227 0.25781 2.4219 0.71875 3.5312 1.3281 2.2227 1.2383 4.1211 3.1562 5.2734 5.4648 0.58984 1.1562 1.0039 2.3945 1.1992 3.6797 0.042969 0.32812 0.085938 0.65625 0.10938 0.98047l0.023438 0.24219 0.019531 0.23828v0.23828 0.24219 0.45703c0 0.15234-0.019531 0.41406-0.019531 0.56641-0.023438 0.34766-0.066406 0.71875-0.10938 1.0664s-0.10938 0.69531-0.17578 1.0469c-0.066407 0.34766-0.15234 0.69531-0.23828 1.0234-0.17578 0.67188-0.39453 1.3477-0.65625 2.0234-0.52344 1.3086-1.2188 2.5703-2.0469 3.7266-1.6797 2.3086-3.9688 4.1797-6.582 5.3789-1.3086 0.58594-2.6797 1.0234-4.0977 1.2422-0.69922 0.12891-1.418 0.19531-2.1367 0.21484h-1.0039-0.019531-0.066407c-0.39062 0-0.76172-0.019532-1.1562-0.0625-1.5234-0.10938-3.0273-0.39453-4.5078-0.80859-1.4609-0.41406-2.8789-1-4.2305-1.6992-2.6797-1.4375-5.1016-3.3945-6.9727-5.7695-0.9375-1.1758-1.7656-2.4609-2.4414-3.7891-0.67578-1.3281-1.2227-2.7461-1.6133-4.1602-0.39453-1.4375-0.63281-2.8984-0.74219-4.3789l-0.019531-0.28125v-1.2422-0.023438-0.12891-0.54688c0.019531-0.71875 0.085937-1.4805 0.17187-2.2188 0.089844-0.74219 0.21875-1.5039 0.37109-2.2461 0.15234-0.73828 0.32812-1.4805 0.54688-2.2188 0.41406-1.4609 0.93359-2.875 1.5469-4.2031 1.2422-2.6602 2.8555-5.0312 4.793-6.9297 0.48047-0.47656 0.98047-0.91406 1.5039-1.3477 0.52344-0.41406 1.0703-0.80859 1.6367-1.1758 0.54297-0.37109 1.1328-0.69922 1.7188-1.0039 0.28516-0.15234 0.58984-0.30469 0.89453-0.43359 0.15234-0.066406 0.30469-0.13281 0.45703-0.19531 0.15234-0.066406 0.30469-0.13281 0.46094-0.19922 0.60938-0.26172 1.2422-0.47656 1.8945-0.67188 0.15234-0.046875 0.32812-0.089844 0.48047-0.15625 0.15234-0.042969 0.32422-0.085938 0.47656-0.12891 0.32813-0.085937 0.65625-0.17578 0.98438-0.23828 0.15234-0.042969 0.32422-0.066406 0.5-0.10938 0.17187-0.042968 0.32812-0.066406 0.5-0.10938 0.17578-0.023437 0.32812-0.066406 0.5-0.085937l0.24219-0.046875 0.26172-0.042969c0.17188-0.019531 0.32812-0.042969 0.5-0.0625 0.19531-0.023438 0.37109-0.046875 0.56641-0.066406 0.15234-0.023438 0.41406-0.042969 0.56641-0.066406 0.10938-0.019532 0.24219-0.019532 0.35156-0.042969l0.23828-0.023438 0.10938-0.019531h0.12891c0.19922-0.023438 0.37109-0.023438 0.56641-0.042969l0.28516-0.023437h0.019531 0.19922c0.15234 0 0.32422-0.019532 0.47656-0.019532 0.63281-0.023437 1.2891-0.023437 1.918 0 1.2656 0.042969 2.5078 0.19531 3.707 0.41016 2.418 0.46094 4.6875 1.2227 6.7578 2.2461 2.0703 1 3.8984 2.2422 5.5117 3.5938 0.10937 0.085938 0.19531 0.17188 0.30469 0.26172 0.089844 0.085938 0.19922 0.17188 0.28516 0.26172 0.19531 0.17188 0.37109 0.34766 0.56641 0.51953 0.19531 0.17578 0.37109 0.35156 0.54297 0.52344 0.17578 0.17578 0.35156 0.34766 0.52344 0.54688 0.67578 0.71875 1.3086 1.4375 1.875 2.1758 1.1328 1.4609 2.0508 2.9414 2.7695 4.3359 0.042969 0.085938 0.085937 0.17188 0.12891 0.26172 0.042969 0.085938 0.089844 0.17188 0.13281 0.26172 0.085937 0.17188 0.17188 0.34766 0.23828 0.51953 0.085937 0.17578 0.15234 0.32812 0.23828 0.50391 0.066406 0.17187 0.15625 0.32422 0.21875 0.5 0.26172 0.65234 0.52344 1.2852 0.71875 1.8711 0.32812 0.96094 0.56641 1.8086 0.76562 2.5508 0.0625 0.30469 0.34766 0.5 0.65234 0.45703 0.32812-0.023438 0.56641-0.28516 0.56641-0.60938 0.023438-0.78516 0-1.7227-0.10938-2.7891z"/>
-</clipPath>
-<linearGradient id="ay" x1="175.5" x2="175.5" y1="1.0001" y2="364" gradientTransform="matrix(.21795 0 0 .2178 238.5 1056.9)" gradientUnits="userSpaceOnUse">
-<stop stop-color="#ef5a28" offset="0"/>
-<stop stop-color="#ef5a28" offset=".25"/>
-<stop stop-color="#ef5a28" offset=".28125"/>
-<stop stop-color="#ef5a28" offset=".29688"/>
-<stop stop-color="#ef5a27" offset=".30469"/>
-<stop stop-color="#f05b27" offset=".30859"/>
-<stop stop-color="#f05c27" offset=".3125"/>
-<stop stop-color="#f05c27" offset=".31641"/>
-<stop stop-color="#f05d27" offset=".32031"/>
-<stop stop-color="#f05e26" offset=".32422"/>
-<stop stop-color="#f05e26" offset=".32812"/>
-<stop stop-color="#f05f26" offset=".33203"/>
-<stop stop-color="#f05f26" offset=".33594"/>
-<stop stop-color="#f06026" offset=".33984"/>
-<stop stop-color="#f06126" offset=".34375"/>
-<stop stop-color="#f06125" offset=".34766"/>
-<stop stop-color="#f06225" offset=".35156"/>
-<stop stop-color="#f06325" offset=".35547"/>
-<stop stop-color="#f06325" offset=".35938"/>
-<stop stop-color="#f06425" offset=".36328"/>
-<stop stop-color="#f16525" offset=".36719"/>
-<stop stop-color="#f16524" offset=".37109"/>
-<stop stop-color="#f16624" offset=".375"/>
-<stop stop-color="#f16624" offset=".37891"/>
-<stop stop-color="#f16724" offset=".38281"/>
-<stop stop-color="#f16824" offset=".38672"/>
-<stop stop-color="#f16824" offset=".39062"/>
-<stop stop-color="#f16923" offset=".39453"/>
-<stop stop-color="#f16a23" offset=".39844"/>
-<stop stop-color="#f16a23" offset=".40234"/>
-<stop stop-color="#f16b23" offset=".40625"/>
-<stop stop-color="#f16b23" offset=".41016"/>
-<stop stop-color="#f16c23" offset=".41406"/>
-<stop stop-color="#f16d22" offset=".41797"/>
-<stop stop-color="#f16d22" offset=".42188"/>
-<stop stop-color="#f16e22" offset=".42578"/>
-<stop stop-color="#f26f22" offset=".42969"/>
-<stop stop-color="#f26f22" offset=".43359"/>
-<stop stop-color="#f27022" offset=".4375"/>
-<stop stop-color="#f27121" offset=".44141"/>
-<stop stop-color="#f27121" offset=".44531"/>
-<stop stop-color="#f27221" offset=".44922"/>
-<stop stop-color="#f27221" offset=".45312"/>
-<stop stop-color="#f27321" offset=".45703"/>
-<stop stop-color="#f27421" offset=".46094"/>
-<stop stop-color="#f27420" offset=".46484"/>
-<stop stop-color="#f27520" offset=".46875"/>
-<stop stop-color="#f27620" offset=".47266"/>
-<stop stop-color="#f27620" offset=".47656"/>
-<stop stop-color="#f27720" offset=".48047"/>
-<stop stop-color="#f2771f" offset=".48438"/>
-<stop stop-color="#f2781f" offset=".48828"/>
-<stop stop-color="#f3791f" offset=".49219"/>
-<stop stop-color="#f3791f" offset=".49609"/>
-<stop stop-color="#f37a1f" offset=".5"/>
-<stop stop-color="#f37b1f" offset=".50391"/>
-<stop stop-color="#f37b1e" offset=".50781"/>
-<stop stop-color="#f37c1e" offset=".51172"/>
-<stop stop-color="#f37c1e" offset=".51562"/>
-<stop stop-color="#f37d1e" offset=".51953"/>
-<stop stop-color="#f37e1e" offset=".52344"/>
-<stop stop-color="#f37e1e" offset=".52734"/>
-<stop stop-color="#f37f1d" offset=".53125"/>
-<stop stop-color="#f3801d" offset=".53516"/>
-<stop stop-color="#f3801d" offset=".53906"/>
-<stop stop-color="#f3811d" offset=".54297"/>
-<stop stop-color="#f3821d" offset=".54688"/>
-<stop stop-color="#f3821d" offset=".55078"/>
-<stop stop-color="#f3831c" offset=".55469"/>
-<stop stop-color="#f4831c" offset=".55859"/>
-<stop stop-color="#f4841c" offset=".5625"/>
-<stop stop-color="#f4851c" offset=".56641"/>
-<stop stop-color="#f4851c" offset=".57031"/>
-<stop stop-color="#f4861c" offset=".57422"/>
-<stop stop-color="#f4871b" offset=".57812"/>
-<stop stop-color="#f4871b" offset=".58203"/>
-<stop stop-color="#f4881b" offset=".58594"/>
-<stop stop-color="#f4881b" offset=".58984"/>
-<stop stop-color="#f4891b" offset=".59375"/>
-<stop stop-color="#f48a1b" offset=".59766"/>
-<stop stop-color="#f48a1a" offset=".60156"/>
-<stop stop-color="#f48b1a" offset=".60547"/>
-<stop stop-color="#f48c1a" offset=".60938"/>
-<stop stop-color="#f48c1a" offset=".61328"/>
-<stop stop-color="#f48d1a" offset=".61719"/>
-<stop stop-color="#f58d1a" offset=".62109"/>
-<stop stop-color="#f58e19" offset=".625"/>
-<stop stop-color="#f58f19" offset=".62891"/>
-<stop stop-color="#f58f19" offset=".63281"/>
-<stop stop-color="#f59019" offset=".63672"/>
-<stop stop-color="#f59119" offset=".64062"/>
-<stop stop-color="#f59119" offset=".64453"/>
-<stop stop-color="#f59218" offset=".64844"/>
-<stop stop-color="#f59318" offset=".65234"/>
-<stop stop-color="#f59318" offset=".65625"/>
-<stop stop-color="#f59418" offset=".66016"/>
-<stop stop-color="#f59418" offset=".66406"/>
-<stop stop-color="#f59518" offset=".66797"/>
-<stop stop-color="#f59617" offset=".67188"/>
-<stop stop-color="#f59617" offset=".67578"/>
-<stop stop-color="#f59717" offset=".67969"/>
-<stop stop-color="#f69817" offset=".68359"/>
-<stop stop-color="#f69817" offset=".6875"/>
-<stop stop-color="#f69917" offset=".69141"/>
-<stop stop-color="#f69916" offset=".69531"/>
-<stop stop-color="#f69a16" offset=".69922"/>
-<stop stop-color="#f69b16" offset=".70312"/>
-<stop stop-color="#f69b16" offset=".70703"/>
-<stop stop-color="#f69c16" offset=".71094"/>
-<stop stop-color="#f69d15" offset=".71484"/>
-<stop stop-color="#f69d15" offset=".71875"/>
-<stop stop-color="#f69e15" offset=".72266"/>
-<stop stop-color="#f69f15" offset=".72656"/>
-<stop stop-color="#f69f15" offset=".73047"/>
-<stop stop-color="#f6a015" offset=".73438"/>
-<stop stop-color="#f6a014" offset=".73828"/>
-<stop stop-color="#f6a114" offset=".74219"/>
-<stop stop-color="#f7a214" offset=".74609"/>
-<stop stop-color="#f7a214" offset=".75"/>
-<stop stop-color="#f7a314" offset=".75391"/>
-<stop stop-color="#f7a414" offset=".75781"/>
-<stop stop-color="#f7a413" offset=".76172"/>
-<stop stop-color="#f7a513" offset=".76562"/>
-<stop stop-color="#f7a513" offset=".76953"/>
-<stop stop-color="#f7a613" offset=".77344"/>
-<stop stop-color="#f7a713" offset=".77734"/>
-<stop stop-color="#f7a713" offset=".78125"/>
-<stop stop-color="#f7a812" offset=".78516"/>
-<stop stop-color="#f7a912" offset=".78906"/>
-<stop stop-color="#f7a912" offset=".79297"/>
-<stop stop-color="#f7aa12" offset=".79688"/>
-<stop stop-color="#f7aa12" offset=".80078"/>
-<stop stop-color="#f7ab12" offset=".80469"/>
-<stop stop-color="#f8ac11" offset=".80859"/>
-<stop stop-color="#f8ac11" offset=".8125"/>
-<stop stop-color="#f8ad11" offset=".81641"/>
-<stop stop-color="#f8ae11" offset=".82031"/>
-<stop stop-color="#f8ae11" offset=".82422"/>
-<stop stop-color="#f8af11" offset=".82812"/>
-<stop stop-color="#f8b010" offset=".83203"/>
-<stop stop-color="#f8b010" offset=".83594"/>
-<stop stop-color="#f8b110" offset=".83984"/>
-<stop stop-color="#f8b110" offset=".84375"/>
-<stop stop-color="#f8b210" offset=".84766"/>
-<stop stop-color="#f8b310" offset=".85156"/>
-<stop stop-color="#f8b30f" offset=".85547"/>
-<stop stop-color="#f8b40f" offset=".85938"/>
-<stop stop-color="#f8b50f" offset=".86328"/>
-<stop stop-color="#f8b50f" offset=".86719"/>
-<stop stop-color="#f8b60f" offset=".87109"/>
-<stop stop-color="#f9b60f" offset=".875"/>
-<stop stop-color="#f9b70e" offset=".87891"/>
-<stop stop-color="#f9b80e" offset=".88281"/>
-<stop stop-color="#f9b80e" offset=".88672"/>
-<stop stop-color="#f9b90e" offset=".89062"/>
-<stop stop-color="#f9ba0e" offset=".89453"/>
-<stop stop-color="#f9ba0e" offset=".89844"/>
-<stop stop-color="#f9bb0d" offset=".90234"/>
-<stop stop-color="#f9bc0d" offset=".90625"/>
-<stop stop-color="#f9bc0d" offset=".91016"/>
-<stop stop-color="#f9bd0d" offset=".91406"/>
-<stop stop-color="#f9bd0d" offset=".91797"/>
-<stop stop-color="#f9be0d" offset=".92188"/>
-<stop stop-color="#f9bf0c" offset=".92578"/>
-<stop stop-color="#f9bf0c" offset=".92969"/>
-<stop stop-color="#f9c00c" offset=".93359"/>
-<stop stop-color="#fac10c" offset=".9375"/>
-<stop stop-color="#fac10c" offset=".94141"/>
-<stop stop-color="#fac20b" offset=".94531"/>
-<stop stop-color="#fac20b" offset=".94922"/>
-<stop stop-color="#fac30b" offset=".95312"/>
-<stop stop-color="#fac40b" offset=".95703"/>
-<stop stop-color="#fac40b" offset=".96094"/>
-<stop stop-color="#fac50b" offset=".96484"/>
-<stop stop-color="#fac60a" offset=".96875"/>
-<stop stop-color="#fac60a" offset=".97266"/>
-<stop stop-color="#fac70a" offset=".97656"/>
-<stop stop-color="#fac70a" offset=".98047"/>
-<stop stop-color="#fac80a" offset=".98438"/>
-<stop stop-color="#fac90a" offset=".98828"/>
-<stop stop-color="#fac909" offset=".99219"/>
-<stop stop-color="#fac909" offset="1"/>
-</linearGradient>
-</defs>
-<g clip-path="url(#ac)">
-<g clip-path="url(#bg)">
-<path d="m47.199 53.27h447.36v182.36h-447.36z" fill="#b8d2ff"/>
-</g>
-</g>
-<g clip-path="url(#r)">
-<g clip-path="url(#ab)">
-<path d="m146.64 142.5h108.12v59.656h-108.12z" fill="#cbff8b"/>
-</g>
-</g>
-<g clip-path="url(#bb)">
-<g clip-path="url(#ad)">
-<path d="m284.8 142.5h112.55v59.656h-112.55z" fill="#cbff8b"/>
-</g>
-</g>
-<g clip-path="url(#am)">
-<g clip-path="url(#az)">
-<path d="m530.3 53.27h439.52v182.36h-439.52z" fill="#b8d2ff"/>
-</g>
-</g>
-<g clip-path="url(#u)">
-<g clip-path="url(#ah)">
-<path d="m567.82 142.5h121.64v59.656h-121.64z" fill="#cbff8b"/>
-</g>
-</g>
-<g clip-path="url(#as)">
-<g clip-path="url(#bh)">
-<path d="m838.38 142.5h96.707v59.656h-96.707z" fill="#cbff8b"/>
-</g>
-</g>
-<g clip-path="url(#bw)">
-<g clip-path="url(#aj)">
-<path d="m1005.7 53.27h447.36v182.36h-447.36z" fill="#b8d2ff"/>
-</g>
-</g>
-<g clip-path="url(#ai)">
-<g clip-path="url(#bp)">
-<path d="m1069.3 176.91h203.71v37.848h-203.71z" fill="#cbff8b"/>
-</g>
-</g>
-<g clip-path="url(#s)">
-<g clip-path="url(#aq)">
-<path d="m47.199 255h1405.8v488.32h-1405.8z" fill="#b8d2ff"/>
-</g>
-</g>
-<path transform="matrix(.62291 .41772 -.41772 .62291 271.47 234.7)" d="m-7.8722e-4 1.502 496.83-0.001124" fill="none" stroke="#3d516e" stroke-width="3"/>
-<path transform="matrix(.62291 .41772 -.41772 .62291 271.47 234.7)" d="m490.82-3.0014 6.0042 4.5022-6 4.5001" fill="none" stroke="#3d516e" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
-<path transform="matrix(0 .75 -.75 0 751.12 235.63)" d="m-0.0021133 1.4993h191.3" fill="none" stroke="#3d516e" stroke-width="3"/>
-<path transform="matrix(0 .75 -.75 0 751.12 235.63)" d="m185.3-3.0007 6 4.5-6 4.5" fill="none" stroke="#3d516e" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
-<path transform="matrix(-.62296 .41763 -.41763 -.62296 1229.9 236.56)" d="m-0.0023612 1.5004 496.92 5.24e-4" fill="none" stroke="#3d516e" stroke-width="3"/>
-<path transform="matrix(-.62296 .41763 -.41763 -.62296 1229.9 236.56)" d="m490.92-2.9984 6.0006 4.4993-6.0006 4.4987" fill="none" stroke="#3d516e" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
-<g clip-path="url(#bk)">
-<g clip-path="url(#bj)">
-<path d="m66.363 621.42h138.48v78.957h-138.48z" fill="#22a472"/>
-</g>
-</g>
-<g fill="#fffbf9">
-<g transform="translate(102.55 656.67)">
-<path d="m8.9844-2.2344h-4.7188l-0.75 2.2344h-3.2344l4.5781-12.641h3.5625l4.5781 12.641h-3.2656zm-0.79688-2.375-1.5625-4.625-1.5469 4.625z"/>
-</g>
-<g transform="translate(115.82 656.67)">
-<path d="m0.5-5.0156c0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0195-1.3789 1.7812-1.7969 0.75781-0.42578 1.6328-0.64062 2.625-0.64062 1.2578 0 2.3125 0.33594 3.1562 1 0.84375 0.65625 1.3984 1.5859 1.6719 2.7812h-3.2812c-0.28125-0.76953-0.82031-1.1562-1.6094-1.1562-0.5625 0-1.0117 0.21875-1.3438 0.65625-0.33594 0.4375-0.5 1.0703-0.5 1.8906 0 0.8125 0.16406 1.4375 0.5 1.875 0.33203 0.4375 0.78125 0.65625 1.3438 0.65625 0.78906 0 1.3281-0.38281 1.6094-1.1562h3.2812c-0.27344 1.1797-0.83594 2.1055-1.6875 2.7812-0.84375 0.66797-1.8906 1-3.1406 1-0.99219 0-1.8672-0.20703-2.625-0.625-0.76172-0.41406-1.3555-1.0156-1.7812-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344z"/>
-</g>
-<g transform="translate(126.71 656.67)">
-<path d="m0.5-5.0156c0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0195-1.3789 1.7812-1.7969 0.75781-0.42578 1.6328-0.64062 2.625-0.64062 1.2578 0 2.3125 0.33594 3.1562 1 0.84375 0.65625 1.3984 1.5859 1.6719 2.7812h-3.2812c-0.28125-0.76953-0.82031-1.1562-1.6094-1.1562-0.5625 0-1.0117 0.21875-1.3438 0.65625-0.33594 0.4375-0.5 1.0703-0.5 1.8906 0 0.8125 0.16406 1.4375 0.5 1.875 0.33203 0.4375 0.78125 0.65625 1.3438 0.65625 0.78906 0 1.3281-0.38281 1.6094-1.1562h3.2812c-0.27344 1.1797-0.83594 2.1055-1.6875 2.7812-0.84375 0.66797-1.8906 1-3.1406 1-0.99219 0-1.8672-0.20703-2.625-0.625-0.76172-0.41406-1.3555-1.0156-1.7812-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344z"/>
-</g>
-<g transform="translate(137.6 656.67)">
-<path d="m10.578-5.1875c0 0.29297-0.015625 0.59375-0.046875 0.90625h-6.9688c0.050781 0.625 0.25391 1.1055 0.60938 1.4375 0.35156 0.32422 0.78516 0.48438 1.2969 0.48438 0.76953 0 1.3047-0.32031 1.6094-0.96875h3.2656c-0.16797 0.65625-0.46875 1.25-0.90625 1.7812s-0.99219 0.94922-1.6562 1.25c-0.65625 0.29297-1.3906 0.4375-2.2031 0.4375-0.98047 0-1.8555-0.20703-2.625-0.625-0.77344-0.41406-1.375-1.0156-1.8125-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344 0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0234-1.3789 1.7969-1.7969 0.76953-0.42578 1.6484-0.64062 2.6406-0.64062 0.96875 0 1.832 0.20312 2.5938 0.60938 0.75781 0.40625 1.3477 0.99219 1.7656 1.75 0.42578 0.75 0.64062 1.6328 0.64062 2.6406zm-3.1406-0.8125c0-0.51953-0.18359-0.9375-0.54688-1.25-0.35547-0.3125-0.80469-0.46875-1.3438-0.46875-0.52344 0-0.96094 0.15234-1.3125 0.45312-0.35547 0.29297-0.57422 0.71484-0.65625 1.2656z"/>
-</g>
-<g transform="translate(148.68 656.67)">
-<path d="m5.2031 0.14062c-0.875 0-1.6562-0.14453-2.3438-0.4375-0.67969-0.30078-1.2188-0.71094-1.625-1.2344-0.39844-0.53125-0.61719-1.1172-0.65625-1.7656h3.0469c0.03125 0.35547 0.1875 0.64062 0.46875 0.85938 0.28906 0.21094 0.64844 0.3125 1.0781 0.3125 0.375 0 0.66406-0.070312 0.875-0.21875 0.21875-0.15625 0.32812-0.35156 0.32812-0.59375 0-0.28125-0.15234-0.48828-0.45312-0.625-0.30469-0.14453-0.78906-0.30078-1.4531-0.46875-0.71875-0.16406-1.3242-0.34375-1.8125-0.53125-0.48047-0.1875-0.89062-0.47656-1.2344-0.875-0.34375-0.40625-0.51562-0.95312-0.51562-1.6406 0-0.57031 0.15625-1.0938 0.46875-1.5625 0.32031-0.47656 0.78906-0.85156 1.4062-1.125 0.61328-0.28125 1.3477-0.42188 2.2031-0.42188 1.2578 0 2.25 0.3125 2.9688 0.9375 0.72656 0.625 1.1484 1.4531 1.2656 2.4844h-2.8438c-0.054688-0.35156-0.21094-0.62891-0.46875-0.82812-0.25-0.20703-0.58984-0.3125-1.0156-0.3125-0.35547 0-0.63281 0.074219-0.82812 0.21875-0.1875 0.13672-0.28125 0.32422-0.28125 0.5625 0 0.28125 0.14844 0.49609 0.45312 0.64062 0.3125 0.14844 0.78906 0.29297 1.4375 0.4375 0.73828 0.1875 1.3438 0.375 1.8125 0.5625s0.87891 0.49219 1.2344 0.90625c0.35156 0.41797 0.53516 0.96875 0.54688 1.6562 0 0.59375-0.16797 1.125-0.5 1.5938-0.32422 0.46094-0.79688 0.82031-1.4219 1.0781-0.61719 0.25781-1.3281 0.39062-2.1406 0.39062z"/>
-</g>
-<g transform="translate(158.73 656.67)">
-<path d="m5.2031 0.14062c-0.875 0-1.6562-0.14453-2.3438-0.4375-0.67969-0.30078-1.2188-0.71094-1.625-1.2344-0.39844-0.53125-0.61719-1.1172-0.65625-1.7656h3.0469c0.03125 0.35547 0.1875 0.64062 0.46875 0.85938 0.28906 0.21094 0.64844 0.3125 1.0781 0.3125 0.375 0 0.66406-0.070312 0.875-0.21875 0.21875-0.15625 0.32812-0.35156 0.32812-0.59375 0-0.28125-0.15234-0.48828-0.45312-0.625-0.30469-0.14453-0.78906-0.30078-1.4531-0.46875-0.71875-0.16406-1.3242-0.34375-1.8125-0.53125-0.48047-0.1875-0.89062-0.47656-1.2344-0.875-0.34375-0.40625-0.51562-0.95312-0.51562-1.6406 0-0.57031 0.15625-1.0938 0.46875-1.5625 0.32031-0.47656 0.78906-0.85156 1.4062-1.125 0.61328-0.28125 1.3477-0.42188 2.2031-0.42188 1.2578 0 2.25 0.3125 2.9688 0.9375 0.72656 0.625 1.1484 1.4531 1.2656 2.4844h-2.8438c-0.054688-0.35156-0.21094-0.62891-0.46875-0.82812-0.25-0.20703-0.58984-0.3125-1.0156-0.3125-0.35547 0-0.63281 0.074219-0.82812 0.21875-0.1875 0.13672-0.28125 0.32422-0.28125 0.5625 0 0.28125 0.14844 0.49609 0.45312 0.64062 0.3125 0.14844 0.78906 0.29297 1.4375 0.4375 0.73828 0.1875 1.3438 0.375 1.8125 0.5625s0.87891 0.49219 1.2344 0.90625c0.35156 0.41797 0.53516 0.96875 0.54688 1.6562 0 0.59375-0.16797 1.125-0.5 1.5938-0.32422 0.46094-0.79688 0.82031-1.4219 1.0781-0.61719 0.25781-1.3281 0.39062-2.1406 0.39062z"/>
-</g>
-<g transform="translate(101.11 676.92)">
-<path d="m0.59375-6.3438c0-1.2383 0.26953-2.3477 0.8125-3.3281 0.53906-0.97656 1.2891-1.7383 2.25-2.2812 0.96875-0.55078 2.0664-0.82812 3.2969-0.82812 1.5 0 2.7812 0.39844 3.8438 1.1875 1.0703 0.79297 1.7852 1.8711 2.1406 3.2344h-3.375c-0.25-0.51953-0.60938-0.91406-1.0781-1.1875-0.46094-0.28125-0.98438-0.42188-1.5781-0.42188-0.94922 0-1.7188 0.33594-2.3125 1-0.58594 0.65625-0.875 1.5312-0.875 2.625 0 1.1055 0.28906 1.9922 0.875 2.6562 0.59375 0.65625 1.3633 0.98438 2.3125 0.98438 0.59375 0 1.1172-0.13281 1.5781-0.40625 0.46875-0.28125 0.82812-0.67969 1.0781-1.2031h3.375c-0.35547 1.3672-1.0703 2.4453-2.1406 3.2344-1.0625 0.78125-2.3438 1.1719-3.8438 1.1719-1.2305 0-2.3281-0.26953-3.2969-0.8125-0.96094-0.55078-1.7109-1.3125-2.25-2.2812-0.54297-0.97656-0.8125-2.0938-0.8125-3.3438z"/>
-</g>
-<g transform="translate(114.83 676.92)">
-<path d="m5.6875 0.14062c-0.98047 0-1.8672-0.20703-2.6562-0.625-0.78125-0.41406-1.4023-1.0156-1.8594-1.7969-0.44922-0.78125-0.67188-1.6914-0.67188-2.7344 0-1.0312 0.22656-1.9375 0.6875-2.7188 0.45703-0.78906 1.082-1.3945 1.875-1.8125 0.78906-0.42578 1.6758-0.64062 2.6562-0.64062 0.98828 0 1.8789 0.21484 2.6719 0.64062 0.78906 0.41797 1.4102 1.0234 1.8594 1.8125 0.45703 0.78125 0.6875 1.6875 0.6875 2.7188s-0.23047 1.9453-0.6875 2.7344c-0.46094 0.78125-1.0898 1.3828-1.8906 1.7969-0.80469 0.41797-1.6953 0.625-2.6719 0.625zm0-2.6562c0.58203 0 1.082-0.21094 1.5-0.64062 0.41406-0.4375 0.625-1.0547 0.625-1.8594 0-0.8125-0.20312-1.4297-0.60938-1.8594-0.39844-0.4375-0.89062-0.65625-1.4844-0.65625s-1.0898 0.21484-1.4844 0.64062c-0.39844 0.42969-0.59375 1.0547-0.59375 1.875 0 0.80469 0.19141 1.4219 0.57812 1.8594 0.39453 0.42969 0.88281 0.64062 1.4688 0.64062z"/>
-</g>
-<g transform="translate(126.29 676.92)">
-<path d="m7.2344-10.156c1.1758 0 2.1133 0.38672 2.8125 1.1562 0.70703 0.76172 1.0625 1.8047 1.0625 3.125v5.875h-3.0625v-5.4531c0-0.67578-0.17969-1.1953-0.53125-1.5625-0.34375-0.375-0.80859-0.5625-1.3906-0.5625-0.59375 0-1.0703 0.1875-1.4219 0.5625-0.34375 0.36719-0.51562 0.88672-0.51562 1.5625v5.4531h-3.0781v-10.047h3.0781v1.3281c0.3125-0.4375 0.73438-0.78516 1.2656-1.0469 0.53125-0.25781 1.125-0.39062 1.7812-0.39062z"/>
-</g>
-<g transform="translate(138.42 676.92)">
-<path d="m6.7188-2.6094v2.6094h-1.5781c-1.1172 0-1.9844-0.26953-2.6094-0.8125-0.61719-0.55078-0.92188-1.4414-0.92188-2.6719v-4h-1.2344v-2.5625h1.2344v-2.4375h3.0781v2.4375h2.0156v2.5625h-2.0156v4.0312c0 0.30469 0.066406 0.52344 0.20312 0.65625 0.14453 0.125 0.38281 0.1875 0.71875 0.1875z"/>
-</g>
-<g transform="translate(145.73 676.92)">
-<path d="m4.1875-8.375c0.36328-0.55078 0.81641-0.98438 1.3594-1.2969 0.53906-0.32031 1.1406-0.48438 1.7969-0.48438v3.2656h-0.84375c-0.77344 0-1.3516 0.16797-1.7344 0.5-0.38672 0.32422-0.57812 0.90234-0.57812 1.7344v4.6562h-3.0781v-10.047h3.0781z"/>
-</g>
-<g transform="translate(153.44 676.92)">
-<path d="m5.6875 0.14062c-0.98047 0-1.8672-0.20703-2.6562-0.625-0.78125-0.41406-1.4023-1.0156-1.8594-1.7969-0.44922-0.78125-0.67188-1.6914-0.67188-2.7344 0-1.0312 0.22656-1.9375 0.6875-2.7188 0.45703-0.78906 1.082-1.3945 1.875-1.8125 0.78906-0.42578 1.6758-0.64062 2.6562-0.64062 0.98828 0 1.8789 0.21484 2.6719 0.64062 0.78906 0.41797 1.4102 1.0234 1.8594 1.8125 0.45703 0.78125 0.6875 1.6875 0.6875 2.7188s-0.23047 1.9453-0.6875 2.7344c-0.46094 0.78125-1.0898 1.3828-1.8906 1.7969-0.80469 0.41797-1.6953 0.625-2.6719 0.625zm0-2.6562c0.58203 0 1.082-0.21094 1.5-0.64062 0.41406-0.4375 0.625-1.0547 0.625-1.8594 0-0.8125-0.20312-1.4297-0.60938-1.8594-0.39844-0.4375-0.89062-0.65625-1.4844-0.65625s-1.0898 0.21484-1.4844 0.64062c-0.39844 0.42969-0.59375 1.0547-0.59375 1.875 0 0.80469 0.19141 1.4219 0.57812 1.8594 0.39453 0.42969 0.88281 0.64062 1.4688 0.64062z"/>
-</g>
-<g transform="translate(164.9 676.92)">
-<path d="m4.1875-13.312v13.312h-3.0781v-13.312z"/>
-</g>
-</g>
-<g clip-path="url(#av)">
-<g clip-path="url(#o)">
-<path d="m213.23 621.42h140.11v80.062h-140.11z" fill="#22a472"/>
-</g>
-</g>
-<g fill="#fffbf9">
-<g transform="translate(246.18 667.17)">
-<path d="m4.1875-2.375h4.0312v2.375h-7.1094v-12.641h3.0781z"/>
-</g>
-<g transform="translate(254.77 667.17)">
-<path d="m5.6875 0.14062c-0.98047 0-1.8672-0.20703-2.6562-0.625-0.78125-0.41406-1.4023-1.0156-1.8594-1.7969-0.44922-0.78125-0.67188-1.6914-0.67188-2.7344 0-1.0312 0.22656-1.9375 0.6875-2.7188 0.45703-0.78906 1.082-1.3945 1.875-1.8125 0.78906-0.42578 1.6758-0.64062 2.6562-0.64062 0.98828 0 1.8789 0.21484 2.6719 0.64062 0.78906 0.41797 1.4102 1.0234 1.8594 1.8125 0.45703 0.78125 0.6875 1.6875 0.6875 2.7188s-0.23047 1.9453-0.6875 2.7344c-0.46094 0.78125-1.0898 1.3828-1.8906 1.7969-0.80469 0.41797-1.6953 0.625-2.6719 0.625zm0-2.6562c0.58203 0 1.082-0.21094 1.5-0.64062 0.41406-0.4375 0.625-1.0547 0.625-1.8594 0-0.8125-0.20312-1.4297-0.60938-1.8594-0.39844-0.4375-0.89062-0.65625-1.4844-0.65625s-1.0898 0.21484-1.4844 0.64062c-0.39844 0.42969-0.59375 1.0547-0.59375 1.875 0 0.80469 0.19141 1.4219 0.57812 1.8594 0.39453 0.42969 0.88281 0.64062 1.4688 0.64062z"/>
-</g>
-<g transform="translate(266.23 667.17)">
-<path d="m4.9375-10.188c0.70703 0 1.3281 0.14844 1.8594 0.4375 0.53125 0.28125 0.94141 0.65625 1.2344 1.125v-1.4219h3.0781v10.031c0 0.92578-0.18359 1.7656-0.54688 2.5156-0.36719 0.75-0.92188 1.3438-1.6719 1.7812-0.75 0.44531-1.6875 0.67188-2.8125 0.67188-1.4805 0-2.6836-0.35547-3.6094-1.0625-0.92969-0.69922-1.4609-1.6484-1.5938-2.8438h3.0469c0.09375 0.38281 0.31641 0.6875 0.67188 0.90625 0.36328 0.21875 0.8125 0.32812 1.3438 0.32812 0.63281 0 1.1406-0.18359 1.5156-0.54688 0.38281-0.36719 0.57812-0.94922 0.57812-1.75v-1.4219c-0.30469 0.46875-0.71875 0.85156-1.25 1.1406-0.52344 0.29297-1.1367 0.4375-1.8438 0.4375-0.83594 0-1.5898-0.21094-2.2656-0.64062-0.66797-0.42578-1.1992-1.0312-1.5938-1.8125-0.38672-0.78125-0.57812-1.6914-0.57812-2.7344 0-1.0312 0.19141-1.9297 0.57812-2.7031 0.39453-0.78125 0.92578-1.3789 1.5938-1.7969 0.67578-0.42578 1.4297-0.64062 2.2656-0.64062zm3.0938 5.1719c0-0.76953-0.21484-1.375-0.64062-1.8125-0.42969-0.44531-0.94922-0.67188-1.5625-0.67188-0.61719 0-1.1367 0.21875-1.5625 0.65625-0.41797 0.4375-0.625 1.0391-0.625 1.7969 0 0.77344 0.20703 1.3867 0.625 1.8438 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.42578-0.44531 0.64062-1.0508 0.64062-1.8125z"/>
-</g>
-<g transform="translate(278.46 667.17)">
-<path d="m4.9375-10.188c0.70703 0 1.3281 0.14844 1.8594 0.4375 0.53125 0.28125 0.94141 0.65625 1.2344 1.125v-1.4219h3.0781v10.031c0 0.92578-0.18359 1.7656-0.54688 2.5156-0.36719 0.75-0.92188 1.3438-1.6719 1.7812-0.75 0.44531-1.6875 0.67188-2.8125 0.67188-1.4805 0-2.6836-0.35547-3.6094-1.0625-0.92969-0.69922-1.4609-1.6484-1.5938-2.8438h3.0469c0.09375 0.38281 0.31641 0.6875 0.67188 0.90625 0.36328 0.21875 0.8125 0.32812 1.3438 0.32812 0.63281 0 1.1406-0.18359 1.5156-0.54688 0.38281-0.36719 0.57812-0.94922 0.57812-1.75v-1.4219c-0.30469 0.46875-0.71875 0.85156-1.25 1.1406-0.52344 0.29297-1.1367 0.4375-1.8438 0.4375-0.83594 0-1.5898-0.21094-2.2656-0.64062-0.66797-0.42578-1.1992-1.0312-1.5938-1.8125-0.38672-0.78125-0.57812-1.6914-0.57812-2.7344 0-1.0312 0.19141-1.9297 0.57812-2.7031 0.39453-0.78125 0.92578-1.3789 1.5938-1.7969 0.67578-0.42578 1.4297-0.64062 2.2656-0.64062zm3.0938 5.1719c0-0.76953-0.21484-1.375-0.64062-1.8125-0.42969-0.44531-0.94922-0.67188-1.5625-0.67188-0.61719 0-1.1367 0.21875-1.5625 0.65625-0.41797 0.4375-0.625 1.0391-0.625 1.7969 0 0.77344 0.20703 1.3867 0.625 1.8438 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.42578-0.44531 0.64062-1.0508 0.64062-1.8125z"/>
-</g>
-<g transform="translate(290.68 667.17)">
-<path d="m2.6562-11.094c-0.53125 0-0.96875-0.15625-1.3125-0.46875-0.34375-0.32031-0.51562-0.71875-0.51562-1.1875 0-0.47656 0.17188-0.875 0.51562-1.1875 0.34375-0.32031 0.78125-0.48438 1.3125-0.48438s0.96875 0.16406 1.3125 0.48438c0.34375 0.3125 0.51562 0.71094 0.51562 1.1875 0 0.46875-0.17188 0.86719-0.51562 1.1875-0.34375 0.3125-0.78125 0.46875-1.3125 0.46875zm1.5312 1.0469v10.047h-3.0781v-10.047z"/>
-</g>
-<g transform="translate(295.99 667.17)">
-<path d="m7.2344-10.156c1.1758 0 2.1133 0.38672 2.8125 1.1562 0.70703 0.76172 1.0625 1.8047 1.0625 3.125v5.875h-3.0625v-5.4531c0-0.67578-0.17969-1.1953-0.53125-1.5625-0.34375-0.375-0.80859-0.5625-1.3906-0.5625-0.59375 0-1.0703 0.1875-1.4219 0.5625-0.34375 0.36719-0.51562 0.88672-0.51562 1.5625v5.4531h-3.0781v-10.047h3.0781v1.3281c0.3125-0.4375 0.73438-0.78516 1.2656-1.0469 0.53125-0.25781 1.125-0.39062 1.7812-0.39062z"/>
-</g>
-<g transform="translate(308.12 667.17)">
-<path d="m4.9375-10.188c0.70703 0 1.3281 0.14844 1.8594 0.4375 0.53125 0.28125 0.94141 0.65625 1.2344 1.125v-1.4219h3.0781v10.031c0 0.92578-0.18359 1.7656-0.54688 2.5156-0.36719 0.75-0.92188 1.3438-1.6719 1.7812-0.75 0.44531-1.6875 0.67188-2.8125 0.67188-1.4805 0-2.6836-0.35547-3.6094-1.0625-0.92969-0.69922-1.4609-1.6484-1.5938-2.8438h3.0469c0.09375 0.38281 0.31641 0.6875 0.67188 0.90625 0.36328 0.21875 0.8125 0.32812 1.3438 0.32812 0.63281 0 1.1406-0.18359 1.5156-0.54688 0.38281-0.36719 0.57812-0.94922 0.57812-1.75v-1.4219c-0.30469 0.46875-0.71875 0.85156-1.25 1.1406-0.52344 0.29297-1.1367 0.4375-1.8438 0.4375-0.83594 0-1.5898-0.21094-2.2656-0.64062-0.66797-0.42578-1.1992-1.0312-1.5938-1.8125-0.38672-0.78125-0.57812-1.6914-0.57812-2.7344 0-1.0312 0.19141-1.9297 0.57812-2.7031 0.39453-0.78125 0.92578-1.3789 1.5938-1.7969 0.67578-0.42578 1.4297-0.64062 2.2656-0.64062zm3.0938 5.1719c0-0.76953-0.21484-1.375-0.64062-1.8125-0.42969-0.44531-0.94922-0.67188-1.5625-0.67188-0.61719 0-1.1367 0.21875-1.5625 0.65625-0.41797 0.4375-0.625 1.0391-0.625 1.7969 0 0.77344 0.20703 1.3867 0.625 1.8438 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.42578-0.44531 0.64062-1.0508 0.64062-1.8125z"/>
-</g>
-</g>
-<g clip-path="url(#l)">
-<g clip-path="url(#bn)">
-<path d="m361.57 621.42h147.31v80.062h-147.31z" fill="#22a472"/>
-</g>
-</g>
-<g fill="#fffbf9">
-<g transform="translate(399.95 667.17)">
-<path d="m8.7656-6.4844c0.72656 0.15625 1.3164 0.52344 1.7656 1.0938 0.44531 0.57422 0.67188 1.2266 0.67188 1.9531 0 1.0547-0.37109 1.8906-1.1094 2.5156-0.74219 0.61719-1.7734 0.92188-3.0938 0.92188h-5.8906v-12.641h5.6875c1.2891 0 2.2969 0.29688 3.0156 0.89062 0.72656 0.58594 1.0938 1.3828 1.0938 2.3906 0 0.74219-0.19922 1.3594-0.59375 1.8594-0.38672 0.49219-0.90234 0.82812-1.5469 1.0156zm-4.5781-1.0469h2.0156c0.50781 0 0.89844-0.10938 1.1719-0.32812 0.26953-0.21875 0.40625-0.54688 0.40625-0.98438 0-0.42578-0.13672-0.75391-0.40625-0.98438-0.27344-0.22656-0.66406-0.34375-1.1719-0.34375h-2.0156zm2.2812 5.0469c0.50781 0 0.90625-0.11328 1.1875-0.34375 0.28125-0.23828 0.42188-0.58203 0.42188-1.0312 0-0.4375-0.14844-0.78125-0.4375-1.0312-0.29297-0.25781-0.69922-0.39062-1.2188-0.39062h-2.2344v2.7969z"/>
-</g>
-<g transform="translate(411.81 667.17)">
-<path d="m0.5-5.0469c0-1.0312 0.19141-1.9297 0.57812-2.7031 0.39453-0.78125 0.92578-1.3789 1.5938-1.7969 0.67578-0.42578 1.4297-0.64062 2.2656-0.64062 0.70703 0 1.3281 0.14844 1.8594 0.4375 0.53125 0.28125 0.94141 0.65625 1.2344 1.125v-1.4219h3.0781v10.047h-3.0781v-1.4219c-0.30469 0.46875-0.72656 0.85156-1.2656 1.1406-0.53125 0.28125-1.1523 0.42188-1.8594 0.42188-0.8125 0-1.5586-0.21094-2.2344-0.64062-0.66797-0.42578-1.1992-1.0312-1.5938-1.8125-0.38672-0.78125-0.57812-1.6914-0.57812-2.7344zm7.5312 0.03125c0-0.76953-0.21484-1.375-0.64062-1.8125-0.42969-0.44531-0.94922-0.67188-1.5625-0.67188-0.61719 0-1.1367 0.21875-1.5625 0.65625-0.41797 0.4375-0.625 1.0391-0.625 1.7969 0 0.77344 0.20703 1.3867 0.625 1.8438 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.42578-0.44531 0.64062-1.0508 0.64062-1.8125z"/>
-</g>
-<g transform="translate(424.03 667.17)">
-<path d="m0.5-5.0156c0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0195-1.3789 1.7812-1.7969 0.75781-0.42578 1.6328-0.64062 2.625-0.64062 1.2578 0 2.3125 0.33594 3.1562 1 0.84375 0.65625 1.3984 1.5859 1.6719 2.7812h-3.2812c-0.28125-0.76953-0.82031-1.1562-1.6094-1.1562-0.5625 0-1.0117 0.21875-1.3438 0.65625-0.33594 0.4375-0.5 1.0703-0.5 1.8906 0 0.8125 0.16406 1.4375 0.5 1.875 0.33203 0.4375 0.78125 0.65625 1.3438 0.65625 0.78906 0 1.3281-0.38281 1.6094-1.1562h3.2812c-0.27344 1.1797-0.83594 2.1055-1.6875 2.7812-0.84375 0.66797-1.8906 1-3.1406 1-0.99219 0-1.8672-0.20703-2.625-0.625-0.76172-0.41406-1.3555-1.0156-1.7812-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344z"/>
-</g>
-<g transform="translate(434.92 667.17)">
-<path d="m7.25 0-3.0625-4.2188v4.2188h-3.0781v-13.312h3.0781v7.3594l3.0469-4.0938h3.7969l-4.1719 5.0469 4.2031 5z"/>
-</g>
-<g transform="translate(446.04 667.17)">
-<path d="m11.031-10.047v10.047h-3.0781v-1.375c-0.3125 0.44922-0.73438 0.80859-1.2656 1.0781-0.53125 0.27344-1.125 0.40625-1.7812 0.40625-0.76172 0-1.4375-0.17188-2.0312-0.51562-0.58594-0.34375-1.0391-0.83594-1.3594-1.4844-0.32422-0.64453-0.48438-1.4062-0.48438-2.2812v-5.875h3.0625v5.4531c0 0.67969 0.17188 1.2031 0.51562 1.5781 0.34375 0.36719 0.8125 0.54688 1.4062 0.54688s1.0625-0.17969 1.4062-0.54688c0.35156-0.375 0.53125-0.89844 0.53125-1.5781v-5.4531z"/>
-</g>
-<g transform="translate(458.18 667.17)">
-<path d="m4.1875-8.625c0.30078-0.46875 0.71875-0.84375 1.25-1.125 0.53125-0.28906 1.1484-0.4375 1.8594-0.4375 0.82031 0 1.5664 0.21484 2.2344 0.64062 0.67578 0.41797 1.207 1.0156 1.5938 1.7969 0.39453 0.77344 0.59375 1.6719 0.59375 2.7031 0 1.043-0.19922 1.9531-0.59375 2.7344-0.38672 0.78125-0.91797 1.3867-1.5938 1.8125-0.66797 0.42969-1.4141 0.64062-2.2344 0.64062-0.69922 0-1.3203-0.14062-1.8594-0.42188-0.53125-0.28906-0.94922-0.66406-1.25-1.125v6.1875h-3.0781v-14.828h3.0781zm4.4062 3.5781c0-0.75781-0.21484-1.3594-0.64062-1.7969-0.42969-0.4375-0.95312-0.65625-1.5781-0.65625-0.61719 0-1.1367 0.22656-1.5625 0.67188-0.42969 0.4375-0.64062 1.043-0.64062 1.8125 0 0.76172 0.21094 1.3672 0.64062 1.8125 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.4375-0.45703 0.65625-1.0703 0.65625-1.8438z"/>
-</g>
-</g>
-<g clip-path="url(#v)">
-<g clip-path="url(#m)">
-<path d="m517.04 621.42h149.8v80.062h-149.8z" fill="#22a472"/>
-</g>
-</g>
-<g fill="#fffbf9">
-<g transform="translate(538.01 656.67)">
-<path d="m0.59375-6.3438c0-1.2383 0.26953-2.3477 0.8125-3.3281 0.53906-0.97656 1.2891-1.7383 2.25-2.2812 0.96875-0.55078 2.0664-0.82812 3.2969-0.82812 1.5 0 2.7812 0.39844 3.8438 1.1875 1.0703 0.79297 1.7852 1.8711 2.1406 3.2344h-3.375c-0.25-0.51953-0.60938-0.91406-1.0781-1.1875-0.46094-0.28125-0.98438-0.42188-1.5781-0.42188-0.94922 0-1.7188 0.33594-2.3125 1-0.58594 0.65625-0.875 1.5312-0.875 2.625 0 1.1055 0.28906 1.9922 0.875 2.6562 0.59375 0.65625 1.3633 0.98438 2.3125 0.98438 0.59375 0 1.1172-0.13281 1.5781-0.40625 0.46875-0.28125 0.82812-0.67969 1.0781-1.2031h3.375c-0.35547 1.3672-1.0703 2.4453-2.1406 3.2344-1.0625 0.78125-2.3438 1.1719-3.8438 1.1719-1.2305 0-2.3281-0.26953-3.2969-0.8125-0.96094-0.55078-1.7109-1.3125-2.25-2.2812-0.54297-0.97656-0.8125-2.0938-0.8125-3.3438z"/>
-</g>
-<g transform="translate(551.73 656.67)">
-<path d="m5.6875 0.14062c-0.98047 0-1.8672-0.20703-2.6562-0.625-0.78125-0.41406-1.4023-1.0156-1.8594-1.7969-0.44922-0.78125-0.67188-1.6914-0.67188-2.7344 0-1.0312 0.22656-1.9375 0.6875-2.7188 0.45703-0.78906 1.082-1.3945 1.875-1.8125 0.78906-0.42578 1.6758-0.64062 2.6562-0.64062 0.98828 0 1.8789 0.21484 2.6719 0.64062 0.78906 0.41797 1.4102 1.0234 1.8594 1.8125 0.45703 0.78125 0.6875 1.6875 0.6875 2.7188s-0.23047 1.9453-0.6875 2.7344c-0.46094 0.78125-1.0898 1.3828-1.8906 1.7969-0.80469 0.41797-1.6953 0.625-2.6719 0.625zm0-2.6562c0.58203 0 1.082-0.21094 1.5-0.64062 0.41406-0.4375 0.625-1.0547 0.625-1.8594 0-0.8125-0.20312-1.4297-0.60938-1.8594-0.39844-0.4375-0.89062-0.65625-1.4844-0.65625s-1.0898 0.21484-1.4844 0.64062c-0.39844 0.42969-0.59375 1.0547-0.59375 1.875 0 0.80469 0.19141 1.4219 0.57812 1.8594 0.39453 0.42969 0.88281 0.64062 1.4688 0.64062z"/>
-</g>
-<g transform="translate(563.2 656.67)">
-<path d="m7.2344-10.156c1.1758 0 2.1133 0.38672 2.8125 1.1562 0.70703 0.76172 1.0625 1.8047 1.0625 3.125v5.875h-3.0625v-5.4531c0-0.67578-0.17969-1.1953-0.53125-1.5625-0.34375-0.375-0.80859-0.5625-1.3906-0.5625-0.59375 0-1.0703 0.1875-1.4219 0.5625-0.34375 0.36719-0.51562 0.88672-0.51562 1.5625v5.4531h-3.0781v-10.047h3.0781v1.3281c0.3125-0.4375 0.73438-0.78516 1.2656-1.0469 0.53125-0.25781 1.125-0.39062 1.7812-0.39062z"/>
-</g>
-<g transform="translate(575.33 656.67)">
-<path d="m6.7188-2.6094v2.6094h-1.5781c-1.1172 0-1.9844-0.26953-2.6094-0.8125-0.61719-0.55078-0.92188-1.4414-0.92188-2.6719v-4h-1.2344v-2.5625h1.2344v-2.4375h3.0781v2.4375h2.0156v2.5625h-2.0156v4.0312c0 0.30469 0.066406 0.52344 0.20312 0.65625 0.14453 0.125 0.38281 0.1875 0.71875 0.1875z"/>
-</g>
-<g transform="translate(582.64 656.67)">
-<path d="m2.6562-11.094c-0.53125 0-0.96875-0.15625-1.3125-0.46875-0.34375-0.32031-0.51562-0.71875-0.51562-1.1875 0-0.47656 0.17188-0.875 0.51562-1.1875 0.34375-0.32031 0.78125-0.48438 1.3125-0.48438s0.96875 0.16406 1.3125 0.48438c0.34375 0.3125 0.51562 0.71094 0.51562 1.1875 0 0.46875-0.17188 0.86719-0.51562 1.1875-0.34375 0.3125-0.78125 0.46875-1.3125 0.46875zm1.5312 1.0469v10.047h-3.0781v-10.047z"/>
-</g>
-<g transform="translate(587.95 656.67)">
-<path d="m7.2344-10.156c1.1758 0 2.1133 0.38672 2.8125 1.1562 0.70703 0.76172 1.0625 1.8047 1.0625 3.125v5.875h-3.0625v-5.4531c0-0.67578-0.17969-1.1953-0.53125-1.5625-0.34375-0.375-0.80859-0.5625-1.3906-0.5625-0.59375 0-1.0703 0.1875-1.4219 0.5625-0.34375 0.36719-0.51562 0.88672-0.51562 1.5625v5.4531h-3.0781v-10.047h3.0781v1.3281c0.3125-0.4375 0.73438-0.78516 1.2656-1.0469 0.53125-0.25781 1.125-0.39062 1.7812-0.39062z"/>
-</g>
-<g transform="translate(600.08 656.67)">
-<path d="m11.031-10.047v10.047h-3.0781v-1.375c-0.3125 0.44922-0.73438 0.80859-1.2656 1.0781-0.53125 0.27344-1.125 0.40625-1.7812 0.40625-0.76172 0-1.4375-0.17188-2.0312-0.51562-0.58594-0.34375-1.0391-0.83594-1.3594-1.4844-0.32422-0.64453-0.48438-1.4062-0.48438-2.2812v-5.875h3.0625v5.4531c0 0.67969 0.17188 1.2031 0.51562 1.5781 0.34375 0.36719 0.8125 0.54688 1.4062 0.54688s1.0625-0.17969 1.4062-0.54688c0.35156-0.375 0.53125-0.89844 0.53125-1.5781v-5.4531z"/>
-</g>
-<g transform="translate(612.21 656.67)">
-<path d="m5.6875 0.14062c-0.98047 0-1.8672-0.20703-2.6562-0.625-0.78125-0.41406-1.4023-1.0156-1.8594-1.7969-0.44922-0.78125-0.67188-1.6914-0.67188-2.7344 0-1.0312 0.22656-1.9375 0.6875-2.7188 0.45703-0.78906 1.082-1.3945 1.875-1.8125 0.78906-0.42578 1.6758-0.64062 2.6562-0.64062 0.98828 0 1.8789 0.21484 2.6719 0.64062 0.78906 0.41797 1.4102 1.0234 1.8594 1.8125 0.45703 0.78125 0.6875 1.6875 0.6875 2.7188s-0.23047 1.9453-0.6875 2.7344c-0.46094 0.78125-1.0898 1.3828-1.8906 1.7969-0.80469 0.41797-1.6953 0.625-2.6719 0.625zm0-2.6562c0.58203 0 1.082-0.21094 1.5-0.64062 0.41406-0.4375 0.625-1.0547 0.625-1.8594 0-0.8125-0.20312-1.4297-0.60938-1.8594-0.39844-0.4375-0.89062-0.65625-1.4844-0.65625s-1.0898 0.21484-1.4844 0.64062c-0.39844 0.42969-0.59375 1.0547-0.59375 1.875 0 0.80469 0.19141 1.4219 0.57812 1.8594 0.39453 0.42969 0.88281 0.64062 1.4688 0.64062z"/>
-</g>
-<g transform="translate(623.68 656.67)">
-<path d="m11.031-10.047v10.047h-3.0781v-1.375c-0.3125 0.44922-0.73438 0.80859-1.2656 1.0781-0.53125 0.27344-1.125 0.40625-1.7812 0.40625-0.76172 0-1.4375-0.17188-2.0312-0.51562-0.58594-0.34375-1.0391-0.83594-1.3594-1.4844-0.32422-0.64453-0.48438-1.4062-0.48438-2.2812v-5.875h3.0625v5.4531c0 0.67969 0.17188 1.2031 0.51562 1.5781 0.34375 0.36719 0.8125 0.54688 1.4062 0.54688s1.0625-0.17969 1.4062-0.54688c0.35156-0.375 0.53125-0.89844 0.53125-1.5781v-5.4531z"/>
-</g>
-<g transform="translate(635.81 656.67)">
-<path d="m5.2031 0.14062c-0.875 0-1.6562-0.14453-2.3438-0.4375-0.67969-0.30078-1.2188-0.71094-1.625-1.2344-0.39844-0.53125-0.61719-1.1172-0.65625-1.7656h3.0469c0.03125 0.35547 0.1875 0.64062 0.46875 0.85938 0.28906 0.21094 0.64844 0.3125 1.0781 0.3125 0.375 0 0.66406-0.070312 0.875-0.21875 0.21875-0.15625 0.32812-0.35156 0.32812-0.59375 0-0.28125-0.15234-0.48828-0.45312-0.625-0.30469-0.14453-0.78906-0.30078-1.4531-0.46875-0.71875-0.16406-1.3242-0.34375-1.8125-0.53125-0.48047-0.1875-0.89062-0.47656-1.2344-0.875-0.34375-0.40625-0.51562-0.95312-0.51562-1.6406 0-0.57031 0.15625-1.0938 0.46875-1.5625 0.32031-0.47656 0.78906-0.85156 1.4062-1.125 0.61328-0.28125 1.3477-0.42188 2.2031-0.42188 1.2578 0 2.25 0.3125 2.9688 0.9375 0.72656 0.625 1.1484 1.4531 1.2656 2.4844h-2.8438c-0.054688-0.35156-0.21094-0.62891-0.46875-0.82812-0.25-0.20703-0.58984-0.3125-1.0156-0.3125-0.35547 0-0.63281 0.074219-0.82812 0.21875-0.1875 0.13672-0.28125 0.32422-0.28125 0.5625 0 0.28125 0.14844 0.49609 0.45312 0.64062 0.3125 0.14844 0.78906 0.29297 1.4375 0.4375 0.73828 0.1875 1.3438 0.375 1.8125 0.5625s0.87891 0.49219 1.2344 0.90625c0.35156 0.41797 0.53516 0.96875 0.54688 1.6562 0 0.59375-0.16797 1.125-0.5 1.5938-0.32422 0.46094-0.79688 0.82031-1.4219 1.0781-0.61719 0.25781-1.3281 0.39062-2.1406 0.39062z"/>
-</g>
-<g transform="translate(535.23 676.92)">
-<path d="m0.59375-6.3438c0-1.2383 0.26953-2.3477 0.8125-3.3281 0.53906-0.97656 1.2891-1.7383 2.25-2.2812 0.96875-0.55078 2.0664-0.82812 3.2969-0.82812 1.5 0 2.7812 0.39844 3.8438 1.1875 1.0703 0.79297 1.7852 1.8711 2.1406 3.2344h-3.375c-0.25-0.51953-0.60938-0.91406-1.0781-1.1875-0.46094-0.28125-0.98438-0.42188-1.5781-0.42188-0.94922 0-1.7188 0.33594-2.3125 1-0.58594 0.65625-0.875 1.5312-0.875 2.625 0 1.1055 0.28906 1.9922 0.875 2.6562 0.59375 0.65625 1.3633 0.98438 2.3125 0.98438 0.59375 0 1.1172-0.13281 1.5781-0.40625 0.46875-0.28125 0.82812-0.67969 1.0781-1.2031h3.375c-0.35547 1.3672-1.0703 2.4453-2.1406 3.2344-1.0625 0.78125-2.3438 1.1719-3.8438 1.1719-1.2305 0-2.3281-0.26953-3.2969-0.8125-0.96094-0.55078-1.7109-1.3125-2.25-2.2812-0.54297-0.97656-0.8125-2.0938-0.8125-3.3438z"/>
-</g>
-<g transform="translate(548.94 676.92)">
-<path d="m5.6875 0.14062c-0.98047 0-1.8672-0.20703-2.6562-0.625-0.78125-0.41406-1.4023-1.0156-1.8594-1.7969-0.44922-0.78125-0.67188-1.6914-0.67188-2.7344 0-1.0312 0.22656-1.9375 0.6875-2.7188 0.45703-0.78906 1.082-1.3945 1.875-1.8125 0.78906-0.42578 1.6758-0.64062 2.6562-0.64062 0.98828 0 1.8789 0.21484 2.6719 0.64062 0.78906 0.41797 1.4102 1.0234 1.8594 1.8125 0.45703 0.78125 0.6875 1.6875 0.6875 2.7188s-0.23047 1.9453-0.6875 2.7344c-0.46094 0.78125-1.0898 1.3828-1.8906 1.7969-0.80469 0.41797-1.6953 0.625-2.6719 0.625zm0-2.6562c0.58203 0 1.082-0.21094 1.5-0.64062 0.41406-0.4375 0.625-1.0547 0.625-1.8594 0-0.8125-0.20312-1.4297-0.60938-1.8594-0.39844-0.4375-0.89062-0.65625-1.4844-0.65625s-1.0898 0.21484-1.4844 0.64062c-0.39844 0.42969-0.59375 1.0547-0.59375 1.875 0 0.80469 0.19141 1.4219 0.57812 1.8594 0.39453 0.42969 0.88281 0.64062 1.4688 0.64062z"/>
-</g>
-<g transform="translate(560.41 676.92)">
-<path d="m13.938-10.156c1.2383 0 2.2266 0.38281 2.9688 1.1406 0.73828 0.75 1.1094 1.7969 1.1094 3.1406v5.875h-3.0625v-5.4531c0-0.64453-0.17188-1.1445-0.51562-1.5-0.33594-0.35156-0.80469-0.53125-1.4062-0.53125-0.60547 0-1.0781 0.17969-1.4219 0.53125-0.33594 0.35547-0.5 0.85547-0.5 1.5v5.4531h-3.0625v-5.4531c0-0.64453-0.17188-1.1445-0.51562-1.5-0.34375-0.35156-0.8125-0.53125-1.4062-0.53125-0.60547 0-1.0781 0.17969-1.4219 0.53125-0.34375 0.35547-0.51562 0.85547-0.51562 1.5v5.4531h-3.0781v-10.047h3.0781v1.2656c0.3125-0.41406 0.71875-0.75 1.2188-1 0.50781-0.25 1.082-0.375 1.7188-0.375 0.75781 0 1.4375 0.16406 2.0312 0.48438 0.59375 0.32422 1.0547 0.78906 1.3906 1.3906 0.34375-0.55078 0.81641-1 1.4219-1.3438 0.60156-0.35156 1.2578-0.53125 1.9688-0.53125z"/>
-</g>
-<g transform="translate(579.47 676.92)">
-<path d="m4.1875-8.625c0.30078-0.46875 0.71875-0.84375 1.25-1.125 0.53125-0.28906 1.1484-0.4375 1.8594-0.4375 0.82031 0 1.5664 0.21484 2.2344 0.64062 0.67578 0.41797 1.207 1.0156 1.5938 1.7969 0.39453 0.77344 0.59375 1.6719 0.59375 2.7031 0 1.043-0.19922 1.9531-0.59375 2.7344-0.38672 0.78125-0.91797 1.3867-1.5938 1.8125-0.66797 0.42969-1.4141 0.64062-2.2344 0.64062-0.69922 0-1.3203-0.14062-1.8594-0.42188-0.53125-0.28906-0.94922-0.66406-1.25-1.125v6.1875h-3.0781v-14.828h3.0781zm4.4062 3.5781c0-0.75781-0.21484-1.3594-0.64062-1.7969-0.42969-0.4375-0.95312-0.65625-1.5781-0.65625-0.61719 0-1.1367 0.22656-1.5625 0.67188-0.42969 0.4375-0.64062 1.043-0.64062 1.8125 0 0.76172 0.21094 1.3672 0.64062 1.8125 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.4375-0.45703 0.65625-1.0703 0.65625-1.8438z"/>
-</g>
-<g transform="translate(591.69 676.92)">
-<path d="m4.1875-13.312v13.312h-3.0781v-13.312z"/>
-</g>
-<g transform="translate(597 676.92)">
-<path d="m2.6562-11.094c-0.53125 0-0.96875-0.15625-1.3125-0.46875-0.34375-0.32031-0.51562-0.71875-0.51562-1.1875 0-0.47656 0.17188-0.875 0.51562-1.1875 0.34375-0.32031 0.78125-0.48438 1.3125-0.48438s0.96875 0.16406 1.3125 0.48438c0.34375 0.3125 0.51562 0.71094 0.51562 1.1875 0 0.46875-0.17188 0.86719-0.51562 1.1875-0.34375 0.3125-0.78125 0.46875-1.3125 0.46875zm1.5312 1.0469v10.047h-3.0781v-10.047z"/>
-</g>
-<g transform="translate(602.31 676.92)">
-<path d="m0.5-5.0469c0-1.0312 0.19141-1.9297 0.57812-2.7031 0.39453-0.78125 0.92578-1.3789 1.5938-1.7969 0.67578-0.42578 1.4297-0.64062 2.2656-0.64062 0.70703 0 1.3281 0.14844 1.8594 0.4375 0.53125 0.28125 0.94141 0.65625 1.2344 1.125v-1.4219h3.0781v10.047h-3.0781v-1.4219c-0.30469 0.46875-0.72656 0.85156-1.2656 1.1406-0.53125 0.28125-1.1523 0.42188-1.8594 0.42188-0.8125 0-1.5586-0.21094-2.2344-0.64062-0.66797-0.42578-1.1992-1.0312-1.5938-1.8125-0.38672-0.78125-0.57812-1.6914-0.57812-2.7344zm7.5312 0.03125c0-0.76953-0.21484-1.375-0.64062-1.8125-0.42969-0.44531-0.94922-0.67188-1.5625-0.67188-0.61719 0-1.1367 0.21875-1.5625 0.65625-0.41797 0.4375-0.625 1.0391-0.625 1.7969 0 0.77344 0.20703 1.3867 0.625 1.8438 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.42578-0.44531 0.64062-1.0508 0.64062-1.8125z"/>
-</g>
-<g transform="translate(614.53 676.92)">
-<path d="m7.2344-10.156c1.1758 0 2.1133 0.38672 2.8125 1.1562 0.70703 0.76172 1.0625 1.8047 1.0625 3.125v5.875h-3.0625v-5.4531c0-0.67578-0.17969-1.1953-0.53125-1.5625-0.34375-0.375-0.80859-0.5625-1.3906-0.5625-0.59375 0-1.0703 0.1875-1.4219 0.5625-0.34375 0.36719-0.51562 0.88672-0.51562 1.5625v5.4531h-3.0781v-10.047h3.0781v1.3281c0.3125-0.4375 0.73438-0.78516 1.2656-1.0469 0.53125-0.25781 1.125-0.39062 1.7812-0.39062z"/>
-</g>
-<g transform="translate(626.66 676.92)">
-<path d="m0.5-5.0156c0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0195-1.3789 1.7812-1.7969 0.75781-0.42578 1.6328-0.64062 2.625-0.64062 1.2578 0 2.3125 0.33594 3.1562 1 0.84375 0.65625 1.3984 1.5859 1.6719 2.7812h-3.2812c-0.28125-0.76953-0.82031-1.1562-1.6094-1.1562-0.5625 0-1.0117 0.21875-1.3438 0.65625-0.33594 0.4375-0.5 1.0703-0.5 1.8906 0 0.8125 0.16406 1.4375 0.5 1.875 0.33203 0.4375 0.78125 0.65625 1.3438 0.65625 0.78906 0 1.3281-0.38281 1.6094-1.1562h3.2812c-0.27344 1.1797-0.83594 2.1055-1.6875 2.7812-0.84375 0.66797-1.8906 1-3.1406 1-0.99219 0-1.8672-0.20703-2.625-0.625-0.76172-0.41406-1.3555-1.0156-1.7812-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344z"/>
-</g>
-<g transform="translate(637.55 676.92)">
-<path d="m10.578-5.1875c0 0.29297-0.015625 0.59375-0.046875 0.90625h-6.9688c0.050781 0.625 0.25391 1.1055 0.60938 1.4375 0.35156 0.32422 0.78516 0.48438 1.2969 0.48438 0.76953 0 1.3047-0.32031 1.6094-0.96875h3.2656c-0.16797 0.65625-0.46875 1.25-0.90625 1.7812s-0.99219 0.94922-1.6562 1.25c-0.65625 0.29297-1.3906 0.4375-2.2031 0.4375-0.98047 0-1.8555-0.20703-2.625-0.625-0.77344-0.41406-1.375-1.0156-1.8125-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344 0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0234-1.3789 1.7969-1.7969 0.76953-0.42578 1.6484-0.64062 2.6406-0.64062 0.96875 0 1.832 0.20312 2.5938 0.60938 0.75781 0.40625 1.3477 0.99219 1.7656 1.75 0.42578 0.75 0.64062 1.6328 0.64062 2.6406zm-3.1406-0.8125c0-0.51953-0.18359-0.9375-0.54688-1.25-0.35547-0.3125-0.80469-0.46875-1.3438-0.46875-0.52344 0-0.96094 0.15234-1.3125 0.45312-0.35547 0.29297-0.57422 0.71484-0.65625 1.2656z"/>
-</g>
-</g>
-<g clip-path="url(#i)">
-<g clip-path="url(#at)">
-<path d="m675.1 621.42h149.89v78.957h-149.89z" fill="#22a472"/>
-</g>
-</g>
-<g fill="#fffbf9">
-<g transform="translate(689.71 656.67)">
-<path d="m12.984-12.641-4.4844 12.641h-3.8594l-4.4844-12.641h3.2812l3.125 9.5469 3.1562-9.5469z"/>
-</g>
-<g transform="translate(702.85 656.67)">
-<path d="m11.031-10.047v10.047h-3.0781v-1.375c-0.3125 0.44922-0.73438 0.80859-1.2656 1.0781-0.53125 0.27344-1.125 0.40625-1.7812 0.40625-0.76172 0-1.4375-0.17188-2.0312-0.51562-0.58594-0.34375-1.0391-0.83594-1.3594-1.4844-0.32422-0.64453-0.48438-1.4062-0.48438-2.2812v-5.875h3.0625v5.4531c0 0.67969 0.17188 1.2031 0.51562 1.5781 0.34375 0.36719 0.8125 0.54688 1.4062 0.54688s1.0625-0.17969 1.4062-0.54688c0.35156-0.375 0.53125-0.89844 0.53125-1.5781v-5.4531z"/>
-</g>
-<g transform="translate(714.98 656.67)">
-<path d="m4.1875-13.312v13.312h-3.0781v-13.312z"/>
-</g>
-<g transform="translate(720.29 656.67)">
-<path d="m7.2344-10.156c1.1758 0 2.1133 0.38672 2.8125 1.1562 0.70703 0.76172 1.0625 1.8047 1.0625 3.125v5.875h-3.0625v-5.4531c0-0.67578-0.17969-1.1953-0.53125-1.5625-0.34375-0.375-0.80859-0.5625-1.3906-0.5625-0.59375 0-1.0703 0.1875-1.4219 0.5625-0.34375 0.36719-0.51562 0.88672-0.51562 1.5625v5.4531h-3.0781v-10.047h3.0781v1.3281c0.3125-0.4375 0.73438-0.78516 1.2656-1.0469 0.53125-0.25781 1.125-0.39062 1.7812-0.39062z"/>
-</g>
-<g transform="translate(732.42 656.67)">
-<path d="m10.578-5.1875c0 0.29297-0.015625 0.59375-0.046875 0.90625h-6.9688c0.050781 0.625 0.25391 1.1055 0.60938 1.4375 0.35156 0.32422 0.78516 0.48438 1.2969 0.48438 0.76953 0 1.3047-0.32031 1.6094-0.96875h3.2656c-0.16797 0.65625-0.46875 1.25-0.90625 1.7812s-0.99219 0.94922-1.6562 1.25c-0.65625 0.29297-1.3906 0.4375-2.2031 0.4375-0.98047 0-1.8555-0.20703-2.625-0.625-0.77344-0.41406-1.375-1.0156-1.8125-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344 0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0234-1.3789 1.7969-1.7969 0.76953-0.42578 1.6484-0.64062 2.6406-0.64062 0.96875 0 1.832 0.20312 2.5938 0.60938 0.75781 0.40625 1.3477 0.99219 1.7656 1.75 0.42578 0.75 0.64062 1.6328 0.64062 2.6406zm-3.1406-0.8125c0-0.51953-0.18359-0.9375-0.54688-1.25-0.35547-0.3125-0.80469-0.46875-1.3438-0.46875-0.52344 0-0.96094 0.15234-1.3125 0.45312-0.35547 0.29297-0.57422 0.71484-0.65625 1.2656z"/>
-</g>
-<g transform="translate(743.51 656.67)">
-<path d="m4.1875-8.375c0.36328-0.55078 0.81641-0.98438 1.3594-1.2969 0.53906-0.32031 1.1406-0.48438 1.7969-0.48438v3.2656h-0.84375c-0.77344 0-1.3516 0.16797-1.7344 0.5-0.38672 0.32422-0.57812 0.90234-0.57812 1.7344v4.6562h-3.0781v-10.047h3.0781z"/>
-</g>
-<g transform="translate(751.21 656.67)">
-<path d="m0.5-5.0469c0-1.0312 0.19141-1.9297 0.57812-2.7031 0.39453-0.78125 0.92578-1.3789 1.5938-1.7969 0.67578-0.42578 1.4297-0.64062 2.2656-0.64062 0.70703 0 1.3281 0.14844 1.8594 0.4375 0.53125 0.28125 0.94141 0.65625 1.2344 1.125v-1.4219h3.0781v10.047h-3.0781v-1.4219c-0.30469 0.46875-0.72656 0.85156-1.2656 1.1406-0.53125 0.28125-1.1523 0.42188-1.8594 0.42188-0.8125 0-1.5586-0.21094-2.2344-0.64062-0.66797-0.42578-1.1992-1.0312-1.5938-1.8125-0.38672-0.78125-0.57812-1.6914-0.57812-2.7344zm7.5312 0.03125c0-0.76953-0.21484-1.375-0.64062-1.8125-0.42969-0.44531-0.94922-0.67188-1.5625-0.67188-0.61719 0-1.1367 0.21875-1.5625 0.65625-0.41797 0.4375-0.625 1.0391-0.625 1.7969 0 0.77344 0.20703 1.3867 0.625 1.8438 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.42578-0.44531 0.64062-1.0508 0.64062-1.8125z"/>
-</g>
-<g transform="translate(763.44 656.67)">
-<path d="m4.1875-8.625c0.28906-0.46875 0.70703-0.84375 1.25-1.125 0.53906-0.28906 1.1602-0.4375 1.8594-0.4375 0.82031 0 1.5664 0.21484 2.2344 0.64062 0.67578 0.41797 1.207 1.0156 1.5938 1.7969 0.39453 0.77344 0.59375 1.6719 0.59375 2.7031 0 1.043-0.19922 1.9531-0.59375 2.7344-0.38672 0.78125-0.91797 1.3867-1.5938 1.8125-0.66797 0.42969-1.4141 0.64062-2.2344 0.64062-0.71094 0-1.3281-0.14062-1.8594-0.42188s-0.94922-0.65625-1.25-1.125v1.4062h-3.0781v-13.312h3.0781zm4.4062 3.5781c0-0.75781-0.21484-1.3594-0.64062-1.7969-0.42969-0.4375-0.95312-0.65625-1.5781-0.65625-0.61719 0-1.1367 0.22656-1.5625 0.67188-0.42969 0.4375-0.64062 1.043-0.64062 1.8125 0 0.76172 0.21094 1.3672 0.64062 1.8125 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.4375-0.45703 0.65625-1.0703 0.65625-1.8438z"/>
-</g>
-<g transform="translate(775.66 656.67)">
-<path d="m2.6562-11.094c-0.53125 0-0.96875-0.15625-1.3125-0.46875-0.34375-0.32031-0.51562-0.71875-0.51562-1.1875 0-0.47656 0.17188-0.875 0.51562-1.1875 0.34375-0.32031 0.78125-0.48438 1.3125-0.48438s0.96875 0.16406 1.3125 0.48438c0.34375 0.3125 0.51562 0.71094 0.51562 1.1875 0 0.46875-0.17188 0.86719-0.51562 1.1875-0.34375 0.3125-0.78125 0.46875-1.3125 0.46875zm1.5312 1.0469v10.047h-3.0781v-10.047z"/>
-</g>
-<g transform="translate(780.97 656.67)">
-<path d="m4.1875-13.312v13.312h-3.0781v-13.312z"/>
-</g>
-<g transform="translate(786.28 656.67)">
-<path d="m2.6562-11.094c-0.53125 0-0.96875-0.15625-1.3125-0.46875-0.34375-0.32031-0.51562-0.71875-0.51562-1.1875 0-0.47656 0.17188-0.875 0.51562-1.1875 0.34375-0.32031 0.78125-0.48438 1.3125-0.48438s0.96875 0.16406 1.3125 0.48438c0.34375 0.3125 0.51562 0.71094 0.51562 1.1875 0 0.46875-0.17188 0.86719-0.51562 1.1875-0.34375 0.3125-0.78125 0.46875-1.3125 0.46875zm1.5312 1.0469v10.047h-3.0781v-10.047z"/>
-</g>
-<g transform="translate(791.59 656.67)">
-<path d="m6.7188-2.6094v2.6094h-1.5781c-1.1172 0-1.9844-0.26953-2.6094-0.8125-0.61719-0.55078-0.92188-1.4414-0.92188-2.6719v-4h-1.2344v-2.5625h1.2344v-2.4375h3.0781v2.4375h2.0156v2.5625h-2.0156v4.0312c0 0.30469 0.066406 0.52344 0.20312 0.65625 0.14453 0.125 0.38281 0.1875 0.71875 0.1875z"/>
-</g>
-<g transform="translate(798.9 656.67)">
-<path d="m11.375-10.047-6.2969 14.812h-3.3125l2.2969-5.1094-4.0781-9.7031h3.4375l2.3125 6.2812 2.3125-6.2812z"/>
-</g>
-<g transform="translate(686.99 676.92)">
-<path d="m15.422-12.641v12.641h-3.0781v-7.5781l-2.8281 7.5781h-2.4844l-2.8438-7.5938v7.5938h-3.0781v-12.641h3.6406l3.5469 8.75 3.5156-8.75z"/>
-</g>
-<g transform="translate(703.51 676.92)">
-<path d="m0.5-5.0469c0-1.0312 0.19141-1.9297 0.57812-2.7031 0.39453-0.78125 0.92578-1.3789 1.5938-1.7969 0.67578-0.42578 1.4297-0.64062 2.2656-0.64062 0.70703 0 1.3281 0.14844 1.8594 0.4375 0.53125 0.28125 0.94141 0.65625 1.2344 1.125v-1.4219h3.0781v10.047h-3.0781v-1.4219c-0.30469 0.46875-0.72656 0.85156-1.2656 1.1406-0.53125 0.28125-1.1523 0.42188-1.8594 0.42188-0.8125 0-1.5586-0.21094-2.2344-0.64062-0.66797-0.42578-1.1992-1.0312-1.5938-1.8125-0.38672-0.78125-0.57812-1.6914-0.57812-2.7344zm7.5312 0.03125c0-0.76953-0.21484-1.375-0.64062-1.8125-0.42969-0.44531-0.94922-0.67188-1.5625-0.67188-0.61719 0-1.1367 0.21875-1.5625 0.65625-0.41797 0.4375-0.625 1.0391-0.625 1.7969 0 0.77344 0.20703 1.3867 0.625 1.8438 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.42578-0.44531 0.64062-1.0508 0.64062-1.8125z"/>
-</g>
-<g transform="translate(715.74 676.92)">
-<path d="m7.2344-10.156c1.1758 0 2.1133 0.38672 2.8125 1.1562 0.70703 0.76172 1.0625 1.8047 1.0625 3.125v5.875h-3.0625v-5.4531c0-0.67578-0.17969-1.1953-0.53125-1.5625-0.34375-0.375-0.80859-0.5625-1.3906-0.5625-0.59375 0-1.0703 0.1875-1.4219 0.5625-0.34375 0.36719-0.51562 0.88672-0.51562 1.5625v5.4531h-3.0781v-10.047h3.0781v1.3281c0.3125-0.4375 0.73438-0.78516 1.2656-1.0469 0.53125-0.25781 1.125-0.39062 1.7812-0.39062z"/>
-</g>
-<g transform="translate(727.87 676.92)">
-<path d="m0.5-5.0469c0-1.0312 0.19141-1.9297 0.57812-2.7031 0.39453-0.78125 0.92578-1.3789 1.5938-1.7969 0.67578-0.42578 1.4297-0.64062 2.2656-0.64062 0.70703 0 1.3281 0.14844 1.8594 0.4375 0.53125 0.28125 0.94141 0.65625 1.2344 1.125v-1.4219h3.0781v10.047h-3.0781v-1.4219c-0.30469 0.46875-0.72656 0.85156-1.2656 1.1406-0.53125 0.28125-1.1523 0.42188-1.8594 0.42188-0.8125 0-1.5586-0.21094-2.2344-0.64062-0.66797-0.42578-1.1992-1.0312-1.5938-1.8125-0.38672-0.78125-0.57812-1.6914-0.57812-2.7344zm7.5312 0.03125c0-0.76953-0.21484-1.375-0.64062-1.8125-0.42969-0.44531-0.94922-0.67188-1.5625-0.67188-0.61719 0-1.1367 0.21875-1.5625 0.65625-0.41797 0.4375-0.625 1.0391-0.625 1.7969 0 0.77344 0.20703 1.3867 0.625 1.8438 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.42578-0.44531 0.64062-1.0508 0.64062-1.8125z"/>
-</g>
-<g transform="translate(740.09 676.92)">
-<path d="m4.9375-10.188c0.70703 0 1.3281 0.14844 1.8594 0.4375 0.53125 0.28125 0.94141 0.65625 1.2344 1.125v-1.4219h3.0781v10.031c0 0.92578-0.18359 1.7656-0.54688 2.5156-0.36719 0.75-0.92188 1.3438-1.6719 1.7812-0.75 0.44531-1.6875 0.67188-2.8125 0.67188-1.4805 0-2.6836-0.35547-3.6094-1.0625-0.92969-0.69922-1.4609-1.6484-1.5938-2.8438h3.0469c0.09375 0.38281 0.31641 0.6875 0.67188 0.90625 0.36328 0.21875 0.8125 0.32812 1.3438 0.32812 0.63281 0 1.1406-0.18359 1.5156-0.54688 0.38281-0.36719 0.57812-0.94922 0.57812-1.75v-1.4219c-0.30469 0.46875-0.71875 0.85156-1.25 1.1406-0.52344 0.29297-1.1367 0.4375-1.8438 0.4375-0.83594 0-1.5898-0.21094-2.2656-0.64062-0.66797-0.42578-1.1992-1.0312-1.5938-1.8125-0.38672-0.78125-0.57812-1.6914-0.57812-2.7344 0-1.0312 0.19141-1.9297 0.57812-2.7031 0.39453-0.78125 0.92578-1.3789 1.5938-1.7969 0.67578-0.42578 1.4297-0.64062 2.2656-0.64062zm3.0938 5.1719c0-0.76953-0.21484-1.375-0.64062-1.8125-0.42969-0.44531-0.94922-0.67188-1.5625-0.67188-0.61719 0-1.1367 0.21875-1.5625 0.65625-0.41797 0.4375-0.625 1.0391-0.625 1.7969 0 0.77344 0.20703 1.3867 0.625 1.8438 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.42578-0.44531 0.64062-1.0508 0.64062-1.8125z"/>
-</g>
-<g transform="translate(752.31 676.92)">
-<path d="m10.578-5.1875c0 0.29297-0.015625 0.59375-0.046875 0.90625h-6.9688c0.050781 0.625 0.25391 1.1055 0.60938 1.4375 0.35156 0.32422 0.78516 0.48438 1.2969 0.48438 0.76953 0 1.3047-0.32031 1.6094-0.96875h3.2656c-0.16797 0.65625-0.46875 1.25-0.90625 1.7812s-0.99219 0.94922-1.6562 1.25c-0.65625 0.29297-1.3906 0.4375-2.2031 0.4375-0.98047 0-1.8555-0.20703-2.625-0.625-0.77344-0.41406-1.375-1.0156-1.8125-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344 0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0234-1.3789 1.7969-1.7969 0.76953-0.42578 1.6484-0.64062 2.6406-0.64062 0.96875 0 1.832 0.20312 2.5938 0.60938 0.75781 0.40625 1.3477 0.99219 1.7656 1.75 0.42578 0.75 0.64062 1.6328 0.64062 2.6406zm-3.1406-0.8125c0-0.51953-0.18359-0.9375-0.54688-1.25-0.35547-0.3125-0.80469-0.46875-1.3438-0.46875-0.52344 0-0.96094 0.15234-1.3125 0.45312-0.35547 0.29297-0.57422 0.71484-0.65625 1.2656z"/>
-</g>
-<g transform="translate(763.4 676.92)">
-<path d="m13.938-10.156c1.2383 0 2.2266 0.38281 2.9688 1.1406 0.73828 0.75 1.1094 1.7969 1.1094 3.1406v5.875h-3.0625v-5.4531c0-0.64453-0.17188-1.1445-0.51562-1.5-0.33594-0.35156-0.80469-0.53125-1.4062-0.53125-0.60547 0-1.0781 0.17969-1.4219 0.53125-0.33594 0.35547-0.5 0.85547-0.5 1.5v5.4531h-3.0625v-5.4531c0-0.64453-0.17188-1.1445-0.51562-1.5-0.34375-0.35156-0.8125-0.53125-1.4062-0.53125-0.60547 0-1.0781 0.17969-1.4219 0.53125-0.34375 0.35547-0.51562 0.85547-0.51562 1.5v5.4531h-3.0781v-10.047h3.0781v1.2656c0.3125-0.41406 0.71875-0.75 1.2188-1 0.50781-0.25 1.082-0.375 1.7188-0.375 0.75781 0 1.4375 0.16406 2.0312 0.48438 0.59375 0.32422 1.0547 0.78906 1.3906 1.3906 0.34375-0.55078 0.81641-1 1.4219-1.3438 0.60156-0.35156 1.2578-0.53125 1.9688-0.53125z"/>
-</g>
-<g transform="translate(782.46 676.92)">
-<path d="m10.578-5.1875c0 0.29297-0.015625 0.59375-0.046875 0.90625h-6.9688c0.050781 0.625 0.25391 1.1055 0.60938 1.4375 0.35156 0.32422 0.78516 0.48438 1.2969 0.48438 0.76953 0 1.3047-0.32031 1.6094-0.96875h3.2656c-0.16797 0.65625-0.46875 1.25-0.90625 1.7812s-0.99219 0.94922-1.6562 1.25c-0.65625 0.29297-1.3906 0.4375-2.2031 0.4375-0.98047 0-1.8555-0.20703-2.625-0.625-0.77344-0.41406-1.375-1.0156-1.8125-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344 0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0234-1.3789 1.7969-1.7969 0.76953-0.42578 1.6484-0.64062 2.6406-0.64062 0.96875 0 1.832 0.20312 2.5938 0.60938 0.75781 0.40625 1.3477 0.99219 1.7656 1.75 0.42578 0.75 0.64062 1.6328 0.64062 2.6406zm-3.1406-0.8125c0-0.51953-0.18359-0.9375-0.54688-1.25-0.35547-0.3125-0.80469-0.46875-1.3438-0.46875-0.52344 0-0.96094 0.15234-1.3125 0.45312-0.35547 0.29297-0.57422 0.71484-0.65625 1.2656z"/>
-</g>
-<g transform="translate(793.55 676.92)">
-<path d="m7.2344-10.156c1.1758 0 2.1133 0.38672 2.8125 1.1562 0.70703 0.76172 1.0625 1.8047 1.0625 3.125v5.875h-3.0625v-5.4531c0-0.67578-0.17969-1.1953-0.53125-1.5625-0.34375-0.375-0.80859-0.5625-1.3906-0.5625-0.59375 0-1.0703 0.1875-1.4219 0.5625-0.34375 0.36719-0.51562 0.88672-0.51562 1.5625v5.4531h-3.0781v-10.047h3.0781v1.3281c0.3125-0.4375 0.73438-0.78516 1.2656-1.0469 0.53125-0.25781 1.125-0.39062 1.7812-0.39062z"/>
-</g>
-<g transform="translate(805.68 676.92)">
-<path d="m6.7188-2.6094v2.6094h-1.5781c-1.1172 0-1.9844-0.26953-2.6094-0.8125-0.61719-0.55078-0.92188-1.4414-0.92188-2.6719v-4h-1.2344v-2.5625h1.2344v-2.4375h3.0781v2.4375h2.0156v2.5625h-2.0156v4.0312c0 0.30469 0.066406 0.52344 0.20312 0.65625 0.14453 0.125 0.38281 0.1875 0.71875 0.1875z"/>
-</g>
-</g>
-<g clip-path="url(#bv)">
-<g clip-path="url(#af)">
-<path d="m833.15 621.42h140.34v78.957h-140.34z" fill="#22a472"/>
-</g>
-</g>
-<g fill="#fffbf9">
-<g transform="translate(861.62 656.67)">
-<path d="m4.1875-12.641v12.641h-3.0781v-12.641z"/>
-</g>
-<g transform="translate(866.93 656.67)">
-<path d="m7.2344-10.156c1.1758 0 2.1133 0.38672 2.8125 1.1562 0.70703 0.76172 1.0625 1.8047 1.0625 3.125v5.875h-3.0625v-5.4531c0-0.67578-0.17969-1.1953-0.53125-1.5625-0.34375-0.375-0.80859-0.5625-1.3906-0.5625-0.59375 0-1.0703 0.1875-1.4219 0.5625-0.34375 0.36719-0.51562 0.88672-0.51562 1.5625v5.4531h-3.0781v-10.047h3.0781v1.3281c0.3125-0.4375 0.73438-0.78516 1.2656-1.0469 0.53125-0.25781 1.125-0.39062 1.7812-0.39062z"/>
-</g>
-<g transform="translate(879.06 656.67)">
-<path d="m6.7188-2.6094v2.6094h-1.5781c-1.1172 0-1.9844-0.26953-2.6094-0.8125-0.61719-0.55078-0.92188-1.4414-0.92188-2.6719v-4h-1.2344v-2.5625h1.2344v-2.4375h3.0781v2.4375h2.0156v2.5625h-2.0156v4.0312c0 0.30469 0.066406 0.52344 0.20312 0.65625 0.14453 0.125 0.38281 0.1875 0.71875 0.1875z"/>
-</g>
-<g transform="translate(886.37 656.67)">
-<path d="m4.1875-8.375c0.36328-0.55078 0.81641-0.98438 1.3594-1.2969 0.53906-0.32031 1.1406-0.48438 1.7969-0.48438v3.2656h-0.84375c-0.77344 0-1.3516 0.16797-1.7344 0.5-0.38672 0.32422-0.57812 0.90234-0.57812 1.7344v4.6562h-3.0781v-10.047h3.0781z"/>
-</g>
-<g transform="translate(894.07 656.67)">
-<path d="m11.031-10.047v10.047h-3.0781v-1.375c-0.3125 0.44922-0.73438 0.80859-1.2656 1.0781-0.53125 0.27344-1.125 0.40625-1.7812 0.40625-0.76172 0-1.4375-0.17188-2.0312-0.51562-0.58594-0.34375-1.0391-0.83594-1.3594-1.4844-0.32422-0.64453-0.48438-1.4062-0.48438-2.2812v-5.875h3.0625v5.4531c0 0.67969 0.17188 1.2031 0.51562 1.5781 0.34375 0.36719 0.8125 0.54688 1.4062 0.54688s1.0625-0.17969 1.4062-0.54688c0.35156-0.375 0.53125-0.89844 0.53125-1.5781v-5.4531z"/>
-</g>
-<g transform="translate(906.2 656.67)">
-<path d="m5.2031 0.14062c-0.875 0-1.6562-0.14453-2.3438-0.4375-0.67969-0.30078-1.2188-0.71094-1.625-1.2344-0.39844-0.53125-0.61719-1.1172-0.65625-1.7656h3.0469c0.03125 0.35547 0.1875 0.64062 0.46875 0.85938 0.28906 0.21094 0.64844 0.3125 1.0781 0.3125 0.375 0 0.66406-0.070312 0.875-0.21875 0.21875-0.15625 0.32812-0.35156 0.32812-0.59375 0-0.28125-0.15234-0.48828-0.45312-0.625-0.30469-0.14453-0.78906-0.30078-1.4531-0.46875-0.71875-0.16406-1.3242-0.34375-1.8125-0.53125-0.48047-0.1875-0.89062-0.47656-1.2344-0.875-0.34375-0.40625-0.51562-0.95312-0.51562-1.6406 0-0.57031 0.15625-1.0938 0.46875-1.5625 0.32031-0.47656 0.78906-0.85156 1.4062-1.125 0.61328-0.28125 1.3477-0.42188 2.2031-0.42188 1.2578 0 2.25 0.3125 2.9688 0.9375 0.72656 0.625 1.1484 1.4531 1.2656 2.4844h-2.8438c-0.054688-0.35156-0.21094-0.62891-0.46875-0.82812-0.25-0.20703-0.58984-0.3125-1.0156-0.3125-0.35547 0-0.63281 0.074219-0.82812 0.21875-0.1875 0.13672-0.28125 0.32422-0.28125 0.5625 0 0.28125 0.14844 0.49609 0.45312 0.64062 0.3125 0.14844 0.78906 0.29297 1.4375 0.4375 0.73828 0.1875 1.3438 0.375 1.8125 0.5625s0.87891 0.49219 1.2344 0.90625c0.35156 0.41797 0.53516 0.96875 0.54688 1.6562 0 0.59375-0.16797 1.125-0.5 1.5938-0.32422 0.46094-0.79688 0.82031-1.4219 1.0781-0.61719 0.25781-1.3281 0.39062-2.1406 0.39062z"/>
-</g>
-<g transform="translate(916.25 656.67)">
-<path d="m2.6562-11.094c-0.53125 0-0.96875-0.15625-1.3125-0.46875-0.34375-0.32031-0.51562-0.71875-0.51562-1.1875 0-0.47656 0.17188-0.875 0.51562-1.1875 0.34375-0.32031 0.78125-0.48438 1.3125-0.48438s0.96875 0.16406 1.3125 0.48438c0.34375 0.3125 0.51562 0.71094 0.51562 1.1875 0 0.46875-0.17188 0.86719-0.51562 1.1875-0.34375 0.3125-0.78125 0.46875-1.3125 0.46875zm1.5312 1.0469v10.047h-3.0781v-10.047z"/>
-</g>
-<g transform="translate(921.56 656.67)">
-<path d="m5.6875 0.14062c-0.98047 0-1.8672-0.20703-2.6562-0.625-0.78125-0.41406-1.4023-1.0156-1.8594-1.7969-0.44922-0.78125-0.67188-1.6914-0.67188-2.7344 0-1.0312 0.22656-1.9375 0.6875-2.7188 0.45703-0.78906 1.082-1.3945 1.875-1.8125 0.78906-0.42578 1.6758-0.64062 2.6562-0.64062 0.98828 0 1.8789 0.21484 2.6719 0.64062 0.78906 0.41797 1.4102 1.0234 1.8594 1.8125 0.45703 0.78125 0.6875 1.6875 0.6875 2.7188s-0.23047 1.9453-0.6875 2.7344c-0.46094 0.78125-1.0898 1.3828-1.8906 1.7969-0.80469 0.41797-1.6953 0.625-2.6719 0.625zm0-2.6562c0.58203 0 1.082-0.21094 1.5-0.64062 0.41406-0.4375 0.625-1.0547 0.625-1.8594 0-0.8125-0.20312-1.4297-0.60938-1.8594-0.39844-0.4375-0.89062-0.65625-1.4844-0.65625s-1.0898 0.21484-1.4844 0.64062c-0.39844 0.42969-0.59375 1.0547-0.59375 1.875 0 0.80469 0.19141 1.4219 0.57812 1.8594 0.39453 0.42969 0.88281 0.64062 1.4688 0.64062z"/>
-</g>
-<g transform="translate(933.02 656.67)">
-<path d="m7.2344-10.156c1.1758 0 2.1133 0.38672 2.8125 1.1562 0.70703 0.76172 1.0625 1.8047 1.0625 3.125v5.875h-3.0625v-5.4531c0-0.67578-0.17969-1.1953-0.53125-1.5625-0.34375-0.375-0.80859-0.5625-1.3906-0.5625-0.59375 0-1.0703 0.1875-1.4219 0.5625-0.34375 0.36719-0.51562 0.88672-0.51562 1.5625v5.4531h-3.0781v-10.047h3.0781v1.3281c0.3125-0.4375 0.73438-0.78516 1.2656-1.0469 0.53125-0.25781 1.125-0.39062 1.7812-0.39062z"/>
-</g>
-<g transform="translate(858.98 676.92)">
-<path d="m0.5-5.0469c0-1.0312 0.19141-1.9297 0.57812-2.7031 0.39453-0.78125 0.92578-1.3789 1.5938-1.7969 0.67578-0.42578 1.4297-0.64062 2.2656-0.64062 0.65625 0 1.2539 0.14062 1.7969 0.42188 0.55078 0.27344 0.98438 0.64062 1.2969 1.1094v-4.6562h3.0781v13.312h-3.0781v-1.4375c-0.29297 0.48047-0.70312 0.86719-1.2344 1.1562-0.53125 0.28125-1.1523 0.42188-1.8594 0.42188-0.83594 0-1.5898-0.21094-2.2656-0.64062-0.66797-0.42578-1.1992-1.0312-1.5938-1.8125-0.38672-0.78125-0.57812-1.6914-0.57812-2.7344zm7.5312 0.03125c0-0.76953-0.21484-1.375-0.64062-1.8125-0.42969-0.44531-0.94922-0.67188-1.5625-0.67188-0.61719 0-1.1367 0.21875-1.5625 0.65625-0.41797 0.4375-0.625 1.0391-0.625 1.7969 0 0.77344 0.20703 1.3867 0.625 1.8438 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.42578-0.44531 0.64062-1.0508 0.64062-1.8125z"/>
-</g>
-<g transform="translate(871.2 676.92)">
-<path d="m10.578-5.1875c0 0.29297-0.015625 0.59375-0.046875 0.90625h-6.9688c0.050781 0.625 0.25391 1.1055 0.60938 1.4375 0.35156 0.32422 0.78516 0.48438 1.2969 0.48438 0.76953 0 1.3047-0.32031 1.6094-0.96875h3.2656c-0.16797 0.65625-0.46875 1.25-0.90625 1.7812s-0.99219 0.94922-1.6562 1.25c-0.65625 0.29297-1.3906 0.4375-2.2031 0.4375-0.98047 0-1.8555-0.20703-2.625-0.625-0.77344-0.41406-1.375-1.0156-1.8125-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344 0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0234-1.3789 1.7969-1.7969 0.76953-0.42578 1.6484-0.64062 2.6406-0.64062 0.96875 0 1.832 0.20312 2.5938 0.60938 0.75781 0.40625 1.3477 0.99219 1.7656 1.75 0.42578 0.75 0.64062 1.6328 0.64062 2.6406zm-3.1406-0.8125c0-0.51953-0.18359-0.9375-0.54688-1.25-0.35547-0.3125-0.80469-0.46875-1.3438-0.46875-0.52344 0-0.96094 0.15234-1.3125 0.45312-0.35547 0.29297-0.57422 0.71484-0.65625 1.2656z"/>
-</g>
-<g transform="translate(882.29 676.92)">
-<path d="m6.7188-2.6094v2.6094h-1.5781c-1.1172 0-1.9844-0.26953-2.6094-0.8125-0.61719-0.55078-0.92188-1.4414-0.92188-2.6719v-4h-1.2344v-2.5625h1.2344v-2.4375h3.0781v2.4375h2.0156v2.5625h-2.0156v4.0312c0 0.30469 0.066406 0.52344 0.20312 0.65625 0.14453 0.125 0.38281 0.1875 0.71875 0.1875z"/>
-</g>
-<g transform="translate(889.6 676.92)">
-<path d="m10.578-5.1875c0 0.29297-0.015625 0.59375-0.046875 0.90625h-6.9688c0.050781 0.625 0.25391 1.1055 0.60938 1.4375 0.35156 0.32422 0.78516 0.48438 1.2969 0.48438 0.76953 0 1.3047-0.32031 1.6094-0.96875h3.2656c-0.16797 0.65625-0.46875 1.25-0.90625 1.7812s-0.99219 0.94922-1.6562 1.25c-0.65625 0.29297-1.3906 0.4375-2.2031 0.4375-0.98047 0-1.8555-0.20703-2.625-0.625-0.77344-0.41406-1.375-1.0156-1.8125-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344 0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0234-1.3789 1.7969-1.7969 0.76953-0.42578 1.6484-0.64062 2.6406-0.64062 0.96875 0 1.832 0.20312 2.5938 0.60938 0.75781 0.40625 1.3477 0.99219 1.7656 1.75 0.42578 0.75 0.64062 1.6328 0.64062 2.6406zm-3.1406-0.8125c0-0.51953-0.18359-0.9375-0.54688-1.25-0.35547-0.3125-0.80469-0.46875-1.3438-0.46875-0.52344 0-0.96094 0.15234-1.3125 0.45312-0.35547 0.29297-0.57422 0.71484-0.65625 1.2656z"/>
-</g>
-<g transform="translate(900.69 676.92)">
-<path d="m0.5-5.0156c0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0195-1.3789 1.7812-1.7969 0.75781-0.42578 1.6328-0.64062 2.625-0.64062 1.2578 0 2.3125 0.33594 3.1562 1 0.84375 0.65625 1.3984 1.5859 1.6719 2.7812h-3.2812c-0.28125-0.76953-0.82031-1.1562-1.6094-1.1562-0.5625 0-1.0117 0.21875-1.3438 0.65625-0.33594 0.4375-0.5 1.0703-0.5 1.8906 0 0.8125 0.16406 1.4375 0.5 1.875 0.33203 0.4375 0.78125 0.65625 1.3438 0.65625 0.78906 0 1.3281-0.38281 1.6094-1.1562h3.2812c-0.27344 1.1797-0.83594 2.1055-1.6875 2.7812-0.84375 0.66797-1.8906 1-3.1406 1-0.99219 0-1.8672-0.20703-2.625-0.625-0.76172-0.41406-1.3555-1.0156-1.7812-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344z"/>
-</g>
-<g transform="translate(911.58 676.92)">
-<path d="m6.7188-2.6094v2.6094h-1.5781c-1.1172 0-1.9844-0.26953-2.6094-0.8125-0.61719-0.55078-0.92188-1.4414-0.92188-2.6719v-4h-1.2344v-2.5625h1.2344v-2.4375h3.0781v2.4375h2.0156v2.5625h-2.0156v4.0312c0 0.30469 0.066406 0.52344 0.20312 0.65625 0.14453 0.125 0.38281 0.1875 0.71875 0.1875z"/>
-</g>
-<g transform="translate(918.89 676.92)">
-<path d="m2.6562-11.094c-0.53125 0-0.96875-0.15625-1.3125-0.46875-0.34375-0.32031-0.51562-0.71875-0.51562-1.1875 0-0.47656 0.17188-0.875 0.51562-1.1875 0.34375-0.32031 0.78125-0.48438 1.3125-0.48438s0.96875 0.16406 1.3125 0.48438c0.34375 0.3125 0.51562 0.71094 0.51562 1.1875 0 0.46875-0.17188 0.86719-0.51562 1.1875-0.34375 0.3125-0.78125 0.46875-1.3125 0.46875zm1.5312 1.0469v10.047h-3.0781v-10.047z"/>
-</g>
-<g transform="translate(924.2 676.92)">
-<path d="m5.6875 0.14062c-0.98047 0-1.8672-0.20703-2.6562-0.625-0.78125-0.41406-1.4023-1.0156-1.8594-1.7969-0.44922-0.78125-0.67188-1.6914-0.67188-2.7344 0-1.0312 0.22656-1.9375 0.6875-2.7188 0.45703-0.78906 1.082-1.3945 1.875-1.8125 0.78906-0.42578 1.6758-0.64062 2.6562-0.64062 0.98828 0 1.8789 0.21484 2.6719 0.64062 0.78906 0.41797 1.4102 1.0234 1.8594 1.8125 0.45703 0.78125 0.6875 1.6875 0.6875 2.7188s-0.23047 1.9453-0.6875 2.7344c-0.46094 0.78125-1.0898 1.3828-1.8906 1.7969-0.80469 0.41797-1.6953 0.625-2.6719 0.625zm0-2.6562c0.58203 0 1.082-0.21094 1.5-0.64062 0.41406-0.4375 0.625-1.0547 0.625-1.8594 0-0.8125-0.20312-1.4297-0.60938-1.8594-0.39844-0.4375-0.89062-0.65625-1.4844-0.65625s-1.0898 0.21484-1.4844 0.64062c-0.39844 0.42969-0.59375 1.0547-0.59375 1.875 0 0.80469 0.19141 1.4219 0.57812 1.8594 0.39453 0.42969 0.88281 0.64062 1.4688 0.64062z"/>
-</g>
-<g transform="translate(935.66 676.92)">
-<path d="m7.2344-10.156c1.1758 0 2.1133 0.38672 2.8125 1.1562 0.70703 0.76172 1.0625 1.8047 1.0625 3.125v5.875h-3.0625v-5.4531c0-0.67578-0.17969-1.1953-0.53125-1.5625-0.34375-0.375-0.80859-0.5625-1.3906-0.5625-0.59375 0-1.0703 0.1875-1.4219 0.5625-0.34375 0.36719-0.51562 0.88672-0.51562 1.5625v5.4531h-3.0781v-10.047h3.0781v1.3281c0.3125-0.4375 0.73438-0.78516 1.2656-1.0469 0.53125-0.25781 1.125-0.39062 1.7812-0.39062z"/>
-</g>
-</g>
-<g clip-path="url(#ak)">
-<g clip-path="url(#bt)">
-<path d="m981.88 621.42h140.34v78.957h-140.34z" fill="#22a472"/>
-</g>
-</g>
-<g fill="#fffbf9">
-<g transform="translate(1013.2 656.67)">
-<path d="m12.422 0h-3.0781l-5.1562-7.7969v7.7969h-3.0781v-12.641h3.0781l5.1562 7.8281v-7.8281h3.0781z"/>
-</g>
-<g transform="translate(1026.7 656.67)">
-<path d="m10.578-5.1875c0 0.29297-0.015625 0.59375-0.046875 0.90625h-6.9688c0.050781 0.625 0.25391 1.1055 0.60938 1.4375 0.35156 0.32422 0.78516 0.48438 1.2969 0.48438 0.76953 0 1.3047-0.32031 1.6094-0.96875h3.2656c-0.16797 0.65625-0.46875 1.25-0.90625 1.7812s-0.99219 0.94922-1.6562 1.25c-0.65625 0.29297-1.3906 0.4375-2.2031 0.4375-0.98047 0-1.8555-0.20703-2.625-0.625-0.77344-0.41406-1.375-1.0156-1.8125-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344 0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0234-1.3789 1.7969-1.7969 0.76953-0.42578 1.6484-0.64062 2.6406-0.64062 0.96875 0 1.832 0.20312 2.5938 0.60938 0.75781 0.40625 1.3477 0.99219 1.7656 1.75 0.42578 0.75 0.64062 1.6328 0.64062 2.6406zm-3.1406-0.8125c0-0.51953-0.18359-0.9375-0.54688-1.25-0.35547-0.3125-0.80469-0.46875-1.3438-0.46875-0.52344 0-0.96094 0.15234-1.3125 0.45312-0.35547 0.29297-0.57422 0.71484-0.65625 1.2656z"/>
-</g>
-<g transform="translate(1037.8 656.67)">
-<path d="m6.7188-2.6094v2.6094h-1.5781c-1.1172 0-1.9844-0.26953-2.6094-0.8125-0.61719-0.55078-0.92188-1.4414-0.92188-2.6719v-4h-1.2344v-2.5625h1.2344v-2.4375h3.0781v2.4375h2.0156v2.5625h-2.0156v4.0312c0 0.30469 0.066406 0.52344 0.20312 0.65625 0.14453 0.125 0.38281 0.1875 0.71875 0.1875z"/>
-</g>
-<g transform="translate(1045.1 656.67)">
-<path d="m15.531-10.047-2.7188 10.047h-3.4062l-1.5781-6.5156-1.6406 6.5156h-3.375l-2.7344-10.047h3.0781l1.4219 7.1875 1.6875-7.1875h3.25l1.7188 7.1562 1.4062-7.1562z"/>
-</g>
-<g transform="translate(1060.7 656.67)">
-<path d="m5.6875 0.14062c-0.98047 0-1.8672-0.20703-2.6562-0.625-0.78125-0.41406-1.4023-1.0156-1.8594-1.7969-0.44922-0.78125-0.67188-1.6914-0.67188-2.7344 0-1.0312 0.22656-1.9375 0.6875-2.7188 0.45703-0.78906 1.082-1.3945 1.875-1.8125 0.78906-0.42578 1.6758-0.64062 2.6562-0.64062 0.98828 0 1.8789 0.21484 2.6719 0.64062 0.78906 0.41797 1.4102 1.0234 1.8594 1.8125 0.45703 0.78125 0.6875 1.6875 0.6875 2.7188s-0.23047 1.9453-0.6875 2.7344c-0.46094 0.78125-1.0898 1.3828-1.8906 1.7969-0.80469 0.41797-1.6953 0.625-2.6719 0.625zm0-2.6562c0.58203 0 1.082-0.21094 1.5-0.64062 0.41406-0.4375 0.625-1.0547 0.625-1.8594 0-0.8125-0.20312-1.4297-0.60938-1.8594-0.39844-0.4375-0.89062-0.65625-1.4844-0.65625s-1.0898 0.21484-1.4844 0.64062c-0.39844 0.42969-0.59375 1.0547-0.59375 1.875 0 0.80469 0.19141 1.4219 0.57812 1.8594 0.39453 0.42969 0.88281 0.64062 1.4688 0.64062z"/>
-</g>
-<g transform="translate(1072.2 656.67)">
-<path d="m4.1875-8.375c0.36328-0.55078 0.81641-0.98438 1.3594-1.2969 0.53906-0.32031 1.1406-0.48438 1.7969-0.48438v3.2656h-0.84375c-0.77344 0-1.3516 0.16797-1.7344 0.5-0.38672 0.32422-0.57812 0.90234-0.57812 1.7344v4.6562h-3.0781v-10.047h3.0781z"/>
-</g>
-<g transform="translate(1079.9 656.67)">
-<path d="m7.25 0-3.0625-4.2188v4.2188h-3.0781v-13.312h3.0781v7.3594l3.0469-4.0938h3.7969l-4.1719 5.0469 4.2031 5z"/>
-</g>
-<g transform="translate(1013.7 676.92)">
-<path d="m5.6875 0.125c-0.92969 0-1.7578-0.14844-2.4844-0.45312-0.73047-0.30078-1.3125-0.74219-1.75-1.3281-0.4375-0.58203-0.67188-1.2891-0.70312-2.125h3.2812c0.050781 0.46875 0.21094 0.82812 0.48438 1.0781 0.28125 0.24219 0.64062 0.35938 1.0781 0.35938 0.45703 0 0.81641-0.10156 1.0781-0.3125 0.26953-0.20703 0.40625-0.5 0.40625-0.875 0-0.3125-0.10938-0.56641-0.32812-0.76562-0.21094-0.20703-0.46484-0.375-0.76562-0.5-0.30469-0.13281-0.73438-0.28516-1.2969-0.45312-0.82422-0.25781-1.4961-0.51562-2.0156-0.76562-0.51172-0.25-0.95312-0.61719-1.3281-1.1094-0.36719-0.48828-0.54688-1.1289-0.54688-1.9219 0-1.1758 0.42188-2.0977 1.2656-2.7656 0.85156-0.66406 1.9688-1 3.3438-1 1.3828 0 2.5039 0.33594 3.3594 1 0.85156 0.66797 1.3125 1.5938 1.375 2.7812h-3.3438c-0.023437-0.40625-0.17188-0.72266-0.45312-0.95312-0.27344-0.23828-0.62109-0.35938-1.0469-0.35938-0.375 0-0.67969 0.10156-0.90625 0.29688-0.23047 0.19922-0.34375 0.48047-0.34375 0.84375 0 0.40625 0.19141 0.72656 0.57812 0.95312 0.38281 0.23047 0.98438 0.48047 1.7969 0.75 0.82031 0.27344 1.4883 0.53125 2 0.78125 0.50781 0.25 0.94531 0.62109 1.3125 1.1094 0.375 0.48047 0.5625 1.0938 0.5625 1.8438 0 0.71875-0.18359 1.375-0.54688 1.9688-0.36719 0.58594-0.89844 1.0547-1.5938 1.4062-0.69922 0.34375-1.5234 0.51562-2.4688 0.51562z"/>
-</g>
-<g transform="translate(1024.7 676.92)">
-<path d="m10.578-5.1875c0 0.29297-0.015625 0.59375-0.046875 0.90625h-6.9688c0.050781 0.625 0.25391 1.1055 0.60938 1.4375 0.35156 0.32422 0.78516 0.48438 1.2969 0.48438 0.76953 0 1.3047-0.32031 1.6094-0.96875h3.2656c-0.16797 0.65625-0.46875 1.25-0.90625 1.7812s-0.99219 0.94922-1.6562 1.25c-0.65625 0.29297-1.3906 0.4375-2.2031 0.4375-0.98047 0-1.8555-0.20703-2.625-0.625-0.77344-0.41406-1.375-1.0156-1.8125-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344 0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0234-1.3789 1.7969-1.7969 0.76953-0.42578 1.6484-0.64062 2.6406-0.64062 0.96875 0 1.832 0.20312 2.5938 0.60938 0.75781 0.40625 1.3477 0.99219 1.7656 1.75 0.42578 0.75 0.64062 1.6328 0.64062 2.6406zm-3.1406-0.8125c0-0.51953-0.18359-0.9375-0.54688-1.25-0.35547-0.3125-0.80469-0.46875-1.3438-0.46875-0.52344 0-0.96094 0.15234-1.3125 0.45312-0.35547 0.29297-0.57422 0.71484-0.65625 1.2656z"/>
-</g>
-<g transform="translate(1035.8 676.92)">
-<path d="m0.5-5.0156c0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0195-1.3789 1.7812-1.7969 0.75781-0.42578 1.6328-0.64062 2.625-0.64062 1.2578 0 2.3125 0.33594 3.1562 1 0.84375 0.65625 1.3984 1.5859 1.6719 2.7812h-3.2812c-0.28125-0.76953-0.82031-1.1562-1.6094-1.1562-0.5625 0-1.0117 0.21875-1.3438 0.65625-0.33594 0.4375-0.5 1.0703-0.5 1.8906 0 0.8125 0.16406 1.4375 0.5 1.875 0.33203 0.4375 0.78125 0.65625 1.3438 0.65625 0.78906 0 1.3281-0.38281 1.6094-1.1562h3.2812c-0.27344 1.1797-0.83594 2.1055-1.6875 2.7812-0.84375 0.66797-1.8906 1-3.1406 1-0.99219 0-1.8672-0.20703-2.625-0.625-0.76172-0.41406-1.3555-1.0156-1.7812-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344z"/>
-</g>
-<g transform="translate(1046.7 676.92)">
-<path d="m11.031-10.047v10.047h-3.0781v-1.375c-0.3125 0.44922-0.73438 0.80859-1.2656 1.0781-0.53125 0.27344-1.125 0.40625-1.7812 0.40625-0.76172 0-1.4375-0.17188-2.0312-0.51562-0.58594-0.34375-1.0391-0.83594-1.3594-1.4844-0.32422-0.64453-0.48438-1.4062-0.48438-2.2812v-5.875h3.0625v5.4531c0 0.67969 0.17188 1.2031 0.51562 1.5781 0.34375 0.36719 0.8125 0.54688 1.4062 0.54688s1.0625-0.17969 1.4062-0.54688c0.35156-0.375 0.53125-0.89844 0.53125-1.5781v-5.4531z"/>
-</g>
-<g transform="translate(1058.9 676.92)">
-<path d="m4.1875-8.375c0.36328-0.55078 0.81641-0.98438 1.3594-1.2969 0.53906-0.32031 1.1406-0.48438 1.7969-0.48438v3.2656h-0.84375c-0.77344 0-1.3516 0.16797-1.7344 0.5-0.38672 0.32422-0.57812 0.90234-0.57812 1.7344v4.6562h-3.0781v-10.047h3.0781z"/>
-</g>
-<g transform="translate(1066.6 676.92)">
-<path d="m2.6562-11.094c-0.53125 0-0.96875-0.15625-1.3125-0.46875-0.34375-0.32031-0.51562-0.71875-0.51562-1.1875 0-0.47656 0.17188-0.875 0.51562-1.1875 0.34375-0.32031 0.78125-0.48438 1.3125-0.48438s0.96875 0.16406 1.3125 0.48438c0.34375 0.3125 0.51562 0.71094 0.51562 1.1875 0 0.46875-0.17188 0.86719-0.51562 1.1875-0.34375 0.3125-0.78125 0.46875-1.3125 0.46875zm1.5312 1.0469v10.047h-3.0781v-10.047z"/>
-</g>
-<g transform="translate(1071.9 676.92)">
-<path d="m6.7188-2.6094v2.6094h-1.5781c-1.1172 0-1.9844-0.26953-2.6094-0.8125-0.61719-0.55078-0.92188-1.4414-0.92188-2.6719v-4h-1.2344v-2.5625h1.2344v-2.4375h3.0781v2.4375h2.0156v2.5625h-2.0156v4.0312c0 0.30469 0.066406 0.52344 0.20312 0.65625 0.14453 0.125 0.38281 0.1875 0.71875 0.1875z"/>
-</g>
-<g transform="translate(1079.2 676.92)">
-<path d="m11.375-10.047-6.2969 14.812h-3.3125l2.2969-5.1094-4.0781-9.7031h3.4375l2.3125 6.2812 2.3125-6.2812z"/>
-</g>
-</g>
-<g clip-path="url(#bc)">
-<g clip-path="url(#z)">
-<path d="m1130.6 621.42h140.34v78.957h-140.34z" fill="#22a472"/>
-</g>
-</g>
-<g fill="#fffbf9">
-<g transform="translate(1173 656.67)">
-<path d="m4.1406-12.641v7.5625c0 0.76172 0.17969 1.3438 0.54688 1.75 0.375 0.40625 0.92578 0.60938 1.6562 0.60938 0.71875 0 1.2656-0.20312 1.6406-0.60938 0.38281-0.40625 0.57812-0.98828 0.57812-1.75v-7.5625h3.0781v7.5469c0 1.125-0.24219 2.0781-0.71875 2.8594-0.48047 0.78125-1.125 1.3711-1.9375 1.7656-0.80469 0.39844-1.7031 0.59375-2.7031 0.59375s-1.8906-0.19141-2.6719-0.57812c-0.78125-0.39453-1.4023-0.98438-1.8594-1.7656-0.46094-0.78906-0.6875-1.75-0.6875-2.875v-7.5469z"/>
-</g>
-<g transform="translate(1185.7 656.67)">
-<path d="m5.2031 0.14062c-0.875 0-1.6562-0.14453-2.3438-0.4375-0.67969-0.30078-1.2188-0.71094-1.625-1.2344-0.39844-0.53125-0.61719-1.1172-0.65625-1.7656h3.0469c0.03125 0.35547 0.1875 0.64062 0.46875 0.85938 0.28906 0.21094 0.64844 0.3125 1.0781 0.3125 0.375 0 0.66406-0.070312 0.875-0.21875 0.21875-0.15625 0.32812-0.35156 0.32812-0.59375 0-0.28125-0.15234-0.48828-0.45312-0.625-0.30469-0.14453-0.78906-0.30078-1.4531-0.46875-0.71875-0.16406-1.3242-0.34375-1.8125-0.53125-0.48047-0.1875-0.89062-0.47656-1.2344-0.875-0.34375-0.40625-0.51562-0.95312-0.51562-1.6406 0-0.57031 0.15625-1.0938 0.46875-1.5625 0.32031-0.47656 0.78906-0.85156 1.4062-1.125 0.61328-0.28125 1.3477-0.42188 2.2031-0.42188 1.2578 0 2.25 0.3125 2.9688 0.9375 0.72656 0.625 1.1484 1.4531 1.2656 2.4844h-2.8438c-0.054688-0.35156-0.21094-0.62891-0.46875-0.82812-0.25-0.20703-0.58984-0.3125-1.0156-0.3125-0.35547 0-0.63281 0.074219-0.82812 0.21875-0.1875 0.13672-0.28125 0.32422-0.28125 0.5625 0 0.28125 0.14844 0.49609 0.45312 0.64062 0.3125 0.14844 0.78906 0.29297 1.4375 0.4375 0.73828 0.1875 1.3438 0.375 1.8125 0.5625s0.87891 0.49219 1.2344 0.90625c0.35156 0.41797 0.53516 0.96875 0.54688 1.6562 0 0.59375-0.16797 1.125-0.5 1.5938-0.32422 0.46094-0.79688 0.82031-1.4219 1.0781-0.61719 0.25781-1.3281 0.39062-2.1406 0.39062z"/>
-</g>
-<g transform="translate(1195.8 656.67)">
-<path d="m10.578-5.1875c0 0.29297-0.015625 0.59375-0.046875 0.90625h-6.9688c0.050781 0.625 0.25391 1.1055 0.60938 1.4375 0.35156 0.32422 0.78516 0.48438 1.2969 0.48438 0.76953 0 1.3047-0.32031 1.6094-0.96875h3.2656c-0.16797 0.65625-0.46875 1.25-0.90625 1.7812s-0.99219 0.94922-1.6562 1.25c-0.65625 0.29297-1.3906 0.4375-2.2031 0.4375-0.98047 0-1.8555-0.20703-2.625-0.625-0.77344-0.41406-1.375-1.0156-1.8125-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344 0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0234-1.3789 1.7969-1.7969 0.76953-0.42578 1.6484-0.64062 2.6406-0.64062 0.96875 0 1.832 0.20312 2.5938 0.60938 0.75781 0.40625 1.3477 0.99219 1.7656 1.75 0.42578 0.75 0.64062 1.6328 0.64062 2.6406zm-3.1406-0.8125c0-0.51953-0.18359-0.9375-0.54688-1.25-0.35547-0.3125-0.80469-0.46875-1.3438-0.46875-0.52344 0-0.96094 0.15234-1.3125 0.45312-0.35547 0.29297-0.57422 0.71484-0.65625 1.2656z"/>
-</g>
-<g transform="translate(1206.9 656.67)"/>
-<g transform="translate(1210.7 656.67)">
-<path d="m5.6875 0.14062c-0.98047 0-1.8672-0.20703-2.6562-0.625-0.78125-0.41406-1.4023-1.0156-1.8594-1.7969-0.44922-0.78125-0.67188-1.6914-0.67188-2.7344 0-1.0312 0.22656-1.9375 0.6875-2.7188 0.45703-0.78906 1.082-1.3945 1.875-1.8125 0.78906-0.42578 1.6758-0.64062 2.6562-0.64062 0.98828 0 1.8789 0.21484 2.6719 0.64062 0.78906 0.41797 1.4102 1.0234 1.8594 1.8125 0.45703 0.78125 0.6875 1.6875 0.6875 2.7188s-0.23047 1.9453-0.6875 2.7344c-0.46094 0.78125-1.0898 1.3828-1.8906 1.7969-0.80469 0.41797-1.6953 0.625-2.6719 0.625zm0-2.6562c0.58203 0 1.082-0.21094 1.5-0.64062 0.41406-0.4375 0.625-1.0547 0.625-1.8594 0-0.8125-0.20312-1.4297-0.60938-1.8594-0.39844-0.4375-0.89062-0.65625-1.4844-0.65625s-1.0898 0.21484-1.4844 0.64062c-0.39844 0.42969-0.59375 1.0547-0.59375 1.875 0 0.80469 0.19141 1.4219 0.57812 1.8594 0.39453 0.42969 0.88281 0.64062 1.4688 0.64062z"/>
-</g>
-<g transform="translate(1222.1 656.67)">
-<path d="m6.1562-7.4844h-1.6562v7.4844h-3.0781v-7.4844h-1.1094v-2.5625h1.1094v-0.28125c0-1.2383 0.35156-2.1758 1.0625-2.8125 0.70703-0.64453 1.7422-0.96875 3.1094-0.96875 0.22656 0 0.39844 0.007813 0.51562 0.015625v2.6094c-0.59375-0.03125-1.0117 0.058594-1.25 0.26562-0.24219 0.19922-0.35938 0.55859-0.35938 1.0781v0.09375h1.6562z"/>
-</g>
-<g transform="translate(1135 676.92)">
-<path d="m0.59375-6.3438c0-1.2383 0.26953-2.3477 0.8125-3.3281 0.53906-0.97656 1.2891-1.7383 2.25-2.2812 0.96875-0.55078 2.0664-0.82812 3.2969-0.82812 1.5 0 2.7812 0.39844 3.8438 1.1875 1.0703 0.79297 1.7852 1.8711 2.1406 3.2344h-3.375c-0.25-0.51953-0.60938-0.91406-1.0781-1.1875-0.46094-0.28125-0.98438-0.42188-1.5781-0.42188-0.94922 0-1.7188 0.33594-2.3125 1-0.58594 0.65625-0.875 1.5312-0.875 2.625 0 1.1055 0.28906 1.9922 0.875 2.6562 0.59375 0.65625 1.3633 0.98438 2.3125 0.98438 0.59375 0 1.1172-0.13281 1.5781-0.40625 0.46875-0.28125 0.82812-0.67969 1.0781-1.2031h3.375c-0.35547 1.3672-1.0703 2.4453-2.1406 3.2344-1.0625 0.78125-2.3438 1.1719-3.8438 1.1719-1.2305 0-2.3281-0.26953-3.2969-0.8125-0.96094-0.55078-1.7109-1.3125-2.25-2.2812-0.54297-0.97656-0.8125-2.0938-0.8125-3.3438z"/>
-</g>
-<g transform="translate(1148.7 676.92)">
-<path d="m4.1875-8.375c0.36328-0.55078 0.81641-0.98438 1.3594-1.2969 0.53906-0.32031 1.1406-0.48438 1.7969-0.48438v3.2656h-0.84375c-0.77344 0-1.3516 0.16797-1.7344 0.5-0.38672 0.32422-0.57812 0.90234-0.57812 1.7344v4.6562h-3.0781v-10.047h3.0781z"/>
-</g>
-<g transform="translate(1156.4 676.92)">
-<path d="m11.375-10.047-6.2969 14.812h-3.3125l2.2969-5.1094-4.0781-9.7031h3.4375l2.3125 6.2812 2.3125-6.2812z"/>
-</g>
-<g transform="translate(1167.8 676.92)">
-<path d="m4.1875-8.625c0.30078-0.46875 0.71875-0.84375 1.25-1.125 0.53125-0.28906 1.1484-0.4375 1.8594-0.4375 0.82031 0 1.5664 0.21484 2.2344 0.64062 0.67578 0.41797 1.207 1.0156 1.5938 1.7969 0.39453 0.77344 0.59375 1.6719 0.59375 2.7031 0 1.043-0.19922 1.9531-0.59375 2.7344-0.38672 0.78125-0.91797 1.3867-1.5938 1.8125-0.66797 0.42969-1.4141 0.64062-2.2344 0.64062-0.69922 0-1.3203-0.14062-1.8594-0.42188-0.53125-0.28906-0.94922-0.66406-1.25-1.125v6.1875h-3.0781v-14.828h3.0781zm4.4062 3.5781c0-0.75781-0.21484-1.3594-0.64062-1.7969-0.42969-0.4375-0.95312-0.65625-1.5781-0.65625-0.61719 0-1.1367 0.22656-1.5625 0.67188-0.42969 0.4375-0.64062 1.043-0.64062 1.8125 0 0.76172 0.21094 1.3672 0.64062 1.8125 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.4375-0.45703 0.65625-1.0703 0.65625-1.8438z"/>
-</g>
-<g transform="translate(1180 676.92)">
-<path d="m6.7188-2.6094v2.6094h-1.5781c-1.1172 0-1.9844-0.26953-2.6094-0.8125-0.61719-0.55078-0.92188-1.4414-0.92188-2.6719v-4h-1.2344v-2.5625h1.2344v-2.4375h3.0781v2.4375h2.0156v2.5625h-2.0156v4.0312c0 0.30469 0.066406 0.52344 0.20312 0.65625 0.14453 0.125 0.38281 0.1875 0.71875 0.1875z"/>
-</g>
-<g transform="translate(1187.3 676.92)">
-<path d="m5.6875 0.14062c-0.98047 0-1.8672-0.20703-2.6562-0.625-0.78125-0.41406-1.4023-1.0156-1.8594-1.7969-0.44922-0.78125-0.67188-1.6914-0.67188-2.7344 0-1.0312 0.22656-1.9375 0.6875-2.7188 0.45703-0.78906 1.082-1.3945 1.875-1.8125 0.78906-0.42578 1.6758-0.64062 2.6562-0.64062 0.98828 0 1.8789 0.21484 2.6719 0.64062 0.78906 0.41797 1.4102 1.0234 1.8594 1.8125 0.45703 0.78125 0.6875 1.6875 0.6875 2.7188s-0.23047 1.9453-0.6875 2.7344c-0.46094 0.78125-1.0898 1.3828-1.8906 1.7969-0.80469 0.41797-1.6953 0.625-2.6719 0.625zm0-2.6562c0.58203 0 1.082-0.21094 1.5-0.64062 0.41406-0.4375 0.625-1.0547 0.625-1.8594 0-0.8125-0.20312-1.4297-0.60938-1.8594-0.39844-0.4375-0.89062-0.65625-1.4844-0.65625s-1.0898 0.21484-1.4844 0.64062c-0.39844 0.42969-0.59375 1.0547-0.59375 1.875 0 0.80469 0.19141 1.4219 0.57812 1.8594 0.39453 0.42969 0.88281 0.64062 1.4688 0.64062z"/>
-</g>
-<g transform="translate(1198.8 676.92)">
-<path d="m4.9375-10.188c0.70703 0 1.3281 0.14844 1.8594 0.4375 0.53125 0.28125 0.94141 0.65625 1.2344 1.125v-1.4219h3.0781v10.031c0 0.92578-0.18359 1.7656-0.54688 2.5156-0.36719 0.75-0.92188 1.3438-1.6719 1.7812-0.75 0.44531-1.6875 0.67188-2.8125 0.67188-1.4805 0-2.6836-0.35547-3.6094-1.0625-0.92969-0.69922-1.4609-1.6484-1.5938-2.8438h3.0469c0.09375 0.38281 0.31641 0.6875 0.67188 0.90625 0.36328 0.21875 0.8125 0.32812 1.3438 0.32812 0.63281 0 1.1406-0.18359 1.5156-0.54688 0.38281-0.36719 0.57812-0.94922 0.57812-1.75v-1.4219c-0.30469 0.46875-0.71875 0.85156-1.25 1.1406-0.52344 0.29297-1.1367 0.4375-1.8438 0.4375-0.83594 0-1.5898-0.21094-2.2656-0.64062-0.66797-0.42578-1.1992-1.0312-1.5938-1.8125-0.38672-0.78125-0.57812-1.6914-0.57812-2.7344 0-1.0312 0.19141-1.9297 0.57812-2.7031 0.39453-0.78125 0.92578-1.3789 1.5938-1.7969 0.67578-0.42578 1.4297-0.64062 2.2656-0.64062zm3.0938 5.1719c0-0.76953-0.21484-1.375-0.64062-1.8125-0.42969-0.44531-0.94922-0.67188-1.5625-0.67188-0.61719 0-1.1367 0.21875-1.5625 0.65625-0.41797 0.4375-0.625 1.0391-0.625 1.7969 0 0.77344 0.20703 1.3867 0.625 1.8438 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.42578-0.44531 0.64062-1.0508 0.64062-1.8125z"/>
-</g>
-<g transform="translate(1211 676.92)">
-<path d="m4.1875-8.375c0.36328-0.55078 0.81641-0.98438 1.3594-1.2969 0.53906-0.32031 1.1406-0.48438 1.7969-0.48438v3.2656h-0.84375c-0.77344 0-1.3516 0.16797-1.7344 0.5-0.38672 0.32422-0.57812 0.90234-0.57812 1.7344v4.6562h-3.0781v-10.047h3.0781z"/>
-</g>
-<g transform="translate(1218.7 676.92)">
-<path d="m0.5-5.0469c0-1.0312 0.19141-1.9297 0.57812-2.7031 0.39453-0.78125 0.92578-1.3789 1.5938-1.7969 0.67578-0.42578 1.4297-0.64062 2.2656-0.64062 0.70703 0 1.3281 0.14844 1.8594 0.4375 0.53125 0.28125 0.94141 0.65625 1.2344 1.125v-1.4219h3.0781v10.047h-3.0781v-1.4219c-0.30469 0.46875-0.72656 0.85156-1.2656 1.1406-0.53125 0.28125-1.1523 0.42188-1.8594 0.42188-0.8125 0-1.5586-0.21094-2.2344-0.64062-0.66797-0.42578-1.1992-1.0312-1.5938-1.8125-0.38672-0.78125-0.57812-1.6914-0.57812-2.7344zm7.5312 0.03125c0-0.76953-0.21484-1.375-0.64062-1.8125-0.42969-0.44531-0.94922-0.67188-1.5625-0.67188-0.61719 0-1.1367 0.21875-1.5625 0.65625-0.41797 0.4375-0.625 1.0391-0.625 1.7969 0 0.77344 0.20703 1.3867 0.625 1.8438 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.42578-0.44531 0.64062-1.0508 0.64062-1.8125z"/>
-</g>
-<g transform="translate(1230.9 676.92)">
-<path d="m4.1875-8.625c0.30078-0.46875 0.71875-0.84375 1.25-1.125 0.53125-0.28906 1.1484-0.4375 1.8594-0.4375 0.82031 0 1.5664 0.21484 2.2344 0.64062 0.67578 0.41797 1.207 1.0156 1.5938 1.7969 0.39453 0.77344 0.59375 1.6719 0.59375 2.7031 0 1.043-0.19922 1.9531-0.59375 2.7344-0.38672 0.78125-0.91797 1.3867-1.5938 1.8125-0.66797 0.42969-1.4141 0.64062-2.2344 0.64062-0.69922 0-1.3203-0.14062-1.8594-0.42188-0.53125-0.28906-0.94922-0.66406-1.25-1.125v6.1875h-3.0781v-14.828h3.0781zm4.4062 3.5781c0-0.75781-0.21484-1.3594-0.64062-1.7969-0.42969-0.4375-0.95312-0.65625-1.5781-0.65625-0.61719 0-1.1367 0.22656-1.5625 0.67188-0.42969 0.4375-0.64062 1.043-0.64062 1.8125 0 0.76172 0.21094 1.3672 0.64062 1.8125 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.4375-0.45703 0.65625-1.0703 0.65625-1.8438z"/>
-</g>
-<g transform="translate(1243.2 676.92)">
-<path d="m7.2969-10.156c1.1445 0 2.0664 0.38672 2.7656 1.1562 0.69531 0.76172 1.0469 1.8047 1.0469 3.125v5.875h-3.0625v-5.4531c0-0.67578-0.17969-1.1953-0.53125-1.5625-0.34375-0.375-0.80859-0.5625-1.3906-0.5625-0.59375 0-1.0703 0.1875-1.4219 0.5625-0.34375 0.36719-0.51562 0.88672-0.51562 1.5625v5.4531h-3.0781v-13.312h3.0781v4.625c0.3125-0.44531 0.73828-0.80078 1.2812-1.0625 0.53906-0.26953 1.1484-0.40625 1.8281-0.40625z"/>
-</g>
-<g transform="translate(1255.3 676.92)">
-<path d="m11.375-10.047-6.2969 14.812h-3.3125l2.2969-5.1094-4.0781-9.7031h3.4375l2.3125 6.2812 2.3125-6.2812z"/>
-</g>
-</g>
-<g clip-path="url(#f)">
-<g clip-path="url(#j)">
-<path d="m1279.3 621.42h159.5v80.062h-159.5z" fill="#22a472"/>
-</g>
-</g>
-<g fill="#fffbf9">
-<g transform="translate(1316.4 656.67)">
-<path d="m0.59375-6.3438c0-1.2383 0.26953-2.3477 0.8125-3.3281 0.53906-0.97656 1.2891-1.7383 2.25-2.2812 0.96875-0.55078 2.0664-0.82812 3.2969-0.82812 1.5 0 2.7812 0.39844 3.8438 1.1875 1.0703 0.79297 1.7852 1.8711 2.1406 3.2344h-3.375c-0.25-0.51953-0.60938-0.91406-1.0781-1.1875-0.46094-0.28125-0.98438-0.42188-1.5781-0.42188-0.94922 0-1.7188 0.33594-2.3125 1-0.58594 0.65625-0.875 1.5312-0.875 2.625 0 1.1055 0.28906 1.9922 0.875 2.6562 0.59375 0.65625 1.3633 0.98438 2.3125 0.98438 0.59375 0 1.1172-0.13281 1.5781-0.40625 0.46875-0.28125 0.82812-0.67969 1.0781-1.2031h3.375c-0.35547 1.3672-1.0703 2.4453-2.1406 3.2344-1.0625 0.78125-2.3438 1.1719-3.8438 1.1719-1.2305 0-2.3281-0.26953-3.2969-0.8125-0.96094-0.55078-1.7109-1.3125-2.25-2.2812-0.54297-0.97656-0.8125-2.0938-0.8125-3.3438z"/>
-</g>
-<g transform="translate(1330.1 656.67)">
-<path d="m0.5-5.0469c0-1.0312 0.19141-1.9297 0.57812-2.7031 0.39453-0.78125 0.92578-1.3789 1.5938-1.7969 0.67578-0.42578 1.4297-0.64062 2.2656-0.64062 0.70703 0 1.3281 0.14844 1.8594 0.4375 0.53125 0.28125 0.94141 0.65625 1.2344 1.125v-1.4219h3.0781v10.047h-3.0781v-1.4219c-0.30469 0.46875-0.72656 0.85156-1.2656 1.1406-0.53125 0.28125-1.1523 0.42188-1.8594 0.42188-0.8125 0-1.5586-0.21094-2.2344-0.64062-0.66797-0.42578-1.1992-1.0312-1.5938-1.8125-0.38672-0.78125-0.57812-1.6914-0.57812-2.7344zm7.5312 0.03125c0-0.76953-0.21484-1.375-0.64062-1.8125-0.42969-0.44531-0.94922-0.67188-1.5625-0.67188-0.61719 0-1.1367 0.21875-1.5625 0.65625-0.41797 0.4375-0.625 1.0391-0.625 1.7969 0 0.77344 0.20703 1.3867 0.625 1.8438 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.42578-0.44531 0.64062-1.0508 0.64062-1.8125z"/>
-</g>
-<g transform="translate(1342.3 656.67)">
-<path d="m4.1875-8.625c0.30078-0.46875 0.71875-0.84375 1.25-1.125 0.53125-0.28906 1.1484-0.4375 1.8594-0.4375 0.82031 0 1.5664 0.21484 2.2344 0.64062 0.67578 0.41797 1.207 1.0156 1.5938 1.7969 0.39453 0.77344 0.59375 1.6719 0.59375 2.7031 0 1.043-0.19922 1.9531-0.59375 2.7344-0.38672 0.78125-0.91797 1.3867-1.5938 1.8125-0.66797 0.42969-1.4141 0.64062-2.2344 0.64062-0.69922 0-1.3203-0.14062-1.8594-0.42188-0.53125-0.28906-0.94922-0.66406-1.25-1.125v6.1875h-3.0781v-14.828h3.0781zm4.4062 3.5781c0-0.75781-0.21484-1.3594-0.64062-1.7969-0.42969-0.4375-0.95312-0.65625-1.5781-0.65625-0.61719 0-1.1367 0.22656-1.5625 0.67188-0.42969 0.4375-0.64062 1.043-0.64062 1.8125 0 0.76172 0.21094 1.3672 0.64062 1.8125 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.4375-0.45703 0.65625-1.0703 0.65625-1.8438z"/>
-</g>
-<g transform="translate(1354.5 656.67)">
-<path d="m0.5-5.0469c0-1.0312 0.19141-1.9297 0.57812-2.7031 0.39453-0.78125 0.92578-1.3789 1.5938-1.7969 0.67578-0.42578 1.4297-0.64062 2.2656-0.64062 0.70703 0 1.3281 0.14844 1.8594 0.4375 0.53125 0.28125 0.94141 0.65625 1.2344 1.125v-1.4219h3.0781v10.047h-3.0781v-1.4219c-0.30469 0.46875-0.72656 0.85156-1.2656 1.1406-0.53125 0.28125-1.1523 0.42188-1.8594 0.42188-0.8125 0-1.5586-0.21094-2.2344-0.64062-0.66797-0.42578-1.1992-1.0312-1.5938-1.8125-0.38672-0.78125-0.57812-1.6914-0.57812-2.7344zm7.5312 0.03125c0-0.76953-0.21484-1.375-0.64062-1.8125-0.42969-0.44531-0.94922-0.67188-1.5625-0.67188-0.61719 0-1.1367 0.21875-1.5625 0.65625-0.41797 0.4375-0.625 1.0391-0.625 1.7969 0 0.77344 0.20703 1.3867 0.625 1.8438 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.42578-0.44531 0.64062-1.0508 0.64062-1.8125z"/>
-</g>
-<g transform="translate(1366.7 656.67)">
-<path d="m0.5-5.0156c0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0195-1.3789 1.7812-1.7969 0.75781-0.42578 1.6328-0.64062 2.625-0.64062 1.2578 0 2.3125 0.33594 3.1562 1 0.84375 0.65625 1.3984 1.5859 1.6719 2.7812h-3.2812c-0.28125-0.76953-0.82031-1.1562-1.6094-1.1562-0.5625 0-1.0117 0.21875-1.3438 0.65625-0.33594 0.4375-0.5 1.0703-0.5 1.8906 0 0.8125 0.16406 1.4375 0.5 1.875 0.33203 0.4375 0.78125 0.65625 1.3438 0.65625 0.78906 0 1.3281-0.38281 1.6094-1.1562h3.2812c-0.27344 1.1797-0.83594 2.1055-1.6875 2.7812-0.84375 0.66797-1.8906 1-3.1406 1-0.99219 0-1.8672-0.20703-2.625-0.625-0.76172-0.41406-1.3555-1.0156-1.7812-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344z"/>
-</g>
-<g transform="translate(1377.6 656.67)">
-<path d="m2.6562-11.094c-0.53125 0-0.96875-0.15625-1.3125-0.46875-0.34375-0.32031-0.51562-0.71875-0.51562-1.1875 0-0.47656 0.17188-0.875 0.51562-1.1875 0.34375-0.32031 0.78125-0.48438 1.3125-0.48438s0.96875 0.16406 1.3125 0.48438c0.34375 0.3125 0.51562 0.71094 0.51562 1.1875 0 0.46875-0.17188 0.86719-0.51562 1.1875-0.34375 0.3125-0.78125 0.46875-1.3125 0.46875zm1.5312 1.0469v10.047h-3.0781v-10.047z"/>
-</g>
-<g transform="translate(1382.9 656.67)">
-<path d="m6.7188-2.6094v2.6094h-1.5781c-1.1172 0-1.9844-0.26953-2.6094-0.8125-0.61719-0.55078-0.92188-1.4414-0.92188-2.6719v-4h-1.2344v-2.5625h1.2344v-2.4375h3.0781v2.4375h2.0156v2.5625h-2.0156v4.0312c0 0.30469 0.066406 0.52344 0.20312 0.65625 0.14453 0.125 0.38281 0.1875 0.71875 0.1875z"/>
-</g>
-<g transform="translate(1390.2 656.67)">
-<path d="m11.375-10.047-6.2969 14.812h-3.3125l2.2969-5.1094-4.0781-9.7031h3.4375l2.3125 6.2812 2.3125-6.2812z"/>
-</g>
-<g transform="translate(1296 676.92)">
-<path d="m15.422-12.641v12.641h-3.0781v-7.5781l-2.8281 7.5781h-2.4844l-2.8438-7.5938v7.5938h-3.0781v-12.641h3.6406l3.5469 8.75 3.5156-8.75z"/>
-</g>
-<g transform="translate(1312.5 676.92)">
-<path d="m0.5-5.0469c0-1.0312 0.19141-1.9297 0.57812-2.7031 0.39453-0.78125 0.92578-1.3789 1.5938-1.7969 0.67578-0.42578 1.4297-0.64062 2.2656-0.64062 0.70703 0 1.3281 0.14844 1.8594 0.4375 0.53125 0.28125 0.94141 0.65625 1.2344 1.125v-1.4219h3.0781v10.047h-3.0781v-1.4219c-0.30469 0.46875-0.72656 0.85156-1.2656 1.1406-0.53125 0.28125-1.1523 0.42188-1.8594 0.42188-0.8125 0-1.5586-0.21094-2.2344-0.64062-0.66797-0.42578-1.1992-1.0312-1.5938-1.8125-0.38672-0.78125-0.57812-1.6914-0.57812-2.7344zm7.5312 0.03125c0-0.76953-0.21484-1.375-0.64062-1.8125-0.42969-0.44531-0.94922-0.67188-1.5625-0.67188-0.61719 0-1.1367 0.21875-1.5625 0.65625-0.41797 0.4375-0.625 1.0391-0.625 1.7969 0 0.77344 0.20703 1.3867 0.625 1.8438 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.42578-0.44531 0.64062-1.0508 0.64062-1.8125z"/>
-</g>
-<g transform="translate(1324.7 676.92)">
-<path d="m7.2344-10.156c1.1758 0 2.1133 0.38672 2.8125 1.1562 0.70703 0.76172 1.0625 1.8047 1.0625 3.125v5.875h-3.0625v-5.4531c0-0.67578-0.17969-1.1953-0.53125-1.5625-0.34375-0.375-0.80859-0.5625-1.3906-0.5625-0.59375 0-1.0703 0.1875-1.4219 0.5625-0.34375 0.36719-0.51562 0.88672-0.51562 1.5625v5.4531h-3.0781v-10.047h3.0781v1.3281c0.3125-0.4375 0.73438-0.78516 1.2656-1.0469 0.53125-0.25781 1.125-0.39062 1.7812-0.39062z"/>
-</g>
-<g transform="translate(1336.9 676.92)">
-<path d="m0.5-5.0469c0-1.0312 0.19141-1.9297 0.57812-2.7031 0.39453-0.78125 0.92578-1.3789 1.5938-1.7969 0.67578-0.42578 1.4297-0.64062 2.2656-0.64062 0.70703 0 1.3281 0.14844 1.8594 0.4375 0.53125 0.28125 0.94141 0.65625 1.2344 1.125v-1.4219h3.0781v10.047h-3.0781v-1.4219c-0.30469 0.46875-0.72656 0.85156-1.2656 1.1406-0.53125 0.28125-1.1523 0.42188-1.8594 0.42188-0.8125 0-1.5586-0.21094-2.2344-0.64062-0.66797-0.42578-1.1992-1.0312-1.5938-1.8125-0.38672-0.78125-0.57812-1.6914-0.57812-2.7344zm7.5312 0.03125c0-0.76953-0.21484-1.375-0.64062-1.8125-0.42969-0.44531-0.94922-0.67188-1.5625-0.67188-0.61719 0-1.1367 0.21875-1.5625 0.65625-0.41797 0.4375-0.625 1.0391-0.625 1.7969 0 0.77344 0.20703 1.3867 0.625 1.8438 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.42578-0.44531 0.64062-1.0508 0.64062-1.8125z"/>
-</g>
-<g transform="translate(1349.1 676.92)">
-<path d="m4.9375-10.188c0.70703 0 1.3281 0.14844 1.8594 0.4375 0.53125 0.28125 0.94141 0.65625 1.2344 1.125v-1.4219h3.0781v10.031c0 0.92578-0.18359 1.7656-0.54688 2.5156-0.36719 0.75-0.92188 1.3438-1.6719 1.7812-0.75 0.44531-1.6875 0.67188-2.8125 0.67188-1.4805 0-2.6836-0.35547-3.6094-1.0625-0.92969-0.69922-1.4609-1.6484-1.5938-2.8438h3.0469c0.09375 0.38281 0.31641 0.6875 0.67188 0.90625 0.36328 0.21875 0.8125 0.32812 1.3438 0.32812 0.63281 0 1.1406-0.18359 1.5156-0.54688 0.38281-0.36719 0.57812-0.94922 0.57812-1.75v-1.4219c-0.30469 0.46875-0.71875 0.85156-1.25 1.1406-0.52344 0.29297-1.1367 0.4375-1.8438 0.4375-0.83594 0-1.5898-0.21094-2.2656-0.64062-0.66797-0.42578-1.1992-1.0312-1.5938-1.8125-0.38672-0.78125-0.57812-1.6914-0.57812-2.7344 0-1.0312 0.19141-1.9297 0.57812-2.7031 0.39453-0.78125 0.92578-1.3789 1.5938-1.7969 0.67578-0.42578 1.4297-0.64062 2.2656-0.64062zm3.0938 5.1719c0-0.76953-0.21484-1.375-0.64062-1.8125-0.42969-0.44531-0.94922-0.67188-1.5625-0.67188-0.61719 0-1.1367 0.21875-1.5625 0.65625-0.41797 0.4375-0.625 1.0391-0.625 1.7969 0 0.77344 0.20703 1.3867 0.625 1.8438 0.42578 0.44922 0.94531 0.67188 1.5625 0.67188 0.61328 0 1.1328-0.22266 1.5625-0.67188 0.42578-0.44531 0.64062-1.0508 0.64062-1.8125z"/>
-</g>
-<g transform="translate(1361.3 676.92)">
-<path d="m10.578-5.1875c0 0.29297-0.015625 0.59375-0.046875 0.90625h-6.9688c0.050781 0.625 0.25391 1.1055 0.60938 1.4375 0.35156 0.32422 0.78516 0.48438 1.2969 0.48438 0.76953 0 1.3047-0.32031 1.6094-0.96875h3.2656c-0.16797 0.65625-0.46875 1.25-0.90625 1.7812s-0.99219 0.94922-1.6562 1.25c-0.65625 0.29297-1.3906 0.4375-2.2031 0.4375-0.98047 0-1.8555-0.20703-2.625-0.625-0.77344-0.41406-1.375-1.0156-1.8125-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344 0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0234-1.3789 1.7969-1.7969 0.76953-0.42578 1.6484-0.64062 2.6406-0.64062 0.96875 0 1.832 0.20312 2.5938 0.60938 0.75781 0.40625 1.3477 0.99219 1.7656 1.75 0.42578 0.75 0.64062 1.6328 0.64062 2.6406zm-3.1406-0.8125c0-0.51953-0.18359-0.9375-0.54688-1.25-0.35547-0.3125-0.80469-0.46875-1.3438-0.46875-0.52344 0-0.96094 0.15234-1.3125 0.45312-0.35547 0.29297-0.57422 0.71484-0.65625 1.2656z"/>
-</g>
-<g transform="translate(1372.4 676.92)">
-<path d="m13.938-10.156c1.2383 0 2.2266 0.38281 2.9688 1.1406 0.73828 0.75 1.1094 1.7969 1.1094 3.1406v5.875h-3.0625v-5.4531c0-0.64453-0.17188-1.1445-0.51562-1.5-0.33594-0.35156-0.80469-0.53125-1.4062-0.53125-0.60547 0-1.0781 0.17969-1.4219 0.53125-0.33594 0.35547-0.5 0.85547-0.5 1.5v5.4531h-3.0625v-5.4531c0-0.64453-0.17188-1.1445-0.51562-1.5-0.34375-0.35156-0.8125-0.53125-1.4062-0.53125-0.60547 0-1.0781 0.17969-1.4219 0.53125-0.34375 0.35547-0.51562 0.85547-0.51562 1.5v5.4531h-3.0781v-10.047h3.0781v1.2656c0.3125-0.41406 0.71875-0.75 1.2188-1 0.50781-0.25 1.082-0.375 1.7188-0.375 0.75781 0 1.4375 0.16406 2.0312 0.48438 0.59375 0.32422 1.0547 0.78906 1.3906 1.3906 0.34375-0.55078 0.81641-1 1.4219-1.3438 0.60156-0.35156 1.2578-0.53125 1.9688-0.53125z"/>
-</g>
-<g transform="translate(1391.5 676.92)">
-<path d="m10.578-5.1875c0 0.29297-0.015625 0.59375-0.046875 0.90625h-6.9688c0.050781 0.625 0.25391 1.1055 0.60938 1.4375 0.35156 0.32422 0.78516 0.48438 1.2969 0.48438 0.76953 0 1.3047-0.32031 1.6094-0.96875h3.2656c-0.16797 0.65625-0.46875 1.25-0.90625 1.7812s-0.99219 0.94922-1.6562 1.25c-0.65625 0.29297-1.3906 0.4375-2.2031 0.4375-0.98047 0-1.8555-0.20703-2.625-0.625-0.77344-0.41406-1.375-1.0156-1.8125-1.7969-0.42969-0.78125-0.64062-1.6914-0.64062-2.7344 0-1.0508 0.21094-1.9609 0.64062-2.7344 0.42578-0.78125 1.0234-1.3789 1.7969-1.7969 0.76953-0.42578 1.6484-0.64062 2.6406-0.64062 0.96875 0 1.832 0.20312 2.5938 0.60938 0.75781 0.40625 1.3477 0.99219 1.7656 1.75 0.42578 0.75 0.64062 1.6328 0.64062 2.6406zm-3.1406-0.8125c0-0.51953-0.18359-0.9375-0.54688-1.25-0.35547-0.3125-0.80469-0.46875-1.3438-0.46875-0.52344 0-0.96094 0.15234-1.3125 0.45312-0.35547 0.29297-0.57422 0.71484-0.65625 1.2656z"/>
-</g>
-<g transform="translate(1402.6 676.92)">
-<path d="m7.2344-10.156c1.1758 0 2.1133 0.38672 2.8125 1.1562 0.70703 0.76172 1.0625 1.8047 1.0625 3.125v5.875h-3.0625v-5.4531c0-0.67578-0.17969-1.1953-0.53125-1.5625-0.34375-0.375-0.80859-0.5625-1.3906-0.5625-0.59375 0-1.0703 0.1875-1.4219 0.5625-0.34375 0.36719-0.51562 0.88672-0.51562 1.5625v5.4531h-3.0781v-10.047h3.0781v1.3281c0.3125-0.4375 0.73438-0.78516 1.2656-1.0469 0.53125-0.25781 1.125-0.39062 1.7812-0.39062z"/>
-</g>
-<g transform="translate(1414.7 676.92)">
-<path d="m6.7188-2.6094v2.6094h-1.5781c-1.1172 0-1.9844-0.26953-2.6094-0.8125-0.61719-0.55078-0.92188-1.4414-0.92188-2.6719v-4h-1.2344v-2.5625h1.2344v-2.4375h3.0781v2.4375h2.0156v2.5625h-2.0156v4.0312c0 0.30469 0.066406 0.52344 0.20312 0.65625 0.14453 0.125 0.38281 0.1875 0.71875 0.1875z"/>
-</g>
-</g>
-<path transform="matrix(0 .75 -.75 0 751.12 507.35)" d="m0.0016737 1.4985h150.59" fill="none" stroke="#3d516e" stroke-width="3"/>
-<path transform="matrix(0 .75 -.75 0 751.12 507.35)" d="m144.6-3.0015 6 4.5-6 4.5" fill="none" stroke="#3d516e" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
-<path transform="matrix(-.60816 .43891 -.43891 -.60816 750.65 508.26)" d="m5.4633e-5 1.4986 258.4 0.002009" fill="none" stroke="#3d516e" stroke-width="3"/>
-<path transform="matrix(-.60816 .43891 -.43891 -.60816 750.65 508.26)" d="m252.4-2.9984 6.0023 4.4989-6.0028 4.4995" fill="none" stroke="#3d516e" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
-<path transform="matrix(-.70514 .2555 -.2555 -.70514 750.37 508.41)" d="m7.0671e-4 1.4998 444.97 0.002803" fill="none" stroke="#3d516e" stroke-width="3"/>
-<path transform="matrix(-.70514 .2555 -.2555 -.70514 750.37 508.41)" d="m438.97-2.9991 6.0026 4.5016-5.9998 4.4958" fill="none" stroke="#3d516e" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
-<path transform="matrix(-.72856 .17807 -.17807 -.72856 750.26 508.44)" d="m9.25e-4 1.4982 639.12 6.95e-4" fill="none" stroke="#3d516e" stroke-width="3"/>
-<path transform="matrix(-.72856 .17807 -.17807 -.72856 750.26 508.44)" d="m633.12-3.0019 5.9988 4.5008-6.0006 4.5009" fill="none" stroke="#3d516e" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
-<path transform="matrix(-.7374 .13692 -.13692 -.7374 750.2 508.45)" d="m-0.0021492 1.4976 831.61 8.28e-4" fill="none" stroke="#3d516e" stroke-width="3"/>
-<path transform="matrix(-.7374 .13692 -.13692 -.7374 750.2 508.45)" d="m825.61-3.0013 6.0034 4.4998-6.0007 4.501" fill="none" stroke="#3d516e" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
-<g clip-path="url(#bd)">
-<g clip-path="url(#ae)">
-<path d="m47.199 764.32h1405.8v197.63h-1405.8z" fill="#b8d2ff"/>
-</g>
-</g>
-<g clip-path="url(#al)">
-<g clip-path="url(#bm)">
-<path d="m47.199 982.95h1405.7v192.75h-1405.7z" fill="#b8d2ff"/>
-</g>
-</g>
-<path d="m137.17 700.36 0.09375 9-3 0.03125-0.09375-9m3.1211 11.969 0.09375 9-3 0.027344-0.09375-9m3.1211 11.973 0.09375 8.9961-3 0.03125-0.089844-9m3.1211 11.969 0.089844 9-3 0.03125-0.089844-9m3.1211 11.969 0.089844 9-3 0.03125-0.089844-9m3.1211 11.969 0.089844 9-3 0.03125-0.089844-9m3.1211 11.969 0.089843 9-3 0.03125-0.089843-9m3.1211 11.969 0.09375 9-3 0.027344-0.09375-8.9961m3.1211 11.969 0.09375 8.9961-3 0.03125-0.09375-9m3.1211 11.969 0.09375 9-3 0.03125-0.089844-9m3.1211 11.969 0.089843 9-3 0.03125-0.089843-9m3.1211 11.969 0.046876 4.8438-3 0.03125-0.046876-4.8438" fill="#3d516e"/>
-<path d="m284.77 701.5-0.078125 9-3-0.027344 0.078125-9m2.8984 12.027-0.074219 9-3-0.027344 0.074219-9m2.8984 12.027-0.074218 8.9961-3-0.023438 0.074218-9m2.8984 12.023-0.074219 9-3-0.023438 0.074219-9m2.9023 12.023-0.078126 9-3-0.023438 0.078126-9m2.8984 12.023-0.074219 9-3-0.023438 0.074219-9m2.8984 12.023-0.074218 9-3-0.023438 0.074218-9m2.8984 12.023-0.074219 9-3-0.027344 0.074219-8.9961m2.9023 12.023-0.078125 9-3-0.027344 0.078125-9m2.8984 12.027-0.078125 9-3-0.027344 0.078125-9m2.8984 12.027-0.074219 9-3-0.027344 0.074219-9m2.8984 12.027-0.03125 3.7344-3-0.027344 0.03125-3.7344" fill="#3d516e"/>
-<path d="m72.906 780.96h344.99v42h-344.99v-42" fill="#b8d2ff"/>
-<g fill="#303b54">
-<g transform="translate(72.906 812.46)">
-<path d="m1.0469-10.5c0-2.0625 0.46094-3.9062 1.3906-5.5312 0.9375-1.6328 2.207-2.9062 3.8125-3.8125 1.6133-0.90625 3.4219-1.3594 5.4219-1.3594 2.3438 0 4.3906 0.60156 6.1406 1.7969 1.7578 1.1992 2.9922 2.8555 3.7031 4.9688h-4.8281c-0.49219-1-1.1719-1.75-2.0469-2.25-0.86719-0.5-1.8672-0.75-3-0.75-1.2188 0-2.3086 0.28906-3.2656 0.85938-0.94922 0.57422-1.6875 1.3828-2.2188 2.4219-0.52344 1.043-0.78125 2.2617-0.78125 3.6562 0 1.375 0.25781 2.5898 0.78125 3.6406 0.53125 1.0547 1.2695 1.8672 2.2188 2.4375 0.95703 0.57422 2.0469 0.85938 3.2656 0.85938 1.1328 0 2.1328-0.25391 3-0.76562 0.875-0.50781 1.5547-1.2656 2.0469-2.2656h4.8281c-0.71094 2.1367-1.9375 3.8047-3.6875 5-1.75 1.1875-3.8047 1.7812-6.1562 1.7812-2 0-3.8086-0.45312-5.4219-1.3594-1.6055-0.91406-2.875-2.1797-3.8125-3.7969-0.92969-1.625-1.3906-3.4688-1.3906-5.5312z"/>
-</g>
-<g transform="translate(95.937 812.46)">
-<path d="m9.4531 0.26562c-1.6055 0-3.0469-0.35156-4.3281-1.0625-1.2812-0.70703-2.2891-1.7109-3.0156-3.0156-0.73047-1.3008-1.0938-2.8008-1.0938-4.5 0-1.6953 0.375-3.1953 1.125-4.5 0.75-1.3008 1.7734-2.3047 3.0781-3.0156 1.3008-0.70703 2.75-1.0625 4.3438-1.0625 1.6016 0 3.0547 0.35547 4.3594 1.0625 1.3008 0.71094 2.3281 1.7148 3.0781 3.0156 0.75 1.3047 1.125 2.8047 1.125 4.5 0 1.6992-0.38672 3.1992-1.1562 4.5-0.77344 1.3047-1.8125 2.3086-3.125 3.0156-1.3125 0.71094-2.7773 1.0625-4.3906 1.0625zm0-3.6562c0.75781 0 1.4727-0.17969 2.1406-0.54688 0.66406-0.375 1.1953-0.92969 1.5938-1.6719 0.40625-0.73828 0.60938-1.6406 0.60938-2.7031 0-1.582-0.41797-2.7969-1.25-3.6406-0.82422-0.85156-1.8359-1.2812-3.0312-1.2812-1.2109 0-2.2188 0.42969-3.0312 1.2812-0.80469 0.84375-1.2031 2.0586-1.2031 3.6406 0 1.5859 0.39453 2.8047 1.1875 3.6562 0.78906 0.84375 1.7852 1.2656 2.9844 1.2656z"/>
-</g>
-<g transform="translate(115.07 812.46)">
-<path d="m22.703-16.859c2.0391 0 3.6875 0.625 4.9375 1.875s1.875 2.9961 1.875 5.2344v9.75h-4.2031v-9.1875c0-1.2891-0.32812-2.2812-0.98438-2.9688-0.65625-0.69531-1.5586-1.0469-2.7031-1.0469-1.1367 0-2.043 0.35156-2.7188 1.0469-0.66797 0.6875-1 1.6797-1 2.9688v9.1875h-4.2031v-9.1875c0-1.2891-0.32812-2.2812-0.98438-2.9688-0.65625-0.69531-1.5586-1.0469-2.7031-1.0469-1.1562 0-2.0742 0.35156-2.75 1.0469-0.66797 0.6875-1 1.6797-1 2.9688v9.1875h-4.2031v-16.625h4.2031v2.0156c0.53906-0.69531 1.2344-1.2422 2.0781-1.6406 0.85156-0.40625 1.7891-0.60938 2.8125-0.60938 1.3008 0 2.4609 0.27734 3.4844 0.82812 1.0195 0.55469 1.8125 1.3359 2.375 2.3438 0.53125-0.95703 1.3125-1.7227 2.3438-2.2969 1.0312-0.58203 2.1445-0.875 3.3438-0.875z"/>
-</g>
-<g transform="translate(146.5 812.46)">
-<path d="m6.2656-14.219c0.53906-0.75781 1.2852-1.3945 2.2344-1.9062 0.95703-0.50781 2.0469-0.76562 3.2656-0.76562 1.4141 0 2.6953 0.35156 3.8438 1.0469 1.1562 0.69922 2.0664 1.6953 2.7344 2.9844 0.66406 1.293 1 2.7891 1 4.4844 0 1.7109-0.33594 3.2188-1 4.5312-0.66797 1.3047-1.5781 2.3125-2.7344 3.0312-1.1484 0.71875-2.4297 1.0781-3.8438 1.0781-1.2188 0-2.2969-0.25-3.2344-0.75-0.92969-0.5-1.6836-1.1289-2.2656-1.8906v10.297h-4.2031v-24.547h4.2031zm8.7969 5.8438c0-1-0.21094-1.8633-0.625-2.5938-0.40625-0.72656-0.94922-1.2812-1.625-1.6562-0.66797-0.38281-1.3867-0.57812-2.1562-0.57812-0.76172 0-1.4805 0.19922-2.1562 0.59375-0.66797 0.38672-1.2109 0.94922-1.625 1.6875-0.40625 0.74219-0.60938 1.6094-0.60938 2.6094s0.20312 1.8711 0.60938 2.6094c0.41406 0.74219 0.95703 1.3086 1.625 1.7031 0.67578 0.38672 1.3945 0.57812 2.1562 0.57812 0.76953 0 1.4883-0.19531 2.1562-0.59375 0.67578-0.40625 1.2188-0.97656 1.625-1.7188 0.41406-0.73828 0.625-1.6172 0.625-2.6406z"/>
-</g>
-<g transform="translate(166.83 812.46)">
-<path d="m6.2656-22.203v22.203h-4.2031v-22.203z"/>
-</g>
-<g transform="translate(175.17 812.46)">
-<path d="m4.2031-18.594c-0.74219 0-1.3555-0.23438-1.8438-0.70312-0.49219-0.47656-0.73438-1.0664-0.73438-1.7656 0-0.69531 0.24219-1.2812 0.73438-1.75 0.48828-0.46875 1.1016-0.70312 1.8438-0.70312 0.73828 0 1.3516 0.23438 1.8438 0.70312 0.48828 0.46875 0.73438 1.0547 0.73438 1.75 0 0.69922-0.24609 1.2891-0.73438 1.7656-0.49219 0.46875-1.1055 0.70312-1.8438 0.70312zm2.0625 1.9688v16.625h-4.2031v-16.625z"/>
-</g>
-<g transform="translate(183.5 812.46)">
-<path d="m0.98438-8.375c0-1.6758 0.33203-3.1641 1-4.4688 0.67578-1.3008 1.5859-2.3008 2.7344-3 1.1562-0.69531 2.4414-1.0469 3.8594-1.0469 1.2383 0 2.3203 0.25 3.25 0.75 0.9375 0.5 1.6797 1.1328 2.2344 1.8906v-2.375h4.2344v16.625h-4.2344v-2.4375c-0.53125 0.78125-1.2773 1.4297-2.2344 1.9375-0.94922 0.50781-2.043 0.76562-3.2812 0.76562-1.3984 0-2.6719-0.35938-3.8281-1.0781-1.1484-0.71875-2.0586-1.7266-2.7344-3.0312-0.66797-1.3125-1-2.8203-1-4.5312zm13.078 0.0625c0-1.0195-0.19922-1.8945-0.59375-2.625-0.39844-0.72656-0.9375-1.2852-1.625-1.6719-0.67969-0.39453-1.4062-0.59375-2.1875-0.59375s-1.5 0.19531-2.1562 0.57812c-0.65625 0.375-1.1953 0.92969-1.6094 1.6562-0.40625 0.73047-0.60938 1.5938-0.60938 2.5938s0.20312 1.875 0.60938 2.625c0.41406 0.75 0.95703 1.3281 1.625 1.7344 0.66406 0.39844 1.3789 0.59375 2.1406 0.59375 0.78125 0 1.5078-0.19141 2.1875-0.57812 0.6875-0.39453 1.2266-0.95703 1.625-1.6875 0.39453-0.72656 0.59375-1.6016 0.59375-2.625z"/>
-</g>
-<g transform="translate(203.84 812.46)">
-<path d="m11.281-16.859c1.9766 0 3.5781 0.625 4.7969 1.875s1.8281 2.9961 1.8281 5.2344v9.75h-4.2031v-9.1875c0-1.3125-0.32812-2.3203-0.98438-3.0312-0.65625-0.71875-1.5586-1.0781-2.7031-1.0781-1.1562 0-2.0742 0.35938-2.75 1.0781-0.66797 0.71094-1 1.7188-1 3.0312v9.1875h-4.2031v-16.625h4.2031v2.0781c0.5625-0.71875 1.2734-1.2812 2.1406-1.6875 0.875-0.41406 1.832-0.625 2.875-0.625z"/>
-</g>
-<g transform="translate(223.66 812.46)">
-<path d="m6.9531-13.172v8.0469c0 0.55469 0.13281 0.95312 0.40625 1.2031 0.26953 0.25 0.72656 0.375 1.375 0.375h1.9531v3.5469h-2.6406c-3.543 0-5.3125-1.7188-5.3125-5.1562v-8.0156h-1.9844v-3.4531h1.9844v-4.1094h4.2188v4.1094h3.7344v3.4531z"/>
-</g>
-<g transform="translate(235.29 812.46)"/>
-<g transform="translate(242.43 812.46)">
-<path d="m13.891 0-7.625-9.3281v9.3281h-4.2031v-20.938h4.2031v9.3906l7.625-9.3906h5.0625l-8.6406 10.375 8.8906 10.562z"/>
-</g>
-<g transform="translate(262.31 812.46)">
-<path d="m17.766-16.625v16.625h-4.2344v-2.0938c-0.54297 0.71875-1.25 1.2812-2.125 1.6875-0.86719 0.40625-1.8086 0.60938-2.8281 0.60938-1.3047 0-2.4531-0.26953-3.4531-0.8125-1-0.55078-1.7891-1.3633-2.3594-2.4375-0.5625-1.0703-0.84375-2.3477-0.84375-3.8281v-9.75h4.2031v9.1562c0 1.3242 0.32812 2.3398 0.98438 3.0469 0.65625 0.71094 1.5547 1.0625 2.7031 1.0625 1.1562 0 2.0625-0.35156 2.7188-1.0625 0.66406-0.70703 1-1.7227 1-3.0469v-9.1562z"/>
-</g>
-<g transform="translate(282.14 812.46)">
-<path d="m6.2656-14.188c0.53906-0.80078 1.2852-1.4531 2.2344-1.9531 0.95703-0.5 2.0469-0.75 3.2656-0.75 1.4141 0 2.6953 0.35156 3.8438 1.0469 1.1562 0.69922 2.0664 1.6953 2.7344 2.9844 0.66406 1.293 1 2.7891 1 4.4844 0 1.7109-0.33594 3.2188-1 4.5312-0.66797 1.3047-1.5781 2.3125-2.7344 3.0312-1.1484 0.71875-2.4297 1.0781-3.8438 1.0781-1.2422 0-2.3281-0.24609-3.2656-0.73438-0.92969-0.48828-1.6719-1.125-2.2344-1.9062v2.375h-4.2031v-22.203h4.2031zm8.7969 5.8125c0-1-0.21094-1.8633-0.625-2.5938-0.40625-0.72656-0.94922-1.2812-1.625-1.6562-0.66797-0.38281-1.3867-0.57812-2.1562-0.57812-0.76172 0-1.4805 0.19922-2.1562 0.59375-0.66797 0.38672-1.2109 0.94922-1.625 1.6875-0.40625 0.74219-0.60938 1.6094-0.60938 2.6094s0.20312 1.8711 0.60938 2.6094c0.41406 0.74219 0.95703 1.3086 1.625 1.7031 0.67578 0.38672 1.3945 0.57812 2.1562 0.57812 0.76953 0 1.4883-0.19531 2.1562-0.59375 0.67578-0.40625 1.2188-0.97656 1.625-1.7188 0.41406-0.73828 0.625-1.6172 0.625-2.6406z"/>
-</g>
-<g transform="translate(302.47 812.46)">
-<path d="m17.516-8.6719c0 0.60547-0.039063 1.1484-0.10938 1.625h-12.156c0.10156 1.1992 0.52344 2.1406 1.2656 2.8281 0.73828 0.67969 1.6445 1.0156 2.7188 1.0156 1.5625 0 2.6719-0.67188 3.3281-2.0156h4.5312c-0.48047 1.6055-1.4023 2.9219-2.7656 3.9531-1.3555 1.0234-3.0234 1.5312-5 1.5312-1.5938 0-3.0273-0.35156-4.2969-1.0625-1.2734-0.70703-2.2656-1.7109-2.9844-3.0156-0.71094-1.3008-1.0625-2.8008-1.0625-4.5 0-1.7188 0.34766-3.2266 1.0469-4.5312 0.70703-1.3008 1.6914-2.3008 2.9531-3 1.2578-0.69531 2.707-1.0469 4.3438-1.0469 1.582 0 3 0.34375 4.25 1.0312 1.25 0.67969 2.2188 1.6406 2.9062 2.8906s1.0312 2.6836 1.0312 4.2969zm-4.3438-1.2031c-0.023437-1.0703-0.41406-1.9297-1.1719-2.5781-0.76172-0.65625-1.6953-0.98438-2.7969-0.98438-1.0312 0-1.9062 0.32031-2.625 0.95312-0.71094 0.625-1.1406 1.4961-1.2969 2.6094z"/>
-</g>
-<g transform="translate(320.97 812.46)">
-<path d="m6.2656-14.047c0.53906-0.875 1.2422-1.5625 2.1094-2.0625 0.875-0.5 1.875-0.75 3-0.75v4.4062h-1.1094c-1.3242 0-2.3242 0.3125-3 0.9375-0.66797 0.61719-1 1.6953-1 3.2344v8.2812h-4.2031v-16.625h4.2031z"/>
-</g>
-<g transform="translate(333.09 812.46)">
-<path d="m11.281-16.859c1.9766 0 3.5781 0.625 4.7969 1.875s1.8281 2.9961 1.8281 5.2344v9.75h-4.2031v-9.1875c0-1.3125-0.32812-2.3203-0.98438-3.0312-0.65625-0.71875-1.5586-1.0781-2.7031-1.0781-1.1562 0-2.0742 0.35938-2.75 1.0781-0.66797 0.71094-1 1.7188-1 3.0312v9.1875h-4.2031v-16.625h4.2031v2.0781c0.5625-0.71875 1.2734-1.2812 2.1406-1.6875 0.875-0.41406 1.832-0.625 2.875-0.625z"/>
-</g>
-<g transform="translate(352.91 812.46)">
-<path d="m17.516-8.6719c0 0.60547-0.039063 1.1484-0.10938 1.625h-12.156c0.10156 1.1992 0.52344 2.1406 1.2656 2.8281 0.73828 0.67969 1.6445 1.0156 2.7188 1.0156 1.5625 0 2.6719-0.67188 3.3281-2.0156h4.5312c-0.48047 1.6055-1.4023 2.9219-2.7656 3.9531-1.3555 1.0234-3.0234 1.5312-5 1.5312-1.5938 0-3.0273-0.35156-4.2969-1.0625-1.2734-0.70703-2.2656-1.7109-2.9844-3.0156-0.71094-1.3008-1.0625-2.8008-1.0625-4.5 0-1.7188 0.34766-3.2266 1.0469-4.5312 0.70703-1.3008 1.6914-2.3008 2.9531-3 1.2578-0.69531 2.707-1.0469 4.3438-1.0469 1.582 0 3 0.34375 4.25 1.0312 1.25 0.67969 2.2188 1.6406 2.9062 2.8906s1.0312 2.6836 1.0312 4.2969zm-4.3438-1.2031c-0.023437-1.0703-0.41406-1.9297-1.1719-2.5781-0.76172-0.65625-1.6953-0.98438-2.7969-0.98438-1.0312 0-1.9062 0.32031-2.625 0.95312-0.71094 0.625-1.1406 1.4961-1.2969 2.6094z"/>
-</g>
-<g transform="translate(371.41 812.46)">
-<path d="m6.9531-13.172v8.0469c0 0.55469 0.13281 0.95312 0.40625 1.2031 0.26953 0.25 0.72656 0.375 1.375 0.375h1.9531v3.5469h-2.6406c-3.543 0-5.3125-1.7188-5.3125-5.1562v-8.0156h-1.9844v-3.4531h1.9844v-4.1094h4.2188v4.1094h3.7344v3.4531z"/>
-</g>
-<g transform="translate(383.05 812.46)">
-<path d="m17.516-8.6719c0 0.60547-0.039063 1.1484-0.10938 1.625h-12.156c0.10156 1.1992 0.52344 2.1406 1.2656 2.8281 0.73828 0.67969 1.6445 1.0156 2.7188 1.0156 1.5625 0 2.6719-0.67188 3.3281-2.0156h4.5312c-0.48047 1.6055-1.4023 2.9219-2.7656 3.9531-1.3555 1.0234-3.0234 1.5312-5 1.5312-1.5938 0-3.0273-0.35156-4.2969-1.0625-1.2734-0.70703-2.2656-1.7109-2.9844-3.0156-0.71094-1.3008-1.0625-2.8008-1.0625-4.5 0-1.7188 0.34766-3.2266 1.0469-4.5312 0.70703-1.3008 1.6914-2.3008 2.9531-3 1.2578-0.69531 2.707-1.0469 4.3438-1.0469 1.582 0 3 0.34375 4.25 1.0312 1.25 0.67969 2.2188 1.6406 2.9062 2.8906s1.0312 2.6836 1.0312 4.2969zm-4.3438-1.2031c-0.023437-1.0703-0.41406-1.9297-1.1719-2.5781-0.76172-0.65625-1.6953-0.98438-2.7969-0.98438-1.0312 0-1.9062 0.32031-2.625 0.95312-0.71094 0.625-1.1406 1.4961-1.2969 2.6094z"/>
-</g>
-<g transform="translate(401.55 812.46)">
-<path d="m8.4375 0.26562c-1.3672 0-2.5898-0.24609-3.6719-0.73438-1.0742-0.48828-1.9297-1.1484-2.5625-1.9844-0.625-0.84375-0.96875-1.7734-1.0312-2.7969h4.2344c0.070312 0.63672 0.38281 1.168 0.9375 1.5938 0.55078 0.41797 1.2383 0.625 2.0625 0.625 0.78906 0 1.4102-0.15625 1.8594-0.46875 0.45703-0.32031 0.6875-0.73438 0.6875-1.2344 0-0.53906-0.27734-0.94531-0.82812-1.2188-0.55469-0.26953-1.4297-0.56641-2.625-0.89062-1.2422-0.30078-2.2578-0.60938-3.0469-0.92188-0.79297-0.32031-1.4766-0.8125-2.0469-1.4688-0.5625-0.66406-0.84375-1.5547-0.84375-2.6719 0-0.92578 0.26562-1.7656 0.79688-2.5156 0.53125-0.75781 1.2891-1.3594 2.2812-1.7969 0.98828-0.44531 2.1484-0.67188 3.4844-0.67188 1.9766 0 3.5547 0.49609 4.7344 1.4844 1.1875 0.99219 1.8359 2.3242 1.9531 4h-4.0156c-0.0625-0.65625-0.33984-1.1758-0.82812-1.5625-0.49219-0.39453-1.1406-0.59375-1.9531-0.59375-0.76172 0-1.3516 0.14062-1.7656 0.42188-0.40625 0.28125-0.60938 0.67188-0.60938 1.1719 0 0.5625 0.27344 0.99219 0.82812 1.2812 0.5625 0.28125 1.4375 0.57422 2.625 0.875 1.1953 0.30469 2.1875 0.61719 2.9688 0.9375 0.78125 0.3125 1.4531 0.80859 2.0156 1.4844 0.57031 0.66797 0.86719 1.5547 0.89062 2.6562 0 0.96094-0.26562 1.8203-0.79688 2.5781-0.53125 0.76172-1.293 1.3555-2.2812 1.7812-0.99219 0.42578-2.1406 0.64062-3.4531 0.64062z"/>
-</g>
-</g>
-<path d="m436.68 701.48v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v3.7305h-3v-3.7305" fill="#3d516e"/>
-<path d="m904.89 700.38 0.015625 9-3 0.007812-0.015625-9m3.0195 11.992 0.015625 9-3 0.007812-0.015625-9m3.0234 11.992 0.011718 9-3 0.007812-0.011718-9m3.0195 11.992 0.015625 9-3 0.007812-0.015625-9m3.0195 11.992 0.015625 9-3 0.007812-0.015625-9m3.0195 11.992 0.015625 9-3 0.007812-0.015625-9m3.0195 11.992 0.015626 9-3 0.007812-0.015626-9m3.0195 11.992 0.015625 9-3 0.007812-0.015625-9m3.0195 11.992 0.015625 9-3 0.007812-0.015625-9m3.0234 11.992 0.011719 9-3 0.007812-0.011719-9m3.0195 11.992 0.015625 9-3 0.007812-0.015625-9m3.0195 11.992 0.011719 6.8516-3 0.003907-0.011719-6.8477" fill="#3d516e"/>
-<path d="m1053.6 700.36 0.082031 9-3 0.027344-0.082031-9m3.1094 11.973 0.082032 9-3 0.027344-0.082032-9m3.1094 11.973 0.078125 9-3 0.027344-0.078125-9m3.1055 11.973 0.082031 9-3 0.027344-0.082031-9m3.1094 11.973 0.082031 9-3 0.023438-0.082031-8.9961m3.1094 11.969 0.078125 9-3 0.027344-0.078125-9m3.1055 11.973 0.082031 9-3 0.027344-0.082031-9m3.1094 11.973 0.082031 9-3 0.027344-0.082031-9m3.1094 11.973 0.078125 9-3 0.027344-0.078125-9m3.1055 11.973 0.082031 9-3 0.027344-0.082031-9m3.1094 11.973 0.082032 9-3 0.027344-0.082032-9m3.1094 11.973 0.042968 4.8398-3 0.027343-0.042968-4.8398" fill="#3d516e"/>
-<path d="m1202.3 700.36 0.11328 9-2.9961 0.035157-0.11328-9m3.1484 11.965 0.11328 8.9961-3 0.039063-0.11328-9m3.1523 11.961 0.11328 9-3 0.039063-0.11328-9m3.1523 11.961 0.11328 9-3 0.039063-0.11328-9m3.1484 11.961 0.11328 9-3 0.035156-0.11328-9m3.1523 11.965 0.11328 8.9961-3 0.039062-0.11328-9m3.1523 11.961 0.11328 9-3 0.039062-0.11328-9m3.1484 11.961 0.11328 9-3 0.039062-0.11328-9m3.1523 11.961 0.11328 9-3 0.035156-0.11328-9m3.1523 11.965 0.11328 8.9961-3 0.039063-0.11328-9m3.1484 11.961 0.11328 9-3 0.039063-0.11328-9m3.1523 11.961 0.03125 2.332-3 0.039062-0.03125-2.332" fill="#3d516e"/>
-<path d="m1360.5 701.48v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v3.7305h-3v-3.7305" fill="#3d516e"/>
-<g clip-path="url(#ax)">
-<g clip-path="url(#h)">
-<path d="m378.37 1056.9h86.004v75.145h-86.004z" fill="#192131"/>
-</g>
-</g>
-<path d="m1205.5 943.28v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v3.6758h-3v-3.6758" fill="#3d516e"/>
-<path d="m1362 943.28v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v3.6758h-3v-3.6758" fill="#3d516e"/>
-<path d="m1056.3 942.12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v3.6719h-3v-3.6719" fill="#3d516e"/>
-<path d="m906.68 943.28v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v3.6758h-3v-3.6758" fill="#3d516e"/>
-<path d="m594.94 942.27v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v3.6719h-3v-3.6719" fill="#3d516e"/>
-<path d="m436.68 942.27v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v3.6719h-3v-3.6719" fill="#3d516e"/>
-<path d="m281.83 943.28v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v3.6758h-3v-3.6758" fill="#3d516e"/>
-<path d="m136 942.27v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v3.6719h-3v-3.6719" fill="#3d516e"/>
-<path d="m1342.5 1194.2c-0.89062-0.16016-1.8047-0.24219-2.7266-0.24219-7.5781 0-15.91 5.4609-20.758 17.836 0.39062-0.59766 0.80078-1.168 1.2305-1.7109 3.3398-4.2188 7.6406-6.543 12.109-6.543 0.68359 0 1.3711 0.054688 2.0391 0.16797 4.4453 0.75391 7.7422 3.082 9.0469 6.3945 1.3281 3.375 0.44531 7.3438-2.4883 11.176-0.94531 1.2344-2.2461 2.3945-3.8945 3.4766 5.6172-2.1406 10.867-5 13.691-8.7109 8.0273-10.543 2.9297-19.852-8.25-21.844z" fill="#3d516e"/>
-<path d="m1339.6 1220.3c5.5703-7.2773 2.1406-13.625-5.5117-14.918-0.57422-0.097656-1.1641-0.14844-1.7617-0.14844-4.9023 0-10.32 3.3438-13.801 10.852 0.09375-0.11328 0.17969-0.23438 0.27344-0.34766 2.5469-3.0898 5.7461-4.793 9.0039-4.793 0.39453 0 0.79297 0.027344 1.1797 0.078125 3.1602 0.42578 5.5234 2.0195 6.4805 4.3711 0.59375 1.457 1.1289 4.4883-1.9531 8.4414-0.53906 0.69141-1.2266 1.3594-2.0586 1.9961 3.3633-1.4336 6.4102-3.2578 8.1484-5.5312z" fill="#3d516e"/>
-<g clip-path="url(#y)">
-<path d="m1332.2 1222.8c4.0078-5.1445 1.7969-9.4336-3.4375-10.145-0.3125-0.039063-0.63281-0.0625-0.95703-0.0625-5.0859 0-11.258 5.2891-12.719 17.641 0 0 13.105-2.293 17.113-7.4336z" fill="#3d516e"/>
-</g>
-<g clip-path="url(#aw)">
-<path d="m1363.9 1216.2c0.16797-1.2266 1.0586-1.7578 2.4297-1.7578 0.89062 0 1.6445 0.33594 1.6445 1.0859 0 0.75391-0.25 1.1445-1.1719 1.4492l-3.1523 1.0898zm-0.69531 5.3477v-0.33203l3.8477-1.3125c2.5938-0.89062 4.0195-1.9492 4.0195-4.625 0-2.1719-1.7031-3.6484-4.4648-3.6484-3.3477 0-5.582 1.8359-5.9414 4.3477l-0.67187 4.793c-0.050782 0.37891-0.078126 0.76172-0.082032 1.1445 0 2.2539 1.4766 3.6484 4.6875 3.6484h4.4102l0.41406-2.8477s-2.6484 0.007813-4.4062 0.007813c-1.2266 0-1.8125-0.39062-1.8125-1.1719zm15.164-15.109h-5.3086l-0.41797 2.8398h2.0156l-1.8633 13.441h-2.3203l-0.41797 2.8438h7.9219l0.42188-2.8438h-2.3125zm40.453-0.38281h-3.2891l-0.50391 3.5664h3.293l0.50391-3.5664zm-0.77734 5.5742h-5.332l-0.41797 2.8398h2.0391l-1.1445 8.25h-2.3164l-0.41797 2.8438h7.9492l0.41797-2.8438h-2.3398zm8.3086 0h-0.007812c-3.1523 0-5.6914 1.418-5.6914 4.1797 0 4.0391 5.5547 3.5391 5.5547 5.5977 0 1.1719-1.1719 1.3086-2.1758 1.3125-2.1758 0-4.1953-0.007813-4.1953-0.007813l-0.40234 2.8477s1.9219 0.003907 4.3242 0.003907c3.6836 0 5.8555-1.8438 5.8555-4.5742 0-4.1484-5.5781-3.7891-5.5781-5.5703 0-0.61328 0.64062-0.97656 2.0352-0.97656 1.5625 0 3.7344-0.011719 3.7344-0.011719l0.41016-2.8008zm-28.945-0.007813h-0.007812c-3.1523 0-5.6875 1.4297-5.6875 4.1875 0 4.0391 5.5508 3.5391 5.5508 5.6016 0 1.168-1.1719 1.3086-2.1758 1.3086-2.1719 0-4.1914-0.003907-4.1914-0.003907l-0.41406 2.8477s1.9336 0.003906 4.332 0.003906c3.6836 0 5.8594-1.8438 5.8594-4.5742 0-4.1523-5.582-3.7891-5.582-5.5742 0-0.61328 0.64062-0.97656 2.0352-0.97656 1.5625 0 3.7344-0.007813 3.7344-0.007813l0.41016-2.8047s-1.7188-0.003906-3.8633-0.007813zm51.531 0.007813h-0.003906c-3.1523 0-5.6914 1.418-5.6914 4.1797 0 4.0391 5.5508 3.5391 5.5508 5.5977 0 1.1719-1.168 1.3086-2.1719 1.3125-2.1758 0-4.1953-0.007813-4.1953-0.007813l-0.41797 2.8477s1.9375 0.003907 4.3359 0.003907c3.6836 0 5.8594-1.8438 5.8594-4.5742 0-4.1484-5.5781-3.7891-5.5781-5.5703 0-0.61328 0.64062-0.97656 2.0352-0.97656 1.5625 0 3.7344-0.011719 3.7344-0.011719l0.41016-2.8008zm-8.5938 0-4.2148 8.8047-1.7305-8.8047h-3.4883l2.9609 13.125-2.9297 5.8203h3.3203l9.5664-18.945h-3.4883zm-53.23 4.8477-0.67188 4.6797c-0.13672 0.94922-1.1719 1.5625-2.2852 1.5625-1.0352 0-1.7578-0.50391-1.7578-1.3672 0-0.33203 0.054687-0.72266 0.10937-1.1133l0.64453-4.207c0.16797-1.0586 1.1445-1.5859 2.2578-1.5859 1.0039 0 1.7578 0.52734 1.7578 1.3633 0 0.22266-0.027344 0.41797-0.054688 0.66797zm1.0039-4.8477-0.27734 1.0859s-0.94922-1.0938-2.8203-1.0938c-2.7031 0-4.7695 1.9023-5.1328 4.5195l-0.69531 4.9062c-0.027344 0.25-0.058594 0.52734-0.058594 0.75 0 2.3125 1.5898 3.7617 3.9609 3.7617 2.0117 0 3.0977-1.1406 3.0977-1.1406l-0.054687 1.1406h2.957l1.9805-13.93zm18.434 10.336c0-0.19531 0.054688-0.64062 0.082031-0.83594l0.94922-6.6836h2.6094l0.41797-2.8164h-2.6094l0.41797-3.0391h-3.2656l-0.41797 3.0391h-2.5391l-0.41797 2.8164h2.5391l-0.97656 6.9922c-0.054688 0.41797-0.10938 0.89062-0.10938 1.1719 0 2.0078 1.1719 2.957 4.0156 2.957 2.1211 0 2.2383-0.003906 2.2383-0.003906l0.38281-2.8438h-1.6992c-1.3125 0-1.6172-0.22266-1.6172-0.75z" fill="#3d516e"/>
-</g>
-<g fill="#3d516e">
-<g transform="translate(1169.9 1223.9)">
-<path d="m6.6562-2.1719c0.28906 0 0.56641-0.039063 0.82812-0.125 0.26953-0.082031 0.50391-0.20312 0.70312-0.35938 0.20703-0.16406 0.36328-0.35938 0.46875-0.57812 0.11328-0.21875 0.16406-0.46094 0.15625-0.73438h2.8125c0.007812 0.59375-0.11719 1.1523-0.375 1.6719-0.26172 0.51172-0.62109 0.95312-1.0781 1.3281-0.44922 0.375-0.96875 0.66797-1.5625 0.875s-1.2266 0.3125-1.8906 0.3125c-0.90625 0-1.7031-0.15234-2.3906-0.45312-0.67969-0.30078-1.2461-0.71875-1.7031-1.25-0.44922-0.53125-0.79297-1.1484-1.0312-1.8594-0.23047-0.71875-0.34375-1.4844-0.34375-2.2969v-0.32812c0-0.8125 0.11328-1.5703 0.34375-2.2812 0.22656-0.71875 0.57031-1.3438 1.0312-1.875 0.45703-0.53125 1.0234-0.94531 1.7031-1.25 0.67578-0.3125 1.4609-0.46875 2.3594-0.46875 0.71875 0 1.3789 0.10938 1.9844 0.32812 0.61328 0.21875 1.1406 0.52734 1.5781 0.92188 0.44531 0.38672 0.78906 0.85547 1.0312 1.4062 0.23828 0.55469 0.35156 1.1719 0.34375 1.8594h-2.8125c0.007812-0.28125-0.039062-0.55078-0.14062-0.8125-0.09375-0.25781-0.24219-0.48438-0.4375-0.67188-0.1875-0.1875-0.41797-0.33203-0.6875-0.4375-0.27344-0.11328-0.57031-0.17188-0.89062-0.17188-0.48047 0-0.875 0.10156-1.1875 0.29688-0.30469 0.1875-0.54688 0.44531-0.73438 0.76562-0.17969 0.32422-0.30469 0.69531-0.375 1.1094-0.074219 0.41797-0.10938 0.84375-0.10938 1.2812v0.32812c0 0.44922 0.03125 0.88672 0.09375 1.3125 0.070312 0.41797 0.19531 0.78906 0.375 1.1094 0.1875 0.3125 0.4375 0.57031 0.75 0.76562 0.3125 0.1875 0.70703 0.28125 1.1875 0.28125z"/>
-</g>
-<g transform="translate(1183.1 1223.9)">
-<path d="m9.8594-11.844c0.44531 0 0.86328 0.03125 1.25 0.09375 0.38281 0.0625 0.69531 0.13281 0.9375 0.20312l-0.4375 2.9688c-0.39844-0.09375-0.80469-0.16016-1.2188-0.20312-0.40625-0.050781-0.79688-0.078125-1.1719-0.078125-0.84375 0-1.5156 0.16406-2.0156 0.48438-0.5 0.32422-0.88281 0.78906-1.1406 1.3906v6.9844h-2.9844v-11.625h2.7812l0.14062 1.9062c0.47656-0.65625 1.0469-1.1719 1.7031-1.5469 0.65625-0.38281 1.375-0.57812 2.1562-0.57812z"/>
-</g>
-<g transform="translate(1196.3 1223.9)">
-<path d="m7.1562 0.21875c-0.89844 0-1.7109-0.14844-2.4375-0.4375-0.73047-0.30078-1.3594-0.70312-1.8906-1.2031-0.52344-0.50781-0.92188-1.1016-1.2031-1.7812-0.28125-0.6875-0.42188-1.4219-0.42188-2.2031v-0.42188c0-0.89453 0.14062-1.707 0.42188-2.4375 0.28125-0.73828 0.67188-1.3672 1.1719-1.8906 0.5-0.53125 1.0938-0.94141 1.7812-1.2344 0.6875-0.30078 1.4375-0.45312 2.25-0.45312 0.83203 0 1.5781 0.14062 2.2344 0.42188 0.65625 0.27344 1.207 0.66406 1.6562 1.1719 0.45703 0.5 0.80469 1.1055 1.0469 1.8125 0.23828 0.69922 0.35938 1.4766 0.35938 2.3281v1.2656h-7.8906c0.050781 0.39844 0.16406 0.75781 0.34375 1.0781 0.17578 0.32422 0.39844 0.60547 0.67188 0.84375 0.26953 0.24219 0.58203 0.42188 0.9375 0.54688 0.35156 0.125 0.73828 0.1875 1.1562 0.1875 0.28906 0 0.57812-0.023438 0.85938-0.078125 0.28906-0.0625 0.56641-0.14453 0.82812-0.25 0.26953-0.11328 0.51953-0.25391 0.75-0.42188 0.22656-0.16406 0.42969-0.35938 0.60938-0.57812l1.4844 1.6094c-0.17969 0.27344-0.41797 0.53906-0.71875 0.79688-0.30469 0.25-0.65625 0.47656-1.0625 0.67188-0.39844 0.1875-0.84375 0.34375-1.3438 0.46875-0.49219 0.125-1.0234 0.1875-1.5938 0.1875zm-0.35938-9.6406c-0.33594 0-0.64062 0.0625-0.92188 0.1875-0.28125 0.11719-0.52734 0.28125-0.73438 0.5-0.21094 0.21875-0.38672 0.48438-0.53125 0.79688-0.14844 0.30469-0.25781 0.64844-0.32812 1.0312h4.9062v-0.23438c-0.023438-0.3125-0.085938-0.60938-0.1875-0.89062-0.10547-0.28125-0.26172-0.51953-0.46875-0.71875-0.19922-0.20703-0.44531-0.36719-0.73438-0.48438-0.28125-0.125-0.61719-0.1875-1-0.1875z"/>
-</g>
-<g transform="translate(1209.5 1223.9)">
-<path d="m8.7812 0c-0.074219-0.14453-0.13672-0.3125-0.1875-0.5-0.054688-0.1875-0.09375-0.37891-0.125-0.57812-0.16797 0.17969-0.35938 0.34375-0.57812 0.5-0.21094 0.15625-0.44531 0.29688-0.70312 0.42188-0.26172 0.11719-0.55469 0.20312-0.875 0.26562-0.3125 0.070313-0.65234 0.10938-1.0156 0.10938-0.59375 0-1.1406-0.085938-1.6406-0.25-0.5-0.17578-0.92969-0.41406-1.2812-0.71875-0.35547-0.3125-0.63672-0.67969-0.84375-1.1094-0.19922-0.42578-0.29688-0.89062-0.29688-1.3906 0-1.2266 0.45312-2.1758 1.3594-2.8438 0.91406-0.66406 2.2812-1 4.0938-1h1.6719v-0.6875c0-0.5625-0.18359-1.0039-0.54688-1.3281-0.36719-0.33203-0.89062-0.5-1.5781-0.5-0.61719 0-1.0625 0.13672-1.3438 0.40625-0.27344 0.26172-0.40625 0.60547-0.40625 1.0312h-2.9844c0-0.48828 0.10938-0.95312 0.32812-1.3906 0.21875-0.44531 0.53516-0.83594 0.95312-1.1719 0.41406-0.34375 0.92578-0.61328 1.5312-0.8125 0.60156-0.19531 1.2969-0.29688 2.0781-0.29688 0.69531 0 1.3477 0.089844 1.9531 0.26562 0.61328 0.16797 1.1406 0.42188 1.5781 0.76562 0.44531 0.33594 0.79688 0.75781 1.0469 1.2656 0.25 0.51172 0.375 1.1055 0.375 1.7812v4.9844c0 0.625 0.035156 1.1406 0.10938 1.5469 0.082031 0.40625 0.20312 0.75781 0.35938 1.0469v0.1875zm-2.8438-2.0938c0.28906 0 0.56641-0.035156 0.82812-0.10938 0.25781-0.070313 0.49219-0.16406 0.70312-0.28125 0.20703-0.11328 0.38281-0.24219 0.53125-0.39062 0.15625-0.14453 0.27344-0.28906 0.35938-0.4375v-2h-1.5312c-0.46094 0-0.85547 0.046875-1.1875 0.14062-0.33594 0.085937-0.60547 0.21094-0.8125 0.375-0.21094 0.15625-0.36719 0.35156-0.46875 0.57812-0.09375 0.21875-0.14062 0.46484-0.14062 0.73438 0 0.39844 0.14062 0.73047 0.42188 1 0.28906 0.26172 0.72266 0.39062 1.2969 0.39062z"/>
-</g>
-<g transform="translate(1222.7 1223.9)">
-<path d="m7-14.469v2.8438h4.3281v2.2031h-4.3281v5c0 0.41797 0.046875 0.77344 0.14062 1.0625 0.09375 0.28125 0.22656 0.50781 0.40625 0.67188 0.1875 0.16797 0.40625 0.28906 0.65625 0.35938 0.25 0.074219 0.53516 0.10938 0.85938 0.10938 0.22656 0 0.46094-0.007812 0.70312-0.03125 0.23828-0.019531 0.46875-0.046875 0.6875-0.078125 0.21875-0.039063 0.42188-0.078125 0.60938-0.10938 0.1875-0.039062 0.34766-0.078125 0.48438-0.10938l0.29688 2.0469c-0.21094 0.125-0.45312 0.23438-0.73438 0.32812-0.28125 0.085938-0.57812 0.15234-0.89062 0.20312-0.3125 0.0625-0.64062 0.10938-0.98438 0.14062s-0.67969 0.046875-1 0.046875c-0.64844 0-1.2305-0.085938-1.75-0.25-0.51172-0.16406-0.95312-0.42578-1.3281-0.78125-0.36719-0.35156-0.65234-0.80078-0.85938-1.3438-0.19922-0.55078-0.29688-1.2109-0.29688-1.9844v-5.2812h-2.6406v-2.2031h2.6406v-2.8438z"/>
-</g>
-<g transform="translate(1235.9 1223.9)">
-<path d="m7.1562 0.21875c-0.89844 0-1.7109-0.14844-2.4375-0.4375-0.73047-0.30078-1.3594-0.70312-1.8906-1.2031-0.52344-0.50781-0.92188-1.1016-1.2031-1.7812-0.28125-0.6875-0.42188-1.4219-0.42188-2.2031v-0.42188c0-0.89453 0.14062-1.707 0.42188-2.4375 0.28125-0.73828 0.67188-1.3672 1.1719-1.8906 0.5-0.53125 1.0938-0.94141 1.7812-1.2344 0.6875-0.30078 1.4375-0.45312 2.25-0.45312 0.83203 0 1.5781 0.14062 2.2344 0.42188 0.65625 0.27344 1.207 0.66406 1.6562 1.1719 0.45703 0.5 0.80469 1.1055 1.0469 1.8125 0.23828 0.69922 0.35938 1.4766 0.35938 2.3281v1.2656h-7.8906c0.050781 0.39844 0.16406 0.75781 0.34375 1.0781 0.17578 0.32422 0.39844 0.60547 0.67188 0.84375 0.26953 0.24219 0.58203 0.42188 0.9375 0.54688 0.35156 0.125 0.73828 0.1875 1.1562 0.1875 0.28906 0 0.57812-0.023438 0.85938-0.078125 0.28906-0.0625 0.56641-0.14453 0.82812-0.25 0.26953-0.11328 0.51953-0.25391 0.75-0.42188 0.22656-0.16406 0.42969-0.35938 0.60938-0.57812l1.4844 1.6094c-0.17969 0.27344-0.41797 0.53906-0.71875 0.79688-0.30469 0.25-0.65625 0.47656-1.0625 0.67188-0.39844 0.1875-0.84375 0.34375-1.3438 0.46875-0.49219 0.125-1.0234 0.1875-1.5938 0.1875zm-0.35938-9.6406c-0.33594 0-0.64062 0.0625-0.92188 0.1875-0.28125 0.11719-0.52734 0.28125-0.73438 0.5-0.21094 0.21875-0.38672 0.48438-0.53125 0.79688-0.14844 0.30469-0.25781 0.64844-0.32812 1.0312h4.9062v-0.23438c-0.023438-0.3125-0.085938-0.60938-0.1875-0.89062-0.10547-0.28125-0.26172-0.51953-0.46875-0.71875-0.19922-0.20703-0.44531-0.36719-0.73438-0.48438-0.28125-0.125-0.61719-0.1875-1-0.1875z"/>
-</g>
-<g transform="translate(1249.1 1223.9)">
-<path d="m1.2031-5.8906c0-0.88281 0.097656-1.6914 0.29688-2.4219 0.20703-0.72656 0.50781-1.3516 0.90625-1.875 0.39453-0.53125 0.875-0.9375 1.4375-1.2188 0.5625-0.28906 1.2031-0.4375 1.9219-0.4375 0.61328 0 1.1484 0.10938 1.6094 0.32812 0.45703 0.21875 0.86719 0.53125 1.2344 0.9375v-5.9219h3v16.5h-2.7031l-0.15625-1.2188c-0.36719 0.46094-0.79688 0.8125-1.2969 1.0625-0.49219 0.25-1.0586 0.375-1.7031 0.375-0.71094 0-1.3438-0.14844-1.9062-0.4375-0.5625-0.30078-1.043-0.71094-1.4375-1.2344-0.38672-0.53125-0.68359-1.1562-0.89062-1.875-0.21094-0.71875-0.3125-1.5-0.3125-2.3438zm2.9844 0.21875c0 0.49219 0.039062 0.94531 0.125 1.3594 0.082031 0.41797 0.21875 0.78125 0.40625 1.0938s0.42578 0.55859 0.71875 0.73438c0.28906 0.17969 0.64844 0.26562 1.0781 0.26562 0.50781 0 0.92969-0.10938 1.2656-0.32812 0.34375-0.21875 0.61719-0.51953 0.82812-0.90625v-4.7188c-0.21094-0.38281-0.48047-0.6875-0.8125-0.90625-0.33594-0.21875-0.75781-0.32812-1.2656-0.32812-0.42969 0-0.79297 0.09375-1.0938 0.28125-0.29297 0.17969-0.53125 0.42969-0.71875 0.75-0.17969 0.3125-0.3125 0.68359-0.40625 1.1094-0.085938 0.42969-0.125 0.88672-0.125 1.375z"/>
-</g>
-<g transform="translate(1262.3 1223.9)"/>
-<g transform="translate(1275.5 1223.9)">
-<path d="m11.984-5.6875c0 0.86719-0.09375 1.6641-0.28125 2.3906-0.1875 0.71875-0.47656 1.3398-0.85938 1.8594-0.375 0.52344-0.85156 0.92969-1.4219 1.2188-0.5625 0.28906-1.2188 0.4375-1.9688 0.4375-0.67969 0-1.2656-0.125-1.7656-0.375-0.5-0.25781-0.92969-0.61719-1.2812-1.0781l-0.14062 1.2344h-2.6875v-16.5h2.9844v5.9219c0.34375-0.39453 0.75-0.70312 1.2188-0.92188 0.46875-0.22656 1.0195-0.34375 1.6562-0.34375 0.75781 0 1.4219 0.15234 1.9844 0.45312 0.57031 0.29297 1.0469 0.69922 1.4219 1.2188 0.38281 0.52344 0.67188 1.1484 0.85938 1.875 0.1875 0.73047 0.28125 1.5234 0.28125 2.375zm-2.9844-0.23438c0-0.46875-0.039062-0.91016-0.10938-1.3281-0.074219-0.42578-0.19922-0.80078-0.375-1.125-0.16797-0.32031-0.40234-0.57031-0.70312-0.75-0.30469-0.1875-0.67969-0.28125-1.125-0.28125-0.55469 0-1 0.11719-1.3438 0.34375-0.33594 0.23047-0.59375 0.54297-0.78125 0.9375v4.6406c0.1875 0.39844 0.44531 0.71094 0.78125 0.9375 0.34375 0.23047 0.79688 0.34375 1.3594 0.34375 0.44531 0 0.81641-0.085937 1.1094-0.26562 0.30078-0.17578 0.53516-0.41406 0.70312-0.71875 0.17578-0.3125 0.30078-0.67969 0.375-1.1094 0.070313-0.42578 0.10938-0.89062 0.10938-1.3906z"/>
-</g>
-<g transform="translate(1288.7 1223.9)">
-<path d="m6.4688-4.875 0.34375 1.25 3.0938-8h3.2969l-5.8906 13.359c-0.13672 0.30078-0.30859 0.625-0.51562 0.96875-0.19922 0.34375-0.45312 0.66016-0.76562 0.95312-0.30469 0.28906-0.67969 0.53516-1.125 0.73438-0.4375 0.19531-0.95312 0.29688-1.5469 0.29688-0.14844 0-0.28125-0.007812-0.40625-0.015625-0.125-0.011719-0.24609-0.027344-0.35938-0.046875-0.11719-0.011719-0.23047-0.03125-0.34375-0.0625-0.10547-0.023438-0.21875-0.046875-0.34375-0.078125l0.35938-2.2812c0.125 0 0.28125 0.003906 0.46875 0.015625 0.1875 0.007812 0.33594 0.015625 0.45312 0.015625 0.23828 0 0.44531-0.074219 0.625-0.21875 0.1875-0.13672 0.34375-0.29297 0.46875-0.46875 0.13281-0.16797 0.23828-0.32422 0.3125-0.46875 0.082031-0.14844 0.14062-0.21875 0.17188-0.21875l0.71875-1.3594-4.9219-11.125h3.2656z"/>
-</g>
-<g transform="translate(1301.9 1223.9)"/>
-</g>
-<path transform="matrix(.60182 .44756 -.44756 .60182 750.67 506.44)" d="m0.0016365 1.5018 253.38-0.00281" fill="none" stroke="#3d516e" stroke-width="3"/>
-<path transform="matrix(.60182 .44756 -.44756 .60182 750.67 506.44)" d="m247.38-3.0015 6.0016 4.5005-5.9996 4.5007" fill="none" stroke="#3d516e" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
-<path transform="matrix(.70165 .26493 -.26493 .70165 750.4 506.29)" d="m-7.2378e-4 1.498 429.08 9.56e-4" fill="none" stroke="#3d516e" stroke-width="3"/>
-<path transform="matrix(.70165 .26493 -.26493 .70165 750.4 506.29)" d="m423.08-3.0009 5.997 4.4999-5.9992 4.5032" fill="none" stroke="#3d516e" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
-<path transform="matrix(.72709 .18397 -.18397 .72709 750.28 506.25)" d="m-4.3923e-4 1.498 618.56 5e-6" fill="none" stroke="#3d516e" stroke-width="3"/>
-<path transform="matrix(.72709 .18397 -.18397 .72709 750.28 506.25)" d="m612.56-3.001 6.0004 4.4989-6.0014 4.5002" fill="none" stroke="#3d516e" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
-<path transform="matrix(.73718 .13808 -.13808 .73718 750.21 506.24)" d="m-3.1328e-4 1.4977 824.63 0.002244" fill="none" stroke="#3d516e" stroke-width="3"/>
-<path transform="matrix(.73718 .13808 -.13808 .73718 750.21 506.24)" d="m818.63-2.9986 5.9985 4.4986-5.9982 4.4989" fill="none" stroke="#3d516e" stroke-linecap="round" stroke-linejoin="round" stroke-width="3"/>
-<g clip-path="url(#au)">
-<g clip-path="url(#x)">
-<path d="m581.25 380.23h337.65v127.11h-337.65z" fill="#fb8ffc"/>
-</g>
-</g>
-<path d="m753 706.14v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9" fill="#3d516e"/>
-<path d="m593.44 701.48v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v4.2344h-3v-4.2344" fill="#3d516e"/>
-<path d="m751.5 943.28v9h-3v-9m3 12v9h-3v-9m3 12v9h-3v-9m3 12v3.6758h-3v-3.6758" fill="#3d516e"/>
-<g clip-path="url(#bq)">
-<g clip-path="url(#bx)">
-<path d="m719.55 142.5h88.781v59.656h-88.781z" fill="#cbff8b"/>
-</g>
-</g>
-<g clip-path="url(#br)">
-<g clip-path="url(#c)">
-<path d="m1069.3 125.99h147.2v37.129h-147.2z" fill="#cbff8b"/>
-</g>
-</g>
-<g clip-path="url(#ap)">
-<g clip-path="url(#e)">
-<path d="m1264.6 125.99h124.58v37.129h-124.58z" fill="#cbff8b"/>
-</g>
-</g>
-<g clip-path="url(#bz)">
-<g clip-path="url(#ar)">
-<path d="m1303 176.91h86.188v37.848h-86.188z" fill="#cbff8b"/>
-</g>
-</g>
-<path d="m157.79 874.87c1.2578-0.58594 2.4258-1.3125 3.5078-2.1758 1.082-0.86719 2.043-1.8516 2.8867-2.9492 0.83984-1.1016 1.5391-2.2812 2.0977-3.5508 0.55469-1.2656 0.95312-2.582 1.1875-3.9453-1.0312-2.3086-2.3047-4.4805-3.8125-6.5117s-3.2188-3.875-5.1328-5.5352c-1.9102-1.6562-3.9805-3.0898-6.207-4.2969-2.2266-1.207-4.5586-2.1602-6.9961-2.8594 1.6758 2.4062 2.9062 5.0234 3.6992 7.8438s1.1016 5.6953 0.92578 8.6172c1.1367 0.95703 2.1641 2.0156 3.0859 3.1758 0.91797 1.1602 1.7188 2.3984 2.3906 3.7188 0.67188 1.3164 1.207 2.6914 1.6055 4.1172 0.39844 1.4258 0.65234 2.875 0.76172 4.3516zm-41.719-8.875c-1.3711-0.17969-2.7461-0.1875-4.125-0.03125-1.375 0.15234-2.7148 0.46875-4.0117 0.94922-1.3008 0.47656-2.5234 1.1016-3.6719 1.875-1.1484 0.76953-2.1875 1.668-3.1211 2.6914-0.36719 2.5312-0.45312 5.0742-0.25781 7.625 0.19141 2.5508 0.66406 5.0508 1.4141 7.4961 0.75 2.4492 1.7578 4.7852 3.0234 7.0078 1.2695 2.2266 2.7617 4.2852 4.4883 6.1836-0.18359-2.9648 0.12891-5.875 0.92578-8.7305 0.80078-2.8594 2.0469-5.5078 3.7383-7.9492-0.44141-1.4062-0.74219-2.8438-0.89844-4.3125s-0.16797-2.9375-0.03125-4.4062 0.41797-2.9141 0.84375-4.3281c0.42578-1.4102 0.98828-2.7695 1.6836-4.0703zm3.9219 26.145c-0.51172 1.3672-0.84375 2.7773-0.99609 4.2266-0.15234 1.4531-0.12109 2.8984 0.097656 4.3438 0.21875 1.4414 0.61328 2.8359 1.1875 4.1758 0.57422 1.3438 1.3047 2.5938 2.1992 3.75 2.0938 0.85156 4.2539 1.4922 6.4727 1.9258 2.2227 0.43359 4.4648 0.64844 6.7266 0.64844 2.2617-0.003907 4.5039-0.22266 6.7227-0.66016 2.2227-0.4375 4.3789-1.082 6.4727-1.9375-2.7578-0.88281-5.2969-2.1797-7.625-3.8984-2.3242-1.7188-4.3125-3.7656-5.9609-6.1367-1.4219-0.023437-2.8281-0.17969-4.2188-0.47266-1.3945-0.29297-2.7461-0.71484-4.0547-1.2656-1.3125-0.55078-2.5586-1.2227-3.7383-2.0117-1.1797-0.78906-2.2773-1.6875-3.2852-2.6875zm20.566-37.277c-0.26172-1.4102-0.69531-2.7695-1.2969-4.0742-0.60547-1.3047-1.3633-2.5117-2.2695-3.6289-0.91016-1.1133-1.9453-2.0977-3.1016-2.957-1.1562-0.85547-2.4023-1.5547-3.7344-2.0977-2.4453 0.39062-4.8242 1.0312-7.1328 1.9297-2.3086 0.89453-4.5 2.0234-6.5664 3.3828-2.0703 1.3594-3.9727 2.9219-5.707 4.6836-1.7344 1.7656-3.2656 3.6914-4.5898 5.7812 2.7422-0.83594 5.5469-1.2148 8.4141-1.1406 2.8633 0.074218 5.6445 0.59766 8.3398 1.5742 1.2656-0.89062 2.6133-1.6367 4.0391-2.2461 1.4219-0.60547 2.8945-1.0586 4.4141-1.3555 1.5195-0.29688 3.0547-0.43359 4.6055-0.41016 1.5469 0.027343 3.0781 0.21094 4.5859 0.55859zm15.555 30.145c-1.0391 2.4727-2.4805 4.6836-4.3242 6.6289-1.8438 1.9492-3.9727 3.5117-6.3867 4.6875 1.043 0.9375 2.1836 1.7344 3.418 2.3945 1.2383 0.66016 2.5352 1.1641 3.8945 1.5117 1.3594 0.34375 2.7422 0.52344 4.1445 0.53516s2.7891-0.14453 4.1523-0.46875c1.5117-1.5977 2.8555-3.3242 4.0391-5.1797 1.1797-1.8516 2.1797-3.7969 2.9922-5.8398 0.8125-2.0391 1.4258-4.1406 1.8398-6.2969 0.41406-2.1562 0.62109-4.3359 0.625-6.5312-1.8711 2.168-4.0391 3.9844-6.5 5.4492-2.4609 1.4648-5.0938 2.5-7.8945 3.1094z" fill="#449fd8"/>
-<path d="m146.63 876.45c0 0.71484-0.070312 1.4219-0.21094 2.125-0.14062 0.69922-0.34766 1.3789-0.62109 2.0391-0.27344 0.66016-0.60938 1.2891-1.0078 1.8828-0.39844 0.59375-0.84766 1.1406-1.3555 1.6484-0.50781 0.50391-1.0586 0.95312-1.6523 1.3516-0.59766 0.39844-1.2266 0.73047-1.8867 1.0039-0.66406 0.27344-1.3438 0.48047-2.0469 0.62109s-1.4141 0.20703-2.1289 0.20703-1.4258-0.066406-2.1289-0.20703-1.3828-0.34766-2.0469-0.62109c-0.66016-0.27344-1.2891-0.60547-1.8867-1.0039-0.59375-0.39844-1.1445-0.84766-1.6523-1.3516-0.50391-0.50781-0.95703-1.0547-1.3555-1.6484-0.39844-0.59375-0.73438-1.2227-1.0078-1.8828-0.27344-0.66016-0.48047-1.3398-0.62109-2.0391-0.14062-0.70312-0.21094-1.4102-0.21094-2.125 0-0.71484 0.070312-1.4219 0.21094-2.1211s0.34766-1.3828 0.62109-2.043 0.60938-1.2852 1.0078-1.8789c0.39844-0.59375 0.85156-1.1445 1.3555-1.6484 0.50781-0.50391 1.0586-0.95703 1.6523-1.3555 0.59766-0.39453 1.2266-0.73047 1.8867-1.0039 0.66406-0.27344 1.3438-0.48047 2.0469-0.61719 0.70312-0.14062 1.4141-0.21094 2.1289-0.21094s1.4258 0.070313 2.1289 0.21094c0.70312 0.13672 1.3828 0.34375 2.0469 0.61719 0.66016 0.27344 1.2891 0.60937 1.8867 1.0039 0.59375 0.39844 1.1445 0.85156 1.6523 1.3555 0.50781 0.50391 0.95703 1.0547 1.3555 1.6484 0.39844 0.59375 0.73438 1.2188 1.0078 1.8789s0.48047 1.3438 0.62109 2.043 0.21094 1.4062 0.21094 2.1211z" fill="#f04d5c"/>
-<g clip-path="url(#bi)">
-<path d="m317.77 869.55c-0.33594 0-0.66016 0.0625-0.97266 0.19141-0.3125 0.12891-0.58984 0.3125-0.82812 0.55078s-0.42188 0.51172-0.55469 0.82422c-0.12891 0.3125-0.19141 0.64062-0.19141 0.97656 0 1.2422-0.0625 2.4805-0.18359 3.7188-0.12109 1.2344-0.30469 2.4609-0.54297 3.6797-0.24219 1.2188-0.54297 2.4219-0.90234 3.6094-0.36328 1.1875-0.77734 2.3555-1.2539 3.5039-0.47266 1.1445-1.0039 2.2695-1.5859 3.3633-0.58594 1.0938-1.2227 2.1602-1.9102 3.1914s-1.4258 2.0273-2.2109 2.9883c-0.78906 0.96094-1.6172 1.8789-2.4961 2.7578-0.875 0.87891-1.793 1.7109-2.75 2.5s-1.9531 1.5273-2.9844 2.2148c-1.0312 0.69141-2.0898 1.3281-3.1836 1.9141-1.0938 0.58594-2.2148 1.1172-3.3594 1.5938-1.1445 0.47656-2.3086 0.89453-3.4961 1.2539-1.1875 0.35938-2.3867 0.66016-3.6016 0.90625-1.2188 0.24219-2.4414 0.42188-3.6758 0.54688-1.2344 0.12109-2.4688 0.18359-3.7109 0.18359-0.33594 0-0.66016 0.0625-0.97266 0.19141-0.30859 0.12891-0.58594 0.31641-0.82422 0.55469s-0.42188 0.51172-0.55078 0.82422-0.19531 0.63672-0.19531 0.97656c0 0.33594 0.066407 0.66406 0.19531 0.97656 0.12891 0.30859 0.3125 0.58594 0.55078 0.82422 0.23828 0.23828 0.51562 0.42578 0.82422 0.55469 0.3125 0.12891 0.63672 0.19141 0.97266 0.19141 1.4062 0 2.8125-0.070312 4.2109-0.20703 1.3984-0.13672 2.7891-0.34375 4.168-0.62109 1.3789-0.27344 2.7422-0.61719 4.0859-1.0273 1.3477-0.40625 2.668-0.88281 3.9688-1.4219 1.2969-0.53906 2.5664-1.1406 3.8086-1.8047 1.2383-0.66406 2.4414-1.3867 3.6133-2.1719 1.168-0.78125 2.2969-1.6211 3.3828-2.5156 1.0859-0.89062 2.1289-1.8359 3.1211-2.832 0.99609-0.99609 1.9375-2.0391 2.8281-3.1289 0.89453-1.0898 1.7305-2.2188 2.5117-3.3906 0.78125-1.1719 1.5039-2.3789 2.1641-3.6211 0.66406-1.2422 1.2656-2.5156 1.8008-3.8164 0.53906-1.3008 1.0117-2.625 1.4219-3.9727 0.40625-1.3516 0.75-2.7148 1.0234-4.0977 0.27344-1.3789 0.48047-2.7734 0.61719-4.1758 0.13672-1.3984 0.20703-2.8047 0.20703-4.2148 0-0.33594-0.0625-0.66016-0.19141-0.97266-0.12891-0.3125-0.3125-0.58594-0.55078-0.82422-0.23828-0.23828-0.51172-0.42188-0.82422-0.55078s-0.63672-0.19531-0.97266-0.19531zm-64.93-10.688c-1.6055 2.4883-2.7812 5.1641-3.5273 8.0312-0.74219 2.8672-1.0156 5.7773-0.82031 8.7305 0.96875 15.449 14.938 27.16 28.109 25.898 5.168-0.50391 10.457-4.7227 9.9961-12.262-0.21484-3.2852-1.8203-5.2188-4.4141-6.7031-2.4805-1.418-5.6719-2.3203-9.2773-3.332-4.3672-1.2383-9.4336-2.6094-13.305-5.4766-4.6602-3.4453-7.8516-7.4258-6.7617-14.887z" fill="#005eb8"/>
-</g>
-<path d="m302.43 885.86c1.6094-2.4844 2.7812-5.1602 3.5273-8.0273 0.74219-2.8672 1.0156-5.7773 0.82031-8.7344-0.96484-15.445-14.938-27.156-28.109-25.898-5.1641 0.50781-10.453 4.7266-9.9961 12.266 0.21484 3.2812 1.8203 5.2188 4.4141 6.7031 2.4844 1.418 5.6719 2.3164 9.2773 3.3281 4.3672 1.2383 9.4336 2.6133 13.309 5.4805 4.6602 3.4414 7.8477 7.4258 6.7578 14.883z" fill="#003b5c"/>
-<g clip-path="url(#bf)">
-<path d="m457.48 900.86c-2.1484 0-3.1992 0.85547-4.3984 1.8086-1.3008 1.0508-2.8008 2.207-5.6484 2.207-2.8516 0-4.3516-1.2031-5.6523-2.207-1.1992-0.95312-2.25-1.8086-4.3984-1.8086-2.1484 0-3.1992 0.85547-4.3984 1.8086-1.3008 1.0508-2.8008 2.207-5.6523 2.207-2.8477 0-4.3477-1.2031-5.6484-2.207-1.1992-0.95312-2.25-1.8086-4.3984-1.8086-2.1523 0-3.2031 0.85547-4.4023 1.8086-0.94922 0.80078-2 1.4531-3.1992 1.8555 5.6016 4.9648 12.699 7.9766 20.148 8.625 0.19922 0 0.40234 0.050781 0.65234 0.050781 0.75 0.050782 1.5 0.10156 2.25 0.10156s1.5-0.050781 2.25-0.10156c0.19922 0 0.39844-0.050781 0.64844-0.050781 9.1484-0.75 17.598-5.1133 23.598-12.086-0.64844-0.15234-1.1992-0.20312-1.75-0.20312" fill="#239de0"/>
-</g>
-<path d="m407.08 874.68c2.3516 0 3.5508-0.90625 4.75-1.9062 1.3008-1.0547 2.6523-2.1094 5.3008-2.1094 2.6484 0 4 1.0547 5.3008 2.1094 1.25 1 2.3984 1.9062 4.75 1.9062 2.3477 0 3.5508-0.90625 4.75-1.9062 1.3008-1.0547 2.6484-2.1094 5.3477-2.1094 2.7031 0 4 1.0547 5.3008 2.1094 1.25 1 2.3984 1.9062 4.75 1.9062s3.5508-0.90625 4.75-1.9062c1.3008-1.0547 2.6484-2.1094 5.3516-2.1094 2.6992 0 4 1.0547 5.3477 2.1094 1.1992 0.95312 2.3516 1.8555 4.6523 1.9062-0.30078-3.1602-1.0508-6.2227-2.2031-9.1797-1.0469-0.40234-2.0469-0.95312-2.8984-1.707-1.25-1.0039-2.4492-1.957-4.8516-1.957-2.4492 0-3.5977 0.95312-4.8477 1.957-1.3008 1.0039-2.6016 2.0586-5.1992 2.0586-2.6016 0-3.9492-1.0547-5.1992-2.0586-1.25-1.0039-2.4531-1.957-4.8516-1.957-2.4492 0-3.6016 0.95312-4.8516 1.957-1.2969 1.0039-2.5977 2.0586-5.1992 2.0586-2.5977 0-3.9492-1.0547-5.1992-2.0586-1.25-1.0039-2.4492-1.957-4.8477-1.957-2.4531 0-3.6016 0.95312-4.8516 1.957-1.3008 1.0039-2.6016 2.0586-5.1992 2.0586-2.6016 0-3.9492-1.0547-5.1992-2.0586-0.30078-0.19922-0.55078-0.44922-0.85156-0.65234-1.1484 2.457-2.0508 5.0156-2.6016 7.6758 1.8008 0.30078 2.8516 1.1523 3.9023 2.0039 1.0508 0.90625 2.25 1.8594 4.5977 1.8594" fill="#239de0"/>
-<path d="m407.08 865.25c2.4531 0 3.6016-0.95312 4.8516-1.957 1.3008-1.0039 2.6016-2.0586 5.1992-2.0586 2.6016 0 3.9492 1.0547 5.25 2.1094 1.25 1 2.4492 1.9531 4.8516 1.9531 2.3984 0 3.5977-0.95312 4.8477-1.9531 1.3008-1.0039 2.6016-2.0586 5.1992-2.0586 2.6016 0 3.9531 1.0547 5.2031 2.0586 1.2461 1 2.4492 1.9531 4.8477 1.9531 2.4492 0 3.6016-0.95312 4.8516-1.9531 1.2969-1.0039 2.5977-2.0586 5.1992-2.0586 2.5977 0 3.9492 1.0547 5.1992 2.0586 0.69922 0.60156 1.4492 1.1016 2.3008 1.4531-7.25-17.957-27.699-26.484-45.551-19.109-7.8984 3.2578-14.297 9.2773-18.047 16.953 0.34766 0.25 0.64844 0.5 0.94922 0.70312 1.25 1 2.3984 1.9062 4.8477 1.9062" fill="#239de0"/>
-<path d="m457.48 891.08c-2.25 0-3.2969 0.85156-4.5469 1.8047-1.3008 1.0039-2.75 2.207-5.5508 2.207-2.8008 0-4.25-1.1562-5.5508-2.207-1.25-1.0039-2.3008-1.8047-4.5508-1.8047s-3.2969 0.85156-4.5469 1.8047c-1.3008 1.0039-2.75 2.207-5.5508 2.207-2.8008 0-4.25-1.1562-5.5508-2.207-1.25-1.0039-2.3008-1.8047-4.5508-1.8047s-3.2969 0.85156-4.5469 1.8047c-1.3008 1.0039-2.75 2.207-5.5508 2.207s-4.25-1.1562-5.5508-2.207c-0.35156-0.25-0.64844-0.50391-0.94922-0.75391 1.75 3.9648 4.1992 7.5742 7.1992 10.633 1.6992-0.14844 2.6484-0.90234 3.75-1.7539 1.3008-1.0547 2.8008-2.207 5.6484-2.207 2.8516 0 4.3516 1.2031 5.6523 2.207 1.1992 0.95313 2.25 1.8047 4.3984 1.8047 2.1484 0 3.1992-0.85156 4.3984-1.8047 1.3008-1.0547 2.8008-2.207 5.6523-2.207 2.8477 0 4.3477 1.2031 5.6484 2.207 1.1992 0.95313 2.25 1.8047 4.3984 1.8047 2.1523 0 3.2031-0.85156 4.4023-1.8047 1.3008-1.0547 2.8008-2.207 5.6484-2.207 1 0 2.0508 0.15234 2.9492 0.55078 1.25-1.6562 2.3516-3.4102 3.3008-5.2148-0.59766-0.35156-1.1992-0.75391-1.75-1.2031-1-1.0039-2.0508-1.8555-4.3008-1.8555" fill="#239de0"/>
-<path d="m467.53 875.58c-2.6484 0-4-1.0547-5.25-2.1094-1.25-1-2.3984-1.9062-4.75-1.9062-2.3477 0-3.5508 0.90625-4.75 1.9062-1.3008 1.0547-2.6484 2.1094-5.3008 2.1094-2.6992 0-3.9961-1.0547-5.3477-2.1094-1.25-1-2.3984-1.9062-4.75-1.9062-2.3516 0-3.5508 0.90625-4.75 1.9062-1.3008 1.0547-2.6484 2.1094-5.3516 2.1094-2.6992 0-4-1.0547-5.2969-2.1094-1.25-1-2.4023-1.9062-4.75-1.9062-2.3516 0-3.5508 0.90625-4.75 1.9062-1.3008 1.0547-2.6523 2.1094-5.3008 2.1094-2.6992 0-4-1.0547-5.3008-2.1094-1-0.80078-1.9492-1.5547-3.5-1.8047-0.30078 1.707-0.5 3.4102-0.55078 5.1172 0 0.44922-0.046875 0.90234-0.046875 1.3555 0 0.44922 0 0.90234 0.046875 1.3516v0.60156c2.3008 0.20312 3.6016 1.207 4.75 2.1094 1.2031 0.95312 2.3516 1.8555 4.6523 1.8555s3.4492-0.90234 4.6484-1.8555c1.25-1.0039 2.6992-2.1562 5.4492-2.1562s4.1523 1.1523 5.4492 2.1562c1.2031 0.95312 2.3516 1.8555 4.6523 1.8555 2.3008 0 3.4492-0.90234 4.6484-1.8555 1.25-1.0039 2.6992-2.1562 5.4492-2.1562s4.1523 1.1523 5.4531 2.1562c1.1992 0.95312 2.3477 1.8555 4.6484 1.8555 2.3008 0 3.4492-0.90234 4.6484-1.8555 1.25-1.0039 2.6992-2.1562 5.4492-2.1562s4.1523 1.1523 5.4531 2.1562c1.0977 0.90234 2.1992 1.7539 4.1992 1.8555 0.19922-1.0547 0.30078-2.1562 0.39844-3.2617 0.050781-0.44922 0.050781-0.85156 0.10156-1.3047v-2.707c-0.30078-0.45312-0.35156-1.2031-0.35156-1.2031" fill="#239de0"/>
-<path d="m457.48 881.34c-2.2969 0-3.4492 0.90625-4.6484 1.8594-1.25 1-2.6992 2.1562-5.4492 2.1562s-4.1484-1.1562-5.4492-2.1562c-1.1992-0.95312-2.3516-1.8594-4.6523-1.8594-2.2969 0-3.4492 0.90625-4.6484 1.8594-1.25 1-2.6992 2.1562-5.4492 2.1562s-4.1523-1.1562-5.4492-2.1562c-1.2031-0.95312-2.3516-1.8594-4.6523-1.8594-2.2969 0-3.4492 0.90625-4.6484 1.8594-1.25 1-2.6992 2.1562-5.4492 2.1562s-4.1523-1.1562-5.4492-2.1562c-1.0508-0.85547-2.0508-1.6562-3.8516-1.8086 0.25 2.9102 0.89844 5.7695 1.8516 8.5273 1.0469 0.40234 2.0469 1.0039 2.8984 1.7578 1.25 1 2.3008 1.8047 4.5508 1.8047s3.3008-0.85156 4.5508-1.8047c1.2969-1.0039 2.75-2.207 5.5469-2.207 2.8008 0 4.25 1.1523 5.5508 2.207 1.25 1 2.3008 1.8047 4.5508 1.8047s3.3008-0.85156 4.5508-1.8047c1.2969-1.0039 2.75-2.207 5.5469-2.207 2.8008 0 4.25 1.1523 5.5508 2.207 1.25 1 2.3008 1.8047 4.5508 1.8047s3.3008-0.85156 4.5508-1.8047c1.2969-1.0039 2.75-2.207 5.5469-2.207 2.8008 0 4.25 1.1523 5.5508 2.207 0.44922 0.39844 0.94922 0.69922 1.4492 1.0508 1.1016-2.3555 1.9023-4.8125 2.4023-7.3711-2.3008-0.15234-3.6016-1.207-4.75-2.1094-1.1992-1-2.3516-1.9062-4.6523-1.9062" fill="#239de0"/>
-<path d="m451.83 901.06c-1.1992 0.95312-2.25 1.8047-4.3984 1.8047-2.1523 0-3.2031-0.85156-4.4023-1.8047-1.2969-1.0547-2.7969-2.207-5.6484-2.207-2.8516 0-4.3516 1.2031-5.6484 2.207-1.2031 0.95312-2.25 1.8047-4.4023 1.8047-2.1484 0-3.1992-0.85156-4.3984-1.8047-1.3008-1.0547-2.8008-2.207-5.6484-2.207-2.8516 0-4.3516 1.2031-5.6523 2.207-1.0508 0.85156-2 1.6055-3.75 1.7539 0.55078 0.60156 1.1523 1.1562 1.8008 1.6562 1.1484-0.40234 2.25-1.0547 3.1992-1.8555 1.1992-0.95312 2.25-1.8047 4.4023-1.8047 2.1484 0 3.1992 0.85156 4.3984 1.8047 1.3008 1.0547 2.8008 2.207 5.6484 2.207 2.8516 0 4.3516-1.2031 5.6523-2.207 1.1992-0.95312 2.25-1.8047 4.3984-1.8047 2.1484 0 3.1992 0.85156 4.3984 1.8047 1.3008 1.0547 2.8008 2.207 5.6523 2.207 2.8477 0 4.3477-1.2031 5.6484-2.207 1.1992-0.95312 2.25-1.8047 4.3984-1.8047 0.55078 0 1.1016 0.046875 1.6016 0.19922 0.44922-0.55078 0.89844-1.1055 1.3516-1.6562-0.95313-0.35156-1.9531-0.55078-2.9531-0.55078-2.8477 0.050781-4.3477 1.2031-5.6484 2.2578" fill="#fff"/>
-<path d="m457.48 889.47c-2.7969 0-4.25 1.1523-5.5469 2.207-1.25 1-2.3008 1.8047-4.5508 1.8047s-3.3008-0.85156-4.5508-1.8047c-1.3008-1.0039-2.75-2.207-5.5508-2.207-2.7969 0-4.25 1.1523-5.5469 2.207-1.25 1-2.3008 1.8047-4.5508 1.8047s-3.3008-0.85156-4.5508-1.8047c-1.3008-1.0039-2.75-2.207-5.5508-2.207-2.7969 0-4.25 1.1523-5.5469 2.207-1.25 1-2.3008 1.8047-4.5508 1.8047s-3.3008-0.85156-4.5508-1.8047c-0.85156-0.75391-1.8516-1.3555-2.8984-1.7578 0.29688 0.80469 0.59766 1.5547 0.89844 2.3086 0.35156 0.25 0.64844 0.44922 0.94922 0.75 1.3008 1.0039 2.75 2.207 5.5508 2.207 2.8008 0 4.25-1.1523 5.5508-2.207 1.25-1 2.3008-1.8047 4.5508-1.8047 2.2461 0 3.2969 0.85156 4.5469 1.8047 1.3008 1.0039 2.75 2.207 5.5508 2.207 2.8008 0 4.25-1.1523 5.5508-2.207 1.25-1 2.3008-1.8047 4.5508-1.8047s3.2969 0.85156 4.5469 1.8047c1.3008 1.0039 2.75 2.207 5.5508 2.207s4.25-1.1523 5.5508-2.207c1.25-1 2.3008-1.8047 4.5508-1.8047s3.2969 0.85156 4.5469 1.8047c0.55078 0.45312 1.1523 0.85547 1.75 1.207 0.25-0.50391 0.5-0.95312 0.70313-1.457-0.5-0.30078-1-0.65234-1.4531-1.0508-1.1992-1.0547-2.6992-2.207-5.5-2.207" fill="#fff"/>
-<path d="m457.48 880.04c-2.75 0-4.1992 1.1523-5.4492 2.1562-1.1992 0.95312-2.3477 1.8555-4.6484 1.8555-2.3008 0-3.4492-0.90234-4.6484-1.8555-1.25-1.0039-2.7031-2.1562-5.4531-2.1562s-4.1992 1.1523-5.4492 2.1562c-1.1992 0.95312-2.3477 1.8555-4.6484 1.8555-2.3008 0-3.4492-0.90234-4.6523-1.8555-1.25-1.0039-2.6992-2.1562-5.4492-2.1562s-4.1484 1.1523-5.4492 2.1562c-1.1992 0.95312-2.3477 1.8555-4.6484 1.8555s-3.4492-0.90234-4.6523-1.8555c-1.1484-0.90234-2.4492-1.957-4.75-2.1094 0 0.45312 0.050781 0.85547 0.10156 1.3047 1.8008 0.20312 2.8008 1.0039 3.8516 1.8086 1.25 1 2.6992 2.1562 5.4492 2.1562s4.1484-1.1562 5.4492-2.1562c1.1992-0.95312 2.3516-1.8594 4.6484-1.8594 2.3008 0 3.4492 0.90625 4.6523 1.8594 1.25 1 2.6992 2.1562 5.4492 2.1562s4.1484-1.1562 5.4492-2.1562c1.1992-0.95312 2.3516-1.8594 4.6484-1.8594 2.3008 0 3.4531 0.90625 4.6523 1.8594 1.25 1 2.6992 2.1562 5.4492 2.1562s4.1484-1.1562 5.4492-2.1562c1.1992-0.95312 2.3516-1.8594 4.6484-1.8594 2.3008 0 3.4531 0.90625 4.6523 1.8594 1.1484 0.90234 2.4492 1.9531 4.75 2.1055 0.097656-0.40234 0.14844-0.85156 0.25-1.2539-2-0.10156-3.0508-0.95313-4.1992-1.8555-1.25-1.0039-2.7031-2.1562-5.4531-2.1562" fill="#fff"/>
-<path d="m407.08 875.58c2.7031 0 4-1.0547 5.3008-2.1094 1.25-1 2.4023-1.9062 4.75-1.9062 2.3516 0 3.5508 0.90625 4.75 1.9062 1.3008 1.0547 2.6484 2.1094 5.3008 2.1094 2.6484 0 4-1.0547 5.3477-2.1094 1.25-1 2.4023-1.9062 4.75-1.9062 2.3516 0 3.5508 0.90625 4.75 1.9062 1.3008 1.0547 2.6523 2.1094 5.3516 2.1094 2.6992 0 4-1.0547 5.3008-2.1094 1.25-1 2.3984-1.9062 4.75-1.9062 2.3477 0 3.5469 0.90625 4.75 1.9062 1.2969 1.0039 2.6484 2.1094 5.25 2.1094v-0.10156c0-0.30078-0.050782-0.55078-0.050782-0.85156-2.25-0.050781-3.4023-0.95312-4.6523-1.9062-1.2969-1.0547-2.6484-2.1094-5.3477-2.1094-2.6992 0-4.0508 1.0547-5.3516 2.1094-1.25 1.0039-2.3984 1.9062-4.75 1.9062-2.3477 0-3.5508-0.90234-4.75-1.9062-1.2969-1.0547-2.6484-2.1094-5.2969-2.1094-2.7031 0-4 1.0547-5.3516 2.1094-1.25 1.0039-2.3984 1.9062-4.75 1.9062-2.3516 0-3.5508-0.90234-4.75-1.9062-1.3008-1.0547-2.6484-2.1094-5.3008-2.1094-2.6484 0-4 1.0547-5.2969 2.1094-1.25 1.0039-2.4023 1.9062-4.75 1.9062-2.3516 0-3.5508-0.90234-4.75-1.9062-1.0508-0.85547-2.1523-1.6562-3.9023-2.0078-0.050781 0.30078-0.097656 0.60156-0.19922 0.90234 1.5508 0.25 2.5508 1.0039 3.5 1.8086 1.3516 1.1016 2.6992 2.1562 5.3984 2.1562" fill="#fff"/>
-<path d="m407.08 865.8c2.6016 0 3.9531-1.0547 5.2031-2.0586 1.25-1.0039 2.4492-1.9531 4.8477-1.9531 2.4492 0 3.6016 0.94922 4.8516 1.9531 1.2969 1.0039 2.5977 2.0586 5.1992 2.0586 2.5977 0 3.9492-1.0547 5.1992-2.0586 1.25-1.0039 2.4492-1.9531 4.8516-1.9531 2.4492 0 3.5977 0.94922 4.8477 1.9531 1.3008 1.0039 2.6016 2.0586 5.1992 2.0586 2.6016 0 3.9492-1.0547 5.1992-2.0586 1.25-1.0039 2.4531-1.9531 4.8516-1.9531 2.4492 0 3.6016 0.94922 4.8516 1.9531 0.84766 0.75391 1.8477 1.3555 2.8984 1.707-0.10156-0.25-0.19922-0.45312-0.25-0.70312-0.85156-0.40234-1.6016-0.85156-2.3008-1.4531-1.3008-1.0039-2.5977-2.0586-5.1992-2.0586s-3.9492 1.0547-5.1992 2.0586c-1.25 1.0039-2.4492 1.957-4.8516 1.957-2.4492 0-3.5977-0.95312-4.8477-1.957-1.3008-1.0039-2.6016-2.0586-5.1992-2.0586-2.6016 0-3.9531 1.0547-5.2031 2.0586-1.25 1.0039-2.4492 1.957-4.8477 1.957-2.4023 0-3.5508-0.90625-4.8008-1.9062-1.3008-1.0039-2.6016-2.0586-5.1992-2.0586-2.6016 0-3.9492 1.0547-5.1992 2.0586-1.25 1-2.4492 1.9531-4.8516 1.9531-2.4492 0-3.5977-0.95312-4.8477-1.9531-0.30078-0.25391-0.60156-0.50391-0.95312-0.70312-0.097656 0.14844-0.14844 0.35156-0.25 0.5 0.30078 0.20312 0.55078 0.45312 0.85156 0.65234 1.1992 0.95313 2.5508 2.0078 5.1484 2.0078" fill="#fff"/>
-<g clip-path="url(#ao)">
-<path d="m571.93 837.83s-4.3594 14.699-4.0391 19.07c0.22266 3.0586 5.9062 7.0781 5.9062 7.0781s-3.0938 3.6758-4.2852 5.75c-1.2305 2.1289-3.1133 7.0234-3.1133 7.0234s-9.332-10.965-8.5547-16.344c0.91406-6.5 14.086-22.578 14.086-22.578zm42.324 0s4.3594 14.699 4.043 19.07c-0.22266 3.0586-5.9062 7.0781-5.9062 7.0781s3.0938 3.6758 4.2852 5.75c1.2305 2.1289 3.1133 7.0234 3.1133 7.0234s9.3164-10.965 8.5547-16.344c-0.91406-6.5-14.09-22.578-14.09-22.578z" fill="#bfbfbf"/>
-</g>
-<path d="m593.23 855.05c-12.355 0-23.258 8.7578-26.855 21.609l26.855 8.9258z" fill="#7d9199"/>
-<path d="m593.21 854.99c12.355 0 23.258 8.7773 26.852 21.605l-26.852 8.9297z" fill="#566366"/>
-<g clip-path="url(#g)">
-<path d="m593.16 876.64h-26.848v18.805s10.844 4.2578 15.316 7.6953c3.7227 2.8594 10.879 12.961 10.879 12.961h0.67969v-39.461z" fill="#7d9199"/>
-</g>
-<g clip-path="url(#bu)">
-<path d="m593.19 876.38h26.848v18.809s-10.844 4.2578-15.316 7.6953c-3.8203 2.9297-10.902 13.203-10.902 13.203h-0.65234z" fill="#566366"/>
-</g>
-<path d="m589.82 875.74c0-0.44531 0.085938-0.87891 0.25781-1.293 0.17188-0.41406 0.41406-0.77734 0.73047-1.0938 0.31641-0.32031 0.67969-0.5625 1.0938-0.73437 0.41406-0.17188 0.84375-0.25781 1.293-0.25781 0.44531 0 0.875 0.085937 1.2891 0.25781 0.41406 0.17187 0.77734 0.41406 1.0938 0.73437 0.31641 0.31641 0.5625 0.67969 0.73047 1.0938 0.17188 0.41406 0.25781 0.84766 0.25781 1.293 0 0.44922-0.085937 0.88281-0.25781 1.2969-0.16797 0.41406-0.41406 0.77734-0.73047 1.0938s-0.67969 0.5625-1.0938 0.73438-0.84375 0.25781-1.2891 0.25781c-0.44922 0-0.87891-0.085938-1.293-0.25781-0.41406-0.17188-0.77734-0.41797-1.0938-0.73438s-0.55859-0.67969-0.73047-1.0938c-0.17188-0.41406-0.25781-0.84766-0.25781-1.2969z" fill="#fff"/>
-<path d="m752.68 881.78c-4.2266-1.7148-6.7266-5.3789-6.5938-9.2695l-9.0312-4.7031c-0.67188 4.5039 0.40234 9.2148 3.1133 13.297 2.8867 4.3438 7.0547 7.582 12.512 9.4531v-8.7812z" fill="#1904da"/>
-<path d="m752.68 901.69v-10.094c-5.8438-1.9258-10.324-5.3867-13.398-10.016-2.9062-4.375-4.0156-9.4492-3.1914-14.273l-8.3945-4.3672c-4.8125 15.82 5.9805 32.668 24.98 38.75z" fill="#1904da"/>
-<path d="m753.92 891.51v10.184c18.648-6.2227 29.844-23.043 25.113-38.699l-8.3516 4.3828c1.043 5.2031 0.13281 10.277-2.6562 14.523-2.8711 4.3594-7.8828 7.6328-14.105 9.6094z" fill="#08b1d5"/>
-<path d="m760.72 872.55c0.039063 3.7773-2.4258 7.1016-6.8086 9.2266v8.7812c5.8242-1.9141 10.527-5.0508 13.219-9.1406 2.6055-3.957 3.4883-8.6797 2.5977-13.547z" fill="#08b1d5"/>
-<path d="m762.02 859.05c3.5234 1.5508 6.3906 4.0273 8.2969 7.1719 0.027344 0.039063 0.050782 0.085938 0.074219 0.125l8.1914-4.2617c-0.12891-0.14844-0.25391-0.30078-0.35547-0.44922-3.0039-4.3789-6.9766-7.6758-11.801-9.7969-13.617-5.9844-30.309-1.4688-38.281 10.258l8.1719 4.2539c5.5508-8.0391 16.715-11.254 25.707-7.3008z" fill="#ffc900"/>
-<path d="m756.91 868.42c1.457 0.64062 2.6406 1.6758 3.418 2.9883 0.027344 0.046875 0.050781 0.09375 0.074219 0.14062l9.0977-4.7344c-0.03125-0.046875-0.058594-0.097656-0.085938-0.14453-1.8008-2.9727-4.5117-5.3164-7.8438-6.7812-8.5039-3.7383-19.082-0.6875-24.359 6.9297l9.0469 4.707c2.3555-3.4062 6.918-4.7422 10.652-3.1055z" fill="#ffc900"/>
-<path d="m789.59 857.45-9.6406 5.0625c5.0859 16.289-6.5742 33.848-26.035 40.172v11.027l35.676-18.738z" fill="#08b1d5"/>
-<path d="m717.12 857.43v37.527l35.559 18.746v-11.027c-19.816-6.1719-31.07-23.762-25.906-40.223l-9.1992-4.7852z" fill="#1904da"/>
-<path d="m717.63 856.63 1.0508 0.54688 8.5703 4.457c8.2422-12.152 25.523-16.828 39.629-10.629 5.0039 2.1953 9.1172 5.6094 12.223 10.145 0.10156 0.14062 0.23438 0.30078 0.38672 0.46484l9.582-4.9883-35.719-18.586z" fill="#ffc900"/>
-<path d="m753.88 880.76c3.5156-1.7734 5.625-4.6094 5.7578-7.7539 0 0 0.015625-0.3125-0.007813-0.82031-0.007812-0.10547-0.78125-1.7617-3.1406-2.9219-3.168-1.5547-7.6641-0.058594-9.4648 2.9219 0 0-0.042969 0.36719-0.019532 0.82031 0.12891 2.8594 2.082 6.2148 5.543 7.7539l0.70312 0.30078 0.625-0.30078z" fill="#ff445f"/>
-<path d="m929.87 865.58c-5.3867 5.3594-10.773 10.715-16.168 16.066l-25.32 25.285-0.0625-0.0625c-1.4492 1.4531-2.8867 2.9141-4.2852 4.4141-0.73828 0.79297-1.0117 1.7969-0.16016 2.7109 0.88672 0.95703 1.9609 0.89844 2.9414 0.17187 0.73438-0.54297 1.375-1.2188 2.0234-1.8672 13.68-13.656 27.352-27.328 41.008-41.012l8.3164-1.4453c-1.3555-1.375-7.0039-5.543-8.293-4.2617z" fill="#00b4c8"/>
-<path d="m933.83 877.8c0.007813-0.39062-0.10547-0.74219-0.33594-1.0586-0.22656-0.32031-0.53125-0.53516-0.90234-0.65234-1.3281-0.47656-2.2344 0.29687-3.0898 1.1484-11.129 11.109-22.262 22.223-33.391 33.34-0.98438 0.98438-2 2.1562-0.79297 3.457 1.332 1.4336 2.582 0.40625 3.6367-0.64844 11.254-11.227 22.504-22.457 33.75-33.691 0.53516-0.53125 1.0703-1.0703 1.125-1.8945zm-22.254-1.3516 2.3398-2.3359c-0.1875-0.58984-0.66797-1.1484-1.1758-1.6523-10.707-10.699-21.418-21.395-32.133-32.082-0.59766-0.59766-1.2383-1.1367-2.168-1.1016-0.72656 0.039062-1.3086 0.34766-1.5859 1.0312-0.48828 1.2031 0.13672 2.0859 0.94141 2.8906 10.707 10.695 21.418 21.391 32.125 32.086 0.50781 0.50391 1.0664 0.98047 1.6562 1.1641zm21.055 14.805c0.98828-1.0039 1.8711-2.1992 0.53516-3.4609-1.1992-1.1328-2.3477-0.34375-3.2891 0.59375-4.2812 4.25-8.5352 8.5273-12.816 12.777-1.4961 1.4844-1.4258 2.8711 0.054687 4.3242 2.5117 2.4648 5.0195 4.9336 7.457 7.4727 1.3672 1.4219 2.8594 2.3125 4.7852 1.9375 0.44531 0.027344 0.78516 0.09375 1.1133 0.0625 1.4102-0.13281 3.1836-0.039062 3.2305-1.9766 0.046875-1.9961-1.6836-2.0039-3.1367-1.9531-1.4688 0.058594-2.5508-0.54688-3.5273-1.5742-1.5039-1.5781-3.0039-3.1641-4.6289-4.6133-1.4336-1.2812-1.2305-2.2227 0.078125-3.4766 3.4414-3.3086 6.7852-6.7227 10.145-10.113zm-28.598-10.363c0.52344 0.51562 1.1484 1.0469 1.8242 1.2695l2.332-2.3281c-0.29688-0.84375-1-1.4062-1.6094-2.0156-6.5625-6.5703-13.133-13.133-19.707-19.688-1.3594-1.3594-2.7148-2.7266-4.1172-4.043-0.82812-0.77344-1.8047-0.97266-2.6875-0.10156-0.83594 0.82812-0.77734 1.8047-0.11719 2.7305 0.30078 0.40625 0.62891 0.78516 0.98828 1.1328 7.6914 7.6875 15.391 15.367 23.094 23.043zm-8.7422 2.7969c1.2422 1.2383 2.4805 2.4844 3.7656 3.6758 0.29297 0.27734 0.62891 0.46875 1.0156 0.57812l2.4375-2.4375c-0.16016-0.625-0.57812-1.125-1.043-1.5898-4.9648-4.9648-9.9297-9.9219-14.906-14.875-0.41016-0.42188-0.88281-0.75391-1.4219-0.99219-0.81641-0.33203-1.6562-0.28125-2.3047 0.43359-0.65625 0.71875-0.64844 1.5469-0.14062 2.3047 0.47266 0.69141 1.0078 1.3281 1.6016 1.9141 3.6562 3.6758 7.3203 7.3359 10.996 10.988z" fill="#00b4c8"/>
-<g clip-path="url(#n)">
-<g clip-path="url(#aa)">
-<path d="m1016.9 842.7v70.453h70.141v-70.453z" fill="url(#p)"/>
-</g>
-</g>
-<g clip-path="url(#bo)">
-<path d="m1052 913.99c-7.1016 0-14.039-2.1133-19.941-6.0742-5.9062-3.9648-10.504-9.5938-13.223-16.184-2.7188-6.5859-3.4297-13.836-2.043-20.828 1.3867-6.9961 4.8047-13.418 9.8242-18.461 5.0195-5.043 11.418-8.4766 18.379-9.8672 6.9648-1.3906 14.18-0.67969 20.742 2.0508 6.5586 2.7305 12.164 7.3516 16.109 13.277 3.9414 5.9297 6.0469 12.902 6.0469 20.031-0.011719 9.5586-3.7969 18.723-10.527 25.48-6.7305 6.7578-15.852 10.562-25.367 10.574zm0-70.453c-6.7734 0.003907-13.391 2.0195-19.02 5.8008-5.6289 3.7773-10.02 9.1484-12.609 15.434-2.5898 6.2852-3.2656 13.199-1.9453 19.867 1.3203 6.6719 4.582 12.801 9.3711 17.609 4.7852 4.8086 10.887 8.082 17.527 9.4102s13.527 0.64844 19.781-1.9531c6.2578-2.6055 11.605-7.0117 15.367-12.664 3.7656-5.6562 5.7734-12.305 5.7734-19.105-0.007812-9.1211-3.6172-17.863-10.039-24.312-6.4219-6.4492-15.129-10.074-24.207-10.086z" fill="#231f20"/>
-</g>
-<path d="m1068.9 900.61c-1.5352 2.4609-8.4531 4.3203-16.758 4.3203-8.3047 0-15.223-1.8594-16.758-4.3203-1.9922 0.77344-3.1484 1.6875-3.1484 2.6758 0 2.7383 8.9141 4.957 19.902 4.957s19.902-2.2188 19.902-4.957c0.011718-0.98828-1.1523-1.9023-3.1406-2.6758z" fill="#173f74"/>
-<path d="m1052.1 904.93c8.3047 0 15.223-1.8594 16.758-4.3203-3.5547-1.375-9.7188-2.2852-16.758-2.2852-7.0352 0-13.219 0.91016-16.758 2.2852 1.5352 2.4609 8.4609 4.3203 16.758 4.3203z" fill="#00214c"/>
-<path d="m1066.2 888.01c1.1289-1.0625 2.3438-2.0273 3.6328-2.8828 5.8398-3.957 4.2344-10.176 2.8203-15.211-1.0078-3.5938 3.8281-4.5586 5.6875 5.8477 1.832 10.238-9.4492 18.273-12.48 18.273" fill="#754c29"/>
-<path d="m1065.9 894.55c-0.13672 0-0.26953-0.054688-0.36719-0.15234-0.097657-0.097656-0.15234-0.23047-0.15234-0.36719 0-0.13672 0.054687-0.26953 0.15234-0.36719 0.097656-0.097657 0.23047-0.15234 0.36719-0.15234 1.4219 0 5.2656-2.2031 8.25-5.7852 2.1914-2.6367 4.6211-6.8359 3.7148-11.879-0.92578-5.1914-2.6211-7.4766-3.7891-7.8555-0.11719-0.050782-0.24609-0.070313-0.37109-0.050782-0.12891 0.019532-0.24609 0.074219-0.33984 0.16016-0.24609 0.23047-0.41797 0.79688-0.17188 1.668 1.3633 4.8672 3.2383 11.531-3.0352 15.785-1.2617 0.83984-2.4492 1.7852-3.5547 2.8203-0.10156 0.074219-0.22266 0.10547-0.34766 0.09375-0.12109-0.011718-0.23828-0.066406-0.32422-0.15625s-0.13672-0.20703-0.14453-0.33203c-0.007813-0.125 0.03125-0.24609 0.10547-0.34766 1.1523-1.082 2.3906-2.0703 3.707-2.9453 5.6523-3.8242 3.9102-10.074 2.6172-14.633-0.31641-1.1172-0.14453-2.1445 0.44531-2.7031 0.23438-0.21875 0.51953-0.36719 0.82812-0.42969 0.3125-0.0625 0.63281-0.039062 0.92969 0.074219 1.957 0.63281 3.6406 3.875 4.4961 8.6602 0.96875 5.4375-1.6094 9.9258-3.9453 12.73-3.0938 3.6914-7.1797 6.1641-9.0703 6.1641z" fill="#231f20"/>
-<path d="m1074.7 868c1.2266 2.9336 4.1836 11.098 0.054688 16.328-4.1328 5.2305-6.9023 4.9609-6.9023 4.9609l0.39844 3.9609c4.3555-2.25 11.594-9.1328 10.098-17.488-0.98438-5.5-2.3047-7.3242-3.6484-7.7617z" fill="#603913"/>
-<path d="m1065.9 894.55c-0.13672 0-0.26953-0.054688-0.36719-0.15234-0.097657-0.097656-0.15234-0.23047-0.15234-0.36719 0-0.13672 0.054687-0.26953 0.15234-0.36719 0.097656-0.097657 0.23047-0.15234 0.36719-0.15234 1.4219 0 5.2656-2.2031 8.25-5.7852 2.1914-2.6367 4.6211-6.8359 3.7148-11.879-0.92578-5.1914-2.6211-7.4766-3.7891-7.8555-0.11719-0.050782-0.24609-0.070313-0.37109-0.050782-0.12891 0.019532-0.24609 0.074219-0.33984 0.16016-0.24609 0.23047-0.41797 0.79688-0.17188 1.668 1.3633 4.8672 3.2383 11.531-3.0352 15.785-1.2617 0.83984-2.4492 1.7852-3.5547 2.8203-0.10156 0.074219-0.22266 0.10547-0.34766 0.09375-0.12109-0.011718-0.23828-0.066406-0.32422-0.15625s-0.13672-0.20703-0.14453-0.33203c-0.007813-0.125 0.03125-0.24609 0.10547-0.34766 1.1523-1.082 2.3906-2.0703 3.707-2.9453 5.6523-3.8242 3.9102-10.074 2.6172-14.633-0.31641-1.1172-0.14453-2.1445 0.44531-2.7031 0.23438-0.21875 0.51953-0.36719 0.82812-0.42969 0.3125-0.0625 0.63281-0.039062 0.92969 0.074219 1.957 0.63281 3.6406 3.875 4.4961 8.6602 0.96875 5.4375-1.6094 9.9258-3.9453 12.73-3.0938 3.6914-7.1797 6.1641-9.0703 6.1641z" fill="#231f20"/>
-<path d="m1069 888.38c0 10.605-7.6602 16.555-17.105 16.555-9.4453 0-17.109-5.9375-17.109-16.555 0-10.617 7.6602-27.156 17.109-27.156 9.4492 0 17.105 16.547 17.105 27.156z" fill="#f7941d"/>
-<path d="m1051.9 905.42c-10.527 0-17.598-6.8516-17.598-17.047 0-10.918 7.8828-27.652 17.598-27.652 9.7188 0 17.602 16.734 17.602 27.652 0 10.199-7.0742 17.047-17.602 17.047zm0-43.711c-2.3828 0-7.0586 1.2148-11.672 9.3516-3.0508 5.3867-4.9297 12.02-4.9297 17.316 0 9.6016 6.6758 16.062 16.617 16.062 9.9414 0 16.613-6.4531 16.613-16.062 0-5.2969-1.8984-11.93-4.9453-17.312-4.625-8.125-9.3047-9.3516-11.684-9.3516z" fill="#231f20"/>
-<path d="m1051.9 861.23h-0.35547c7.3477 0.39063 16.145 17.051 16.145 26.73 0.011719 9.8164-7.3281 15.324-16.395 15.324-3.3906 0-6.4727-0.046875-9.0312-0.8125 2.9336 1.6758 6.2617 2.5352 9.6328 2.4805 9.4492 0 17.105-5.9453 17.105-16.551 0-10.605-7.6562-27.172-17.102-27.172z" fill="#f47729"/>
-<path d="m1065.1 875.7-2.6875 2.4023s3.0391-0.65234 3.1602-1.2031c0.12109-0.54688-0.47266-1.1992-0.47266-1.1992z" fill="#f47729"/>
-<path d="m1065.8 877.72-3.1289 2.4023s3.5352-0.65234 3.6758-1.2031c0.14453-0.55078-0.54688-1.1992-0.54688-1.1992z" fill="#f47729"/>
-<path d="m1066.5 879.8-3.6602 2.7734s4.1367-0.75391 4.3047-1.3867c0.16797-0.63672-0.64453-1.3867-0.64453-1.3867z" fill="#f47729"/>
-<path d="m1066.4 896.1-3.9102-2.3867s2.2266 3.5664 2.875 3.4961c0.65234-0.070312 1.0352-1.1094 1.0352-1.1094z" fill="#f47729"/>
-<path d="m1068.1 894.07-4.3594-1.4258s2.9844 2.9727 3.5977 2.7461c0.61719-0.23047 0.76172-1.3203 0.76172-1.3203z" fill="#f47729"/>
-<path d="m1037.9 875.7 3.1992 2.4023s-3.6016-0.65234-3.7461-1.2031c-0.14844-0.54688 0.54688-1.1992 0.54688-1.1992z" fill="#f47729"/>
-<path d="m1037.1 877.72 3.7031 2.4023s-4.1875-0.65234-4.3516-1.2031c-0.16797-0.55078 0.64844-1.1992 0.64844-1.1992z" fill="#f47729"/>
-<path d="m1036.2 879.8 4.3477 2.7734s-4.8945-0.75391-5.0938-1.3867c-0.19922-0.63672 0.74609-1.3867 0.74609-1.3867z" fill="#f47729"/>
-<path d="m1059.5 885.75c0 5.1406-2.8672 9.6367-8.1055 9.6367s-8.1016-4.4844-8.1016-9.6367c0-5.1562 2.8633-12.453 8.1016-12.453s8.1055 7.3125 8.1055 12.453z" fill="#fff"/>
-<path d="m1051.4 895.86c-5.0508 0-8.5781-4.1562-8.5781-10.109 0.019531-2.9297 0.75-5.8125 2.1328-8.3945 1.625-2.9375 3.9102-4.5547 6.4336-4.5547 2.5234 0 4.8086 1.6172 6.4336 4.5547 1.3789 2.582 2.1133 5.4648 2.1328 8.3945 0.027344 5.9531-3.5 10.109-8.5547 10.109zm0-22.098c-4.9062 0-7.6211 7.0898-7.6211 11.988 0 6.3203 3.8242 9.1445 7.6211 9.1445s7.6289-2.8242 7.6289-9.1445c0-4.8984-2.7148-11.988-7.6289-11.988z" fill="#231f20"/>
-<path d="m1066.9 854.99c-0.066407 0.85937-1.6719-0.26563-2.2148 0.35547l-11.191-6.8711c0.30469-0.78906 0.67969-1.5469 1.1172-2.2656 2.3633-3.8828 7.4414-7.8203 9.9766-4.9805 1.7344 1.9375 2.6914 8.7461 2.3125 13.762z" fill="#754c29"/>
-<g clip-path="url(#an)">
-<path d="m1064.8 856.02-0.35547-0.23047-11.582-7.1016 0.16016-0.40625c0.32031-0.8125 0.70703-1.5977 1.1641-2.3438 1.8281-3.0078 5.3398-6.1992 8.2422-6.1992 0.48438-0.007812 0.96484 0.089844 1.4062 0.28906 0.44141 0.19531 0.83594 0.48828 1.1562 0.85547 1.9062 2.1406 2.8164 9.168 2.4414 14.145-0.003906 0.11719-0.035156 0.23047-0.082031 0.33594-0.050782 0.10547-0.12109 0.19922-0.20703 0.27734-0.089843 0.074219-0.19141 0.13281-0.30078 0.17188-0.10938 0.035156-0.22656 0.046875-0.33984 0.039062-0.23047-0.011718-0.46094-0.042968-0.68359-0.097656-0.19141-0.046875-0.38672-0.074218-0.58203-0.085937-0.050781-0.003907-0.10156 0.003906-0.15234 0.019531zm0.4375-1.3945c0.26563 0.011719 0.52734 0.046875 0.78906 0.10938 0.125 0.027344 0.25391 0.050781 0.38281 0.066406 0.35547-5.1602-0.69531-11.547-2.1914-13.207-0.21875-0.25781-0.49219-0.46094-0.79688-0.59766-0.30859-0.13672-0.64062-0.20703-0.97656-0.19922-2.4375 0-5.6562 2.8945-7.3594 5.7109-0.34766 0.57031-0.65625 1.168-0.91797 1.7852l10.523 6.4414c0.17187-0.074219 0.35937-0.10938 0.54687-0.10938z" fill="#231f20"/>
-</g>
-<path d="m1063.4 851.58c-0.023437 0.28516-4.7188-2.5-4.7188-2.5 0.09375-0.25781 0.21484-0.51172 0.35547-0.75 0.78125-1.2891 2.4336-3.2969 3.3242-2.1445 0.25781 0.33984 1.1641 3.7266 1.0391 5.3945z" fill="#231f20"/>
-<path d="m1063.3 852.12c-0.14062 0-0.57422 0-4.9414-2.5781l-0.38672-0.22656 0.16016-0.41406c0.11328-0.28906 0.25-0.57031 0.41406-0.83594 0.39062-0.63672 1.7773-2.7305 3.1172-2.7305 0.20703 0 0.41406 0.050781 0.60156 0.14844 0.18359 0.097656 0.34375 0.23828 0.46484 0.41016 0.375 0.5 1.25 4.0508 1.1211 5.7109-0.007812 0.14063-0.070312 0.27344-0.17188 0.36719-0.10156 0.097656-0.23828 0.15234-0.37891 0.14844zm-4.0156-3.2383c1.3477 0.78516 2.7578 1.5781 3.5547 1.9609-0.13672-1.4805-0.45703-2.9375-0.96094-4.3398-0.019531-0.039062-0.054687-0.070312-0.09375-0.09375-0.039063-0.019531-0.082031-0.03125-0.12891-0.03125-0.48828 0-1.4727 0.98047-2.2305 2.2305-0.03125 0.089843-0.09375 0.17969-0.14062 0.27344z" fill="#231f20"/>
-<path d="m1064.8 841.5-2.6914 2.4023s3.043-0.65625 3.1641-1.2031c0.12109-0.55078-0.47266-1.1992-0.47266-1.1992z" fill="#3c2415"/>
-<path d="m1036.5 855.34c0.070312 0.85937 1.6719-0.26563 2.2188 0.35547l11.191-6.8711c-0.30859-0.78906-0.68359-1.5469-1.1211-2.2656-2.3594-3.8828-7.4375-7.8203-9.9766-4.9805-1.7344 1.9414-2.6914 8.75-2.3125 13.762z" fill="#f7941d"/>
-<path d="m1038.3 842.7 3.1992 2.4023s-3.6094-0.64844-3.7383-1.1992c-0.12891-0.54688 0.53906-1.2031 0.53906-1.2031z" fill="#f47729"/>
-<path d="m1037.2 844.89 2.4258 1.7266s-2.7422-0.47266-2.8438-0.86328c-0.097656-0.39453 0.41797-0.86328 0.41797-0.86328z" fill="#f47729"/>
-<path d="m1038.7 856.36-0.29297-0.32031c-0.046875-0.019531-0.097656-0.027343-0.14844-0.019531-0.19531 0.007813-0.39063 0.039063-0.58203 0.085938-0.22266 0.050781-0.45312 0.082031-0.68359 0.089843-0.11719 0.011719-0.23437 0-0.34375-0.039062-0.10937-0.035156-0.21094-0.09375-0.29687-0.17188-0.085938-0.074219-0.15625-0.16797-0.20703-0.27344-0.050781-0.10547-0.078125-0.21875-0.082031-0.33594-0.39062-4.9766 0.53516-12.012 2.4531-14.145 0.31641-0.36328 0.71094-0.65625 1.1484-0.85156 0.44141-0.19531 0.91797-0.28906 1.3984-0.28125 2.9102 0 6.4219 3.2109 8.2461 6.1953 0.45312 0.75 0.84375 1.5352 1.1641 2.3516l0.16016 0.40625zm2.3633-15.23c-0.33594-0.007812-0.66797 0.0625-0.97656 0.19922-0.30469 0.13672-0.57812 0.33984-0.80078 0.59766-1.5 1.6758-2.5508 8.0664-2.1875 13.207 0.10938 0 0.25-0.039062 0.38281-0.0625 0.4375-0.125 0.89844-0.125 1.332 0l10.527-6.4609c-0.26172-0.61719-0.57031-1.2148-0.91406-1.7852-1.707-2.8008-4.9336-5.6953-7.3633-5.6953z" fill="#231f20"/>
-<path d="m1040.1 851.93c0.019531 0.28906 4.7188-2.5 4.7188-2.5-0.097657-0.26172-0.21484-0.51562-0.35547-0.75781-0.78516-1.2891-2.4375-3.293-3.3281-2.1406-0.25391 0.35156-1.1641 3.7305-1.0352 5.3984z" fill="#231f20"/>
-<path d="m1040.1 852.47c-0.14063 0.003906-0.27344-0.046875-0.37891-0.14062-0.10156-0.09375-0.16406-0.22266-0.17578-0.36328-0.125-1.6719 0.74609-5.2266 1.125-5.7109 0.12109-0.17188 0.28125-0.3125 0.46484-0.41016 0.1875-0.097656 0.39453-0.14844 0.60156-0.14844 1.3555 0 2.7305 2.0898 3.1211 2.7305 0.16016 0.26562 0.29688 0.54297 0.41406 0.83203l0.16016 0.41406-0.38281 0.22656c-4.3594 2.5625-4.8047 2.5703-4.9492 2.5703zm1.6328-5.7422c-0.042969 0-0.125 0-0.23828 0.14844-0.48047 1.3945-0.78516 2.8477-0.91406 4.3203 0.77734-0.39062 2.1914-1.1797 3.5547-1.9688-0.042969-0.09375-0.09375-0.17969-0.15234-0.26562-0.77734-1.2539-1.7578-2.2344-2.25-2.2344z" fill="#231f20"/>
-<path d="m1056.3 875.95c0.42969 0.53906 0.8125 1.1211 1.1367 1.7305 3.3711-0.90234 6.0898-2.582 7.6133-4.6797-0.11328-0.24219-0.23047-0.47656-0.35547-0.71484-2.4883 1.8398-5.3555 3.0898-8.3945 3.6602z" fill="#603d19"/>
-<path d="m1045.4 877.53c0.32812-0.59766 0.71484-1.1641 1.1445-1.6953-2.7617-0.58594-5.3789-1.7422-7.6758-3.3945-0.13281 0.25781-0.25391 0.51953-0.38281 0.78125 1.4648 1.8867 3.9141 3.418 6.9141 4.3086z" fill="#603d19"/>
-<path d="m1051.7 876.39c-1.7305 0.003906-3.457-0.18359-5.1445-0.55859-0.42969 0.52734-0.81641 1.0938-1.1484 1.6953 2.043 0.60547 4.1602 0.90625 6.2891 0.89844 1.9414 0.007813 3.8789-0.24219 5.7578-0.74219-0.32812-0.60938-0.71094-1.1914-1.1367-1.7305-1.5234 0.29297-3.0703 0.44141-4.6172 0.4375z" fill="#573819"/>
-<path d="m1051.4 895.86c-5.0508 0-8.5781-4.1562-8.5781-10.109 0.019531-2.9297 0.75-5.8125 2.1328-8.3945 1.625-2.9375 3.9102-4.5547 6.4336-4.5547 2.5234 0 4.8086 1.6172 6.4336 4.5547 1.3789 2.582 2.1133 5.4648 2.1328 8.3945 0.027344 5.9531-3.5 10.109-8.5547 10.109zm0-22.098c-4.9062 0-7.6211 7.0898-7.6211 11.988 0 6.3203 3.8242 9.1445 7.6211 9.1445s7.6289-2.8242 7.6289-9.1445c0-4.8984-2.7148-11.988-7.6289-11.988z" fill="#231f20"/>
-<path d="m1066.1 871.16c-0.42578 0.39062-0.86719 0.76172-1.3359 1.1211 0.12109 0.23828 0.23828 0.46875 0.35547 0.71484 0.41406-0.5625 0.74219-1.1797 0.98047-1.8359z" fill="#533414"/>
-<path d="m1051.9 905.42c-10.527 0-17.598-6.8516-17.598-17.047 0-10.918 7.8828-27.652 17.598-27.652 9.7188 0 17.602 16.734 17.602 27.652 0 10.199-7.0742 17.047-17.602 17.047zm0-43.711c-2.3828 0-7.0586 1.2148-11.672 9.3516-3.0508 5.3867-4.9297 12.02-4.9297 17.316 0 9.6016 6.6758 16.062 16.617 16.062 9.9414 0 16.613-6.4531 16.613-16.062 0-5.2969-1.8984-11.93-4.9453-17.312-4.625-8.125-9.3047-9.3516-11.684-9.3516z" fill="#231f20"/>
-<path d="m1064.6 859.67c0.011718-1.1133 0.28906-2.2031 0.80859-3.1875 0.51562-0.98047 1.2578-1.8281 2.168-2.4648-3.3594-3.9258-9.1328-6.5117-15.695-6.5117h-0.66406c0.53516 2.2812 0.75781 4.6289 0.66406 6.9727 0 9.3516-3.3828 17.332-8.1406 20.465 2.6094 0.95313 5.3633 1.4375 8.1406 1.4297 8.3242 0 15.387-4.1719 17.844-9.9453-3.0039-1.0547-5.125-3.6797-5.125-6.7578z" fill="#f7941d"/>
-<path d="m1051.9 876.91c-2.8359 0.011719-5.6523-0.48047-8.3203-1.4531-0.089843-0.035156-0.16797-0.09375-0.22656-0.16797-0.058594-0.078124-0.097657-0.16797-0.10547-0.26562-0.015625-0.09375 0-0.19141 0.042969-0.28125 0.039062-0.085938 0.10156-0.16016 0.18359-0.21484 4.7266-3.1133 7.9023-11.164 7.9023-20.027 0.097656-2.2969-0.12109-4.6016-0.64062-6.8398-0.019531-0.078125-0.023437-0.15625-0.007812-0.23438s0.046875-0.14844 0.09375-0.21484c0.046875-0.0625 0.10938-0.11328 0.17969-0.14844 0.066406-0.035156 0.14453-0.054688 0.22266-0.058594h0.67188c6.4883 0 12.5 2.5 16.086 6.6953 0.046875 0.054687 0.082031 0.11719 0.10547 0.1875 0.019531 0.066406 0.027344 0.14062 0.019531 0.21094-0.007813 0.070313-0.03125 0.14062-0.066406 0.19922-0.039063 0.0625-0.085938 0.11719-0.14453 0.16016-0.83203 0.58594-1.5195 1.3672-1.9961 2.2734-0.47656 0.90625-0.73047 1.9102-0.74609 2.9375 0 2.7812 1.875 5.2461 4.7812 6.2812 0.066406 0.023437 0.125 0.0625 0.17578 0.10938 0.050781 0.050781 0.09375 0.10938 0.12109 0.17188 0.03125 0.066406 0.042969 0.13672 0.042969 0.20703 0 0.074219-0.011719 0.14453-0.042969 0.20703-2.6211 6.1406-9.9883 10.266-18.332 10.266zm-7.0273-2.1094c2.2734 0.71875 4.6445 1.0781 7.0273 1.0703 7.7109 0 14.516-3.6523 17.145-9.1406-3.0195-1.293-4.957-4.0078-4.957-7.0625 0.007812-1.0977 0.25781-2.1758 0.73047-3.1641 0.47656-0.98828 1.1602-1.8594 2.0078-2.5469-3.4297-3.7227-8.9688-5.9258-14.93-5.9258 0.42969 2.1289 0.60156 4.3047 0.52344 6.4766 0 8.8203-2.9336 16.645-7.5469 20.293z" fill="#231f20"/>
-<path d="m1051.9 854.51c0.003906-2.3438-0.21875-4.6797-0.66016-6.9766-10.062 0.26562-18.129 6.6211-18.129 14.426 0 5.7266 4.3438 10.68 10.641 13.016 4.7656-3.1367 7.9297-11.117 8.1484-20.465z" fill="#754c29"/>
-<path d="m1043.7 875.49c-0.0625 0-0.125-0.011719-0.17969-0.03125-6.668-2.4727-10.977-7.7734-10.977-13.508 0-8.1016 8.1758-14.668 18.625-14.945 0.12109 0 0.23828 0.039063 0.33594 0.11719 0.09375 0.078125 0.16016 0.18359 0.18359 0.30469 0.44531 2.332 0.67188 4.6992 0.66797 7.0742-0.21875 9.5117-3.5078 17.691-8.3711 20.902-0.085938 0.054687-0.18359 0.082031-0.28516 0.085937zm7.0508-27.426c-9.6641 0.42969-17.168 6.4688-17.168 13.887 0 5.2227 3.9336 10.078 10.047 12.43 4.4727-3.125 7.4609-10.887 7.6914-19.887 0-2.1562-0.19141-4.3086-0.57031-6.4297z" fill="#231f20"/>
-<path d="m1034.6 856.7 3.1992 2.4023s-3.6133-0.65234-3.7578-1.2031c-0.14453-0.55078 0.55859-1.1992 0.55859-1.1992z" fill="#3c2415"/>
-<path d="m1033.8 858.72 3.7031 2.4023s-4.1875-0.65234-4.3672-1.1992c-0.18359-0.54688 0.66406-1.2031 0.66406-1.2031z" fill="#3c2415"/>
-<path d="m1063.4 865.95c0-2.0352-1.5156-3.6875-3.3867-3.6875-0.65234 0.011719-1.2852 0.21484-1.8281 0.58203-0.53906 0.36719-0.96094 0.88672-1.2148 1.4883 2.9531 0.81641 4.9414 2.3633 4.9414 4.4141-0.003907 0.09375-0.011719 0.18359-0.023438 0.27344 0.47656-0.35547 0.85938-0.81641 1.125-1.3516 0.26172-0.53125 0.39453-1.1211 0.38672-1.7188z" fill="#f47729"/>
-<path d="m1051.2 847.53c0.44141 2.2969 0.66406 4.6328 0.66016 6.9766 0.097656-2.3477-0.125-4.6914-0.66016-6.9766z" fill="#754c29"/>
-<path d="m1051.9 855.02c-0.13672 0-0.26953-0.058594-0.36328-0.15625-0.097656-0.097657-0.14844-0.22656-0.14844-0.36328 0-2.3086-0.22266-4.6094-0.66016-6.875-0.015625-0.066406-0.015625-0.13672-0.003907-0.20312 0.011719-0.070312 0.035157-0.13281 0.070313-0.19141 0.039063-0.058594 0.085937-0.10938 0.14062-0.14844 0.054688-0.039063 0.11719-0.066407 0.18359-0.082032s0.13672-0.019531 0.20312-0.007812c0.070312 0.011718 0.13281 0.039062 0.19141 0.074218 0.058594 0.035157 0.10547 0.082032 0.14453 0.14063 0.042969 0.054687 0.070313 0.11719 0.085938 0.18359 0.54688 2.3398 0.77344 4.7422 0.67578 7.1406-0.011719 0.13281-0.066406 0.25781-0.16406 0.34766-0.097656 0.089844-0.22266 0.14063-0.35547 0.14063z" fill="#231f20"/>
-<path d="m1067.6 854.02c-0.90625 0.63672-1.6484 1.4805-2.1641 2.4609-0.51953 0.97656-0.79688 2.0664-0.8125 3.1758 0 3.0781 2.1328 5.7109 5.125 6.7852 0.61328-1.418 0.92969-2.9492 0.93359-4.4922-0.039063-2.9297-1.1328-5.7461-3.082-7.9297z" fill="#754c29"/>
-<path d="m1070 867.1-0.45703-0.16406c-3.3242-1.1797-5.4844-4.0312-5.4844-7.2617 0.011718-1.1953 0.3125-2.3711 0.86719-3.4258 0.55469-1.0547 1.3555-1.9609 2.332-2.6445l0.38672-0.28516 0.3125 0.35547c2.0273 2.2773 3.1641 5.2109 3.1992 8.2656-0.003906 1.6133-0.33594 3.2109-0.97266 4.6953zm-2.5117-12.344c-0.73047 0.59375-1.3203 1.3438-1.7266 2.1953-0.41016 0.84766-0.625 1.7773-0.63672 2.7227 0 2.6289 1.6758 4.9961 4.3164 6.1016 0.46484-1.2188 0.70312-2.5117 0.71094-3.8203-0.039063-2.6328-0.98047-5.1758-2.6641-7.1992z" fill="#231f20"/>
-<path d="m1047 861.11c2.3984-0.30859 4.125-2.2422 3.8594-4.3125-0.26562-2.0742-2.4219-3.5039-4.8164-3.1953-2.3945 0.30859-4.1211 2.2383-3.8555 4.3086 0.26562 2.0742 2.418 3.5039 4.8125 3.1992z" fill="#231f20"/>
-<path d="m1047.1 860.63c1.7422-0.22266 2.9961-1.625 2.8047-3.1328-0.19141-1.5039-1.7578-2.543-3.5-2.3203-1.7383 0.22656-2.9961 1.6289-2.8047 3.1328 0.19531 1.5039 1.7617 2.5469 3.5 2.3203z" fill="#fff"/>
-<path d="m1046.9 859.09c0.65234-0.082031 1.1211-0.62109 1.0469-1.1992-0.074218-0.57812-0.66016-0.98047-1.3125-0.89844-0.65234 0.085937-1.1211 0.62109-1.0469 1.2031 0.070313 0.57812 0.66016 0.97656 1.3125 0.89453z" fill="#231f20"/>
-<path d="m1043.2 854.57c-0.046876 0-0.089844-0.007812-0.12891-0.023437l-1.207-0.47656c-0.050781-0.007812-0.10156-0.027344-0.14844-0.054687-0.042968-0.03125-0.082031-0.070313-0.10937-0.11719-0.027344-0.046875-0.042969-0.10156-0.046876-0.15234-0.003906-0.054688 0.003907-0.10938 0.023438-0.16016s0.050781-0.09375 0.089844-0.13281c0.039062-0.035157 0.085937-0.0625 0.14062-0.078125 0.050781-0.015625 0.10547-0.019532 0.15625-0.011719 0.054687 0.011719 0.10547 0.03125 0.14844 0.0625l1.2031 0.47266c0.085938 0.035157 0.15234 0.10156 0.1875 0.1875 0.039063 0.082031 0.039063 0.17578 0.011719 0.26172-0.027344 0.066406-0.074219 0.12109-0.12891 0.16016-0.058594 0.039063-0.125 0.0625-0.19141 0.0625z" fill="#231f20"/>
-<path d="m1044.2 853.75c-0.070312 0-0.14062-0.023438-0.19922-0.0625l-1.4453-1.0195c-0.074219-0.054687-0.125-0.13672-0.14062-0.22656s0.003906-0.18359 0.054687-0.26172c0.054688-0.070312 0.13672-0.12109 0.22266-0.13281 0.089843-0.015625 0.18359 0.003906 0.25781 0.050781l1.4492 1.0195c0.074219 0.054688 0.12109 0.13672 0.13672 0.22656 0.015624 0.089844-0.003907 0.18359-0.054688 0.25781-0.03125 0.046875-0.074219 0.082032-0.12109 0.10547-0.050781 0.027344-0.10547 0.039063-0.16016 0.042969z" fill="#231f20"/>
-<path d="m1062.4 858.05c0.26953-2.0703-1.4492-4.0039-3.8398-4.3164-2.3906-0.31641-4.5469 1.1055-4.8164 3.1719-0.26953 2.0703 1.4453 4.0039 3.8359 4.3203 2.3906 0.3125 4.5469-1.1094 4.8203-3.1758z" fill="#231f20"/>
-<path d="m1060.9 858.31c0.19141-1.5078-1.0664-2.9102-2.8047-3.1328-1.7422-0.22656-3.3086 0.8125-3.5 2.3203-0.19141 1.5039 1.0625 2.9062 2.8047 3.1328 1.7383 0.22266 3.3086-0.81641 3.5-2.3203z" fill="#fff"/>
-<path d="m1059 858.19c0.074218-0.57812-0.39453-1.1172-1.0469-1.1992-0.65234-0.082032-1.2422 0.31641-1.3164 0.89844-0.074218 0.57812 0.39453 1.1133 1.0469 1.1992 0.65234 0.082031 1.2422-0.32031 1.3164-0.89844z" fill="#231f20"/>
-<path d="m1061.4 854.57c-0.074219-0.007812-0.14453-0.039062-0.20312-0.09375-0.054688-0.050781-0.09375-0.11719-0.10547-0.19531-0.015625-0.074219-0.003906-0.15234 0.027344-0.22266 0.035156-0.066407 0.085937-0.125 0.15625-0.16016l1.207-0.47266c0.042969-0.03125 0.09375-0.050781 0.14844-0.0625 0.050781-0.007813 0.10547-0.003906 0.16016 0.011719 0.050781 0.015625 0.097656 0.042968 0.13672 0.078125 0.039063 0.039062 0.070313 0.082031 0.089844 0.13281 0.019532 0.050781 0.027344 0.10547 0.023438 0.16016-0.003906 0.050781-0.019532 0.10547-0.046875 0.15234-0.027344 0.046875-0.066407 0.085938-0.10938 0.11719-0.046875 0.027343-0.097656 0.046875-0.14844 0.054687l-1.2109 0.47656c-0.039063 0.015625-0.082031 0.023437-0.125 0.023437z" fill="#231f20"/>
-<path d="m1060.4 853.75c-0.074219-0.007812-0.14063-0.03125-0.19531-0.078125-0.054687-0.042969-0.097656-0.10156-0.11719-0.17188-0.023438-0.066406-0.023438-0.14062-0.003907-0.20703 0.019531-0.070313 0.0625-0.12891 0.11719-0.17578l1.4453-1.0156c0.035157-0.042968 0.078125-0.074218 0.12891-0.09375 0.050781-0.023437 0.10156-0.03125 0.15625-0.027343 0.054687 0.003906 0.10547 0.015625 0.15234 0.042969 0.046875 0.027343 0.089844 0.0625 0.12109 0.10547 0.027344 0.046875 0.050781 0.097656 0.058594 0.14844 0.007812 0.054687 0.003906 0.10938-0.011719 0.16016s-0.039062 0.10156-0.078125 0.14062c-0.035156 0.039063-0.078125 0.070313-0.12891 0.089844l-1.4453 1.0195c-0.0625 0.039062-0.12891 0.0625-0.19922 0.0625z" fill="#231f20"/>
-<path d="m1061.9 868.74c0 3.1016-4.5234 5.625-10.102 5.625-5.5742 0-10.098-2.5-10.098-5.6172 0-3.1133 4.5234-5.0586 10.098-5.0586 5.5781 0 10.102 1.9453 10.102 5.0508z" fill="#fff"/>
-<path d="m1051.9 873.29c-3.6602 0.023437-7.082-0.92578-10.156-4.5352 0.24609 3.7812 4.8516 5.4492 10.02 5.4492 5.5781 0 9.5977-2.1406 10.098-5.4492-2.8789 3.1367-4.7891 4.4883-9.9609 4.5352z" fill="#e6e7e8"/>
-<path d="m1052 872.7c-3.0781 0-5.8867-1.6172-7.1719-4.1367-0.019531-0.074219-0.011719-0.16016 0.023437-0.23047 0.03125-0.074219 0.089844-0.13281 0.16016-0.17188 0.070312-0.035156 0.15234-0.046875 0.23047-0.03125 0.078124 0.015625 0.14844 0.058594 0.19922 0.11719 1.1719 2.2891 3.7383 3.7578 6.5586 3.7578h0.09375c2.7422-0.035156 5.2656-1.4844 6.4258-3.6914 0.011719-0.054688 0.039063-0.10156 0.074219-0.14453 0.03125-0.039063 0.078125-0.074219 0.125-0.09375 0.050781-0.023438 0.10156-0.03125 0.15625-0.03125 0.054688 0.003906 0.10547 0.015625 0.15234 0.042969 0.050781 0.023437 0.089844 0.058593 0.12109 0.10156 0.03125 0.046875 0.054687 0.09375 0.0625 0.14844 0.011718 0.054687 0.007812 0.10547-0.003907 0.16016-0.015625 0.050781-0.042969 0.097656-0.078125 0.14062-1.293 2.4688-3.9883 4.0273-7.0273 4.0625z" fill="#231f20"/>
-<path d="m1051.8 874.88c-5.9531 0-10.613-2.6953-10.613-6.1367 0-3.2852 4.3633-5.5781 10.613-5.5781 6.2539 0 10.617 2.2773 10.617 5.5781 0 3.4414-4.6641 6.1367-10.617 6.1367zm0-10.676c-5.5508 0-9.5781 1.9102-9.5781 4.5391 0 2.7617 4.3867 5.0938 9.5977 5.0938 5.2109 0 9.5938-2.332 9.5938-5.0938-0.03125-2.6289-4.0586-4.5391-9.6133-4.5391z" fill="#231f20"/>
-<path d="m1052.4 865.8h-0.8125v6.7266h0.8125z" fill="#231f20"/>
-<path d="m1054.9 864.01c0 1.6406-2.9609 2.6562-2.9609 2.6562s-2.957-1.0117-2.957-2.6562 1.3242-1.4531 2.957-1.4531c1.6289 0 2.9609-0.18359 2.9609 1.4531z" fill="#231f20"/>
-<path d="m1052 863.97c1.0625 0 1.9219-0.14844 1.9219-0.33203 0-0.18359-0.85938-0.33203-1.9219-0.33203s-1.9219 0.14844-1.9219 0.33203c0 0.18359 0.85938 0.33203 1.9219 0.33203z" fill="#a7a9ac"/>
-<path d="m1062 898.33c0 1.457-0.66016 7.6719-4.3672 7.2148-2.0078-0.25-4.8555-3.3945-3.6562-4.2109 1.2773-0.86719-1.2734-5.3359 0.44531-4.2031 1.7188 1.1367 7.5781-0.25781 7.5781 1.1992z" fill="#f47729"/>
-<path d="m1060 903.82c0 1.4609-1.3711 1.9805-3.5195 1.9805-2.1523 0-3.9102-1.1836-3.9102-2.6445 0-1.457 0.96875-2.6719 2.8008-1.5352 1.8281 1.1328 4.6289 0.74609 4.6289 2.1992z" fill="#fff"/>
-<path d="m1056.2 904.42c-1.3164-0.48828-2.5156-1.25-3.5195-2.2383-0.09375 0.23437-0.14453 0.48437-0.14453 0.73828 0 1.5977 1.8867 2.8867 4.2109 2.8867 1 0.011718 1.9883-0.25781 2.8438-0.77734-1.1562-0.003906-2.3047-0.21094-3.3906-0.60938z" fill="#e6e7e8"/>
-<path d="m1056.8 906.24c-2.5625 0-4.6445-1.4922-4.6445-3.3242 0-1.1641 0.82422-2.2188 2.1797-2.8242-0.20312-0.96875-0.32031-1.957-0.35547-2.9453-0.007812-0.0625 0-0.12109 0.015625-0.17969 0.019531-0.058594 0.046875-0.10938 0.085938-0.15625 0.039062-0.046875 0.085937-0.082031 0.14062-0.10938 0.054687-0.027344 0.11328-0.039063 0.17578-0.042969 0.058594 0 0.11719 0.007813 0.17188 0.03125 0.058594 0.023438 0.10938 0.054688 0.14844 0.097656 0.042968 0.042969 0.078124 0.097657 0.097656 0.15234 0.019531 0.054688 0.03125 0.11719 0.027344 0.17578 0.035156 1.0586 0.17187 2.1133 0.41016 3.1445l0.085937 0.375-0.35547 0.13281c-1.2109 0.44141-1.9609 1.2656-1.9609 2.1406 0 1.3555 1.6953 2.4531 3.7773 2.4531 1.6641 0 3.1523-0.71484 3.6289-1.7852 0.875-2.1172 1.4844-4.3398 1.8086-6.6094 0.023437-0.10938 0.085937-0.20312 0.17578-0.26953 0.09375-0.0625 0.20312-0.089844 0.3125-0.074219s0.20703 0.074219 0.27734 0.16016c0.066406 0.089844 0.10156 0.19922 0.09375 0.30859-0.33594 2.3516-0.96484 4.6523-1.875 6.8477-0.625 1.3789-2.3984 2.3008-4.4219 2.3008z" fill="#231f20"/>
-<path d="m1041.5 898.33c0 1.457 0.65625 7.6719 4.3672 7.2148 2.0039-0.25 4.8555-3.3945 3.6523-4.2109-1.2734-0.86719 0.78125-5.3359-0.93359-4.2031-1.7148 1.1367-7.0859-0.25781-7.0859 1.1992z" fill="#754c29"/>
-<path d="m1043.4 903.82c0 1.4609 1.3711 1.9805 3.5195 1.9805 2.1523 0 3.9102-1.1836 3.9102-2.6445 0-1.457-0.96875-2.6719-2.8008-1.5352-1.8281 1.1328-4.6289 0.74609-4.6289 2.1992z" fill="#fff"/>
-<path d="m1047.6 904.55c1.2891-0.55469 2.4492-1.3789 3.3984-2.4141 0.10156 0.22656 0.16406 0.46875 0.17969 0.71484 0.082032 1.5938-1.7344 2.9844-4.0547 3.1016-1.0078 0.066406-2.0117-0.15234-2.8984-0.63281 1.1602-0.058594 2.3008-0.32031 3.375-0.76953z" fill="#e6e7e8"/>
-<path d="m1046.6 906.24c-2.0234 0-3.7969-0.92188-4.4141-2.2891-0.91016-2.1914-1.5391-4.4922-1.8789-6.8438-0.011718-0.10938 0.023438-0.21875 0.09375-0.30469 0.066406-0.085938 0.16406-0.14453 0.27344-0.16016s0.22266 0.011719 0.3125 0.074219 0.15234 0.16016 0.17578 0.26562c0.32812 2.2773 0.9375 4.5039 1.8164 6.625 0.46875 1.0352 1.9609 1.7617 3.6211 1.7617 2.082 0 3.7773-1.1016 3.7773-2.4531 0-0.88672-0.75-1.7109-1.957-2.1406l-0.35547-0.13281 0.085937-0.375c0.23828-1.0312 0.375-2.0859 0.40625-3.1445 0-0.058594 0.007813-0.12109 0.027344-0.17578 0.023438-0.058594 0.054688-0.10938 0.097656-0.15234 0.042969-0.042969 0.09375-0.078125 0.14844-0.097656 0.054687-0.023438 0.11719-0.035157 0.17578-0.03125 0.058594 0 0.11719 0.015625 0.17188 0.042969 0.054688 0.023437 0.10156 0.0625 0.14062 0.10937 0.039063 0.042969 0.070313 0.097657 0.085937 0.15625 0.019532 0.054688 0.023438 0.11719 0.019532 0.17578-0.035156 0.99219-0.15625 1.9805-0.35547 2.9492 1.3516 0.60547 2.1758 1.6602 2.1758 2.8242 0.015625 1.8242-2.0664 3.3164-4.6445 3.3164z" fill="#231f20"/>
-<path d="m1058 867.38c0.27734 0 0.5-0.22266 0.5-0.5 0-0.28125-0.22266-0.50391-0.5-0.50391-0.27734 0-0.5 0.22266-0.5 0.50391 0 0.27734 0.22266 0.5 0.5 0.5z" fill="#e6e7e8"/>
-<path d="m1057.1 866.14c0.27344 0 0.5-0.22656 0.5-0.50391 0-0.27734-0.22656-0.50391-0.5-0.50391-0.27734 0-0.50391 0.22656-0.50391 0.50391 0 0.27734 0.22656 0.50391 0.50391 0.50391z" fill="#e6e7e8"/>
-<path d="m1056.7 867.91c0.27734 0 0.5-0.22656 0.5-0.50391s-0.22266-0.50391-0.5-0.50391c-0.27734 0-0.50391 0.22656-0.50391 0.50391s0.22656 0.50391 0.50391 0.50391z" fill="#e6e7e8"/>
-<path d="m1046 867.42c0.27344 0 0.5-0.22656 0.5-0.50391 0-0.27734-0.22656-0.50391-0.5-0.50391-0.27734 0-0.50391 0.22656-0.50391 0.50391 0 0.27734 0.22656 0.50391 0.50391 0.50391z" fill="#e6e7e8"/>
-<path d="m1047.4 867.91c0.27734 0 0.50391-0.22656 0.50391-0.50391s-0.22656-0.50391-0.50391-0.50391c-0.27734 0-0.5 0.22656-0.5 0.50391s0.22266 0.50391 0.5 0.50391z" fill="#e6e7e8"/>
-<path d="m1047.2 866.3c0.27734 0 0.5-0.22656 0.5-0.50391 0-0.27734-0.22266-0.50391-0.5-0.50391s-0.50391 0.22656-0.50391 0.50391c0 0.27734 0.22656 0.50391 0.50391 0.50391z" fill="#e6e7e8"/>
-<path d="m1065.6 867.31-7.1914-0.078125c-0.09375 0-0.18359-0.039063-0.25-0.10547-0.066407-0.066406-0.10547-0.16016-0.10547-0.25391s0.039062-0.18359 0.10547-0.25c0.066406-0.070313 0.15625-0.10547 0.25-0.10547l7.1875 0.085937c0.09375 0 0.18359 0.035157 0.25 0.10547 0.066406 0.066407 0.10547 0.15625 0.10547 0.25s-0.039063 0.1875-0.10547 0.25391c-0.066407 0.066406-0.15625 0.10547-0.25 0.10547z" fill="#231f20"/>
-<path d="m1057.4 865.96c-0.074219-0.007812-0.14844-0.039062-0.20312-0.09375-0.054688-0.050781-0.09375-0.11719-0.10938-0.19531-0.011719-0.074219-0.003906-0.15234 0.03125-0.22266 0.03125-0.066406 0.085937-0.125 0.15234-0.16016l6.7539-2.668c0.042968-0.03125 0.09375-0.050782 0.14844-0.0625 0.050781-0.007813 0.10547-0.003907 0.15625 0.011718s0.097657 0.042969 0.13672 0.078125c0.042969 0.039063 0.070312 0.082031 0.089844 0.13281 0.023437 0.050781 0.03125 0.10156 0.027344 0.15625-0.003907 0.054687-0.019532 0.10547-0.046876 0.15234-0.027343 0.046874-0.0625 0.085937-0.10937 0.11719-0.042969 0.03125-0.09375 0.050781-0.14453 0.058594l-6.7539 2.6719c-0.039062 0.015625-0.085938 0.023437-0.12891 0.023437z" fill="#231f20"/>
-<path d="m1038.6 867.31c-0.09375 0-0.18359-0.039063-0.25-0.10547-0.066406-0.066406-0.10547-0.15625-0.10547-0.25391 0-0.09375 0.039063-0.18359 0.10547-0.25 0.066407-0.066407 0.15625-0.10547 0.25-0.10547l7.1836-0.078125c0.09375 0 0.18359 0.035156 0.25 0.10547 0.070313 0.066406 0.10547 0.15625 0.10547 0.25s-0.035156 0.1875-0.10547 0.25391c-0.066406 0.066406-0.15625 0.10547-0.25 0.10547l-7.1875 0.085937z" fill="#231f20"/>
-<path d="m1046.8 865.96c-0.046874 0-0.089843-0.007812-0.12891-0.023437l-6.7695-2.6719c-0.054687-0.007813-0.10547-0.027344-0.14844-0.058594-0.042969-0.03125-0.082032-0.070313-0.10938-0.11719-0.027343-0.046876-0.042968-0.097657-0.046874-0.15234-0.003907-0.054688 0.007812-0.10547 0.027343-0.15625 0.019531-0.050782 0.050781-0.09375 0.089844-0.13281 0.039063-0.035156 0.085937-0.0625 0.13672-0.078125 0.050781-0.015625 0.10547-0.019531 0.15625-0.011718 0.054687 0.011718 0.10547 0.03125 0.14844 0.0625l6.7539 2.668c0.066406 0.035156 0.12109 0.09375 0.15234 0.16016 0.035157 0.070313 0.046875 0.14844 0.03125 0.22266-0.015625 0.078125-0.054687 0.14453-0.10938 0.19531-0.054687 0.054688-0.12891 0.085938-0.20312 0.09375z" fill="#231f20"/>
-<path d="m1080.9 911.89c5.8633 0 10.617-4.7773 10.617-10.668s-4.7539-10.664-10.617-10.664c-5.8672 0-10.621 4.7734-10.621 10.664s4.7539 10.668 10.621 10.668z" fill="#ef4136"/>
-<path d="m1080.9 890.55c2.0977 0 4.1523 0.625 5.8984 1.7969 1.75 1.1719 3.1094 2.8359 3.9141 4.7852 0.80469 1.9492 1.0156 4.0938 0.60547 6.1641-0.41016 2.0664-1.4219 3.9688-2.9062 5.4609-1.4844 1.4922-3.375 2.5078-5.4375 2.9219-2.0586 0.41016-4.1953 0.19922-6.1367-0.60938-1.9375-0.80469-3.5977-2.1719-4.7656-3.9258-1.168-1.7539-1.7891-3.8164-1.7891-5.9258 0-2.8281 1.1172-5.543 3.1094-7.543 1.9922-2 4.6914-3.125 7.5078-3.125zm0-0.38672c-2.1797 0-4.3086 0.64844-6.1211 1.8672-1.8125 1.2148-3.2266 2.9414-4.0586 4.9648-0.83594 2.0234-1.0508 4.2461-0.62891 6.3945 0.42578 2.1445 1.4766 4.1172 3.0156 5.6641 1.543 1.5508 3.5039 2.6016 5.6406 3.0312 2.1406 0.42578 4.3555 0.20703 6.3672-0.62891 2.0117-0.83984 3.7344-2.2578 4.9453-4.0781 1.2109-1.8203 1.8555-3.957 1.8555-6.1484 0-2.9336-1.1602-5.75-3.2266-7.8242-2.0664-2.0742-4.8672-3.2422-7.7891-3.2422z" fill="#ef4136"/>
-<path d="m1071.5 897.77c-0.050782-0.003906-0.10156-0.019531-0.14062-0.050781l0.14062-0.21094-0.17969-0.17969 0.035156-0.035156c1.2305-1.4023 5.6875-6.0078 11.602-6.4258 0.066406-0.003907 0.13281 0.019531 0.18359 0.0625 0.050781 0.042968 0.082031 0.10547 0.089843 0.17187 0.003907 0.035157 0 0.070313-0.011718 0.10156-0.011719 0.03125-0.027344 0.0625-0.050782 0.085937-0.023437 0.027344-0.050781 0.046876-0.078124 0.0625-0.03125 0.015626-0.0625 0.023438-0.097657 0.027344-5.8555 0.41406-10.402 5.2773-11.254 6.25-0.027344 0.039063-0.066406 0.070313-0.10547 0.097656-0.042968 0.023438-0.085937 0.039063-0.13281 0.042969z" fill="#fbb040"/>
-<path d="m1070.8 899.93c-0.050781 0-0.10156-0.015625-0.14453-0.042969-0.027344-0.019531-0.050781-0.042968-0.070313-0.070312-0.019531-0.027344-0.03125-0.058594-0.039062-0.09375-0.007812-0.03125-0.007812-0.066406 0-0.10156 0.007812-0.03125 0.019531-0.0625 0.039062-0.089844 0.054688-0.078125 5.3516-8.0156 14.086-8.0156 0.066406 0 0.13281 0.027343 0.17969 0.074219 0.046874 0.050781 0.074218 0.11328 0.074218 0.18359 0 0.066407-0.027344 0.13281-0.074218 0.17969-0.046876 0.050781-0.11328 0.078125-0.17969 0.078125-8.457 0-13.609 7.7031-13.664 7.7812-0.019532 0.035156-0.050782 0.066406-0.089844 0.085937-0.035156 0.019531-0.078125 0.03125-0.11719 0.03125z" fill="#fbb040"/>
-<path d="m1070.8 901.3c-0.042969 0-0.089844-0.011719-0.12891-0.035157-0.039063-0.019531-0.070313-0.054687-0.09375-0.09375-0.023438-0.039062-0.035156-0.082031-0.03125-0.12891 0-0.046875 0.011718-0.089844 0.035156-0.12891 0.058594-0.097657 5.7578-9.5859 15.457-8.6641 0.0625 0.011719 0.12109 0.046875 0.16016 0.097656 0.039062 0.050782 0.058593 0.11719 0.050781 0.18359-0.003907 0.0625-0.035157 0.125-0.082031 0.16797-0.050782 0.042969-0.11328 0.0625-0.17969 0.0625-9.3828-0.89844-14.926 8.3203-14.969 8.4141-0.023438 0.039062-0.054688 0.070312-0.09375 0.089843-0.035156 0.023438-0.078125 0.035157-0.125 0.035157z" fill="#fbb040"/>
-<path d="m1090.2 905.82c-0.03125 0-0.066406-0.007812-0.097656-0.019531-0.027344-0.011719-0.058594-0.03125-0.082031-0.054687-0.023438-0.023438-0.042969-0.050782-0.054688-0.082032-0.011718-0.03125-0.019531-0.066406-0.019531-0.097656 0-9.7383-4.5938-12.016-4.6406-12.039-0.035156-0.011719-0.066406-0.027344-0.09375-0.054688-0.027344-0.023438-0.046875-0.054688-0.0625-0.085938-0.011719-0.03125-0.019531-0.070312-0.019531-0.10547s0.007812-0.070313 0.023437-0.10547c0.015625-0.03125 0.039063-0.058594 0.0625-0.085937 0.027344-0.023438 0.0625-0.039063 0.09375-0.050782 0.035156-0.011718 0.070313-0.011718 0.10547-0.007812 0.039063 0.003906 0.070313 0.015625 0.10156 0.035156 0.20312 0.089844 4.9375 2.4023 4.9375 12.492 0 0.035156-0.003907 0.066406-0.015626 0.097656-0.011718 0.03125-0.03125 0.0625-0.054687 0.085937-0.023437 0.023438-0.050781 0.042969-0.082031 0.058594-0.03125 0.011719-0.066406 0.019531-0.10156 0.019531z" fill="#fbb040"/>
-<path d="m1089.5 906.77c-0.066406 0-0.12891-0.027344-0.17578-0.070313-0.050781-0.046874-0.078124-0.11328-0.078124-0.17969-0.1875-11.422-5.3086-13.141-5.3555-13.152-0.066407-0.023437-0.12109-0.066406-0.15234-0.12891-0.03125-0.058594-0.039063-0.12891-0.019531-0.19531 0.007812-0.03125 0.027344-0.058593 0.046875-0.085937s0.046875-0.046875 0.078125-0.0625c0.027344-0.015625 0.058594-0.023437 0.09375-0.027344 0.03125-0.003906 0.066406 0 0.097656 0.007813 0.22656 0.070312 5.5234 1.7852 5.7227 13.633 0 0.035156-0.007812 0.070313-0.019531 0.10156s-0.03125 0.058593-0.054687 0.082031c-0.023438 0.023438-0.050782 0.042969-0.082032 0.058594-0.03125 0.011718-0.0625 0.019531-0.097656 0.019531z" fill="#fbb040"/>
-<path d="m1088.6 907.98c-0.066406-0.007813-0.12891-0.035157-0.17578-0.085938-0.042969-0.054687-0.066406-0.12109-0.0625-0.1875 0.66797-10.688-4.4297-13.504-5.1094-13.828h-0.023438c-0.19141-0.074218-0.26562-0.1875-0.22266-0.33984 0.015625-0.058593 0.054688-0.11328 0.10938-0.14453 0.054688-0.035156 0.11719-0.046875 0.17969-0.035156l0.074219 0.027344 0.042968 0.015625c0.019532 0.007812 0.039063 0.019531 0.054688 0.035156 1.0273 0.49609 6.0703 3.5664 5.3984 14.309-0.003906 0.066406-0.035156 0.12891-0.085937 0.17188-0.050782 0.042969-0.11328 0.0625-0.17969 0.0625z" fill="#fbb040"/>
-<path d="m1087.6 909.41h-0.046875c-0.035156-0.003906-0.066406-0.015624-0.09375-0.035156-0.027344-0.015625-0.054687-0.039062-0.074218-0.070312-0.015626-0.027344-0.03125-0.058594-0.039063-0.089844s-0.007813-0.066406 0-0.10156c2.1797-12.02-5.6133-15.207-5.6875-15.242-0.03125-0.011719-0.058594-0.027344-0.082031-0.050781-0.023438-0.023438-0.042969-0.050781-0.058594-0.082031-0.011719-0.03125-0.019531-0.0625-0.019531-0.097657-0.003907-0.03125 0.003906-0.066406 0.015625-0.097656 0.011718-0.03125 0.027344-0.058594 0.050781-0.085937 0.023437-0.023438 0.050781-0.042969 0.082031-0.054688 0.03125-0.015625 0.0625-0.023438 0.097656-0.023438 0.03125 0 0.066407 0.007813 0.097657 0.019532 0.082031 0.03125 8.2617 3.375 6.0078 15.805-0.011719 0.058594-0.042969 0.11328-0.089843 0.14844-0.042969 0.039062-0.10156 0.058593-0.16016 0.058593z" fill="#fbb040"/>
-<path d="m1076.8 910.59c-0.066406 0-0.12891-0.027344-0.17969-0.074219-0.046874-0.046875-0.074218-0.10938-0.074218-0.17969-0.11328-7.3047 4.6172-16.207 4.6641-16.297 0.035156-0.054687 0.089844-0.089844 0.15234-0.10547 0.0625-0.015626 0.125-0.007813 0.17969 0.023437 0.058593 0.03125 0.097656 0.082031 0.12109 0.14062 0.019531 0.058594 0.019531 0.125-0.003906 0.18359-0.046875 0.089844-4.7188 8.875-4.6016 16.062 0 0.070312-0.027343 0.13281-0.074218 0.18359-0.046875 0.046874-0.11328 0.078124-0.17969 0.078124z" fill="#fbb040"/>
-<path d="m1075.9 910.36c-0.066406 0-0.12891-0.027344-0.17578-0.074219-0.050781-0.046875-0.078125-0.11328-0.078125-0.17969-0.10938-7.3047 4.7305-16.289 4.7812-16.379 0.035156-0.054687 0.085938-0.09375 0.15234-0.10937 0.0625-0.015626 0.12891-0.007813 0.18359 0.023437 0.058594 0.03125 0.10156 0.085937 0.12109 0.14453 0.019531 0.0625 0.015624 0.12891-0.011719 0.1875-0.050781 0.089844-4.8281 8.9531-4.7188 16.125 0 0.070313-0.023438 0.13281-0.070313 0.18359-0.046875 0.046875-0.11328 0.078125-0.17969 0.078125z" fill="#fbb040"/>
-<path d="m1077.6 910.95c-0.035156-0.003907-0.066406-0.011719-0.097656-0.023438-0.027344-0.015625-0.054688-0.035156-0.078125-0.058593-0.023438-0.027344-0.039063-0.054688-0.050782-0.085938-0.011718-0.03125-0.015624-0.0625-0.015624-0.097656 0.32422-8.3633 4.4375-16.008 4.4805-16.082 0.015625-0.03125 0.039063-0.058593 0.066406-0.082031 0.023438-0.019531 0.054688-0.039062 0.089844-0.046875 0.035156-0.011718 0.066406-0.011718 0.10156-0.007812 0.035156 0.003906 0.070312 0.015625 0.097656 0.035156 0.03125 0.015625 0.058594 0.039062 0.078125 0.0625 0.023438 0.027344 0.039062 0.058594 0.046875 0.09375 0.011719 0.03125 0.011719 0.066406 0.007813 0.10156-0.003907 0.035157-0.015626 0.066407-0.03125 0.097657-0.039063 0.074219-4.0977 7.6172-4.4219 15.855-0.003906 0.035156-0.011718 0.066406-0.027343 0.097656s-0.035157 0.058594-0.0625 0.078125c-0.023438 0.023437-0.054688 0.039062-0.085938 0.050781-0.03125 0.007812-0.066406 0.011719-0.097656 0.011719z" fill="#fbb040"/>
-<path d="m1079.3 911.31c-0.0625-0.003906-0.125-0.027344-0.17188-0.074219-0.046875-0.042969-0.074219-0.10547-0.078125-0.17188-0.39844-7.0977 4.1367-15.59 4.1836-15.676 0.015624-0.03125 0.035156-0.058594 0.0625-0.082031 0.027343-0.023438 0.058593-0.039063 0.089843-0.046875 0.035157-0.011719 0.070313-0.015625 0.10547-0.007813 0.035156 0.003906 0.066406 0.015625 0.097656 0.03125 0.027344 0.015625 0.054688 0.039063 0.078125 0.066406 0.019531 0.027344 0.035157 0.058594 0.046875 0.089844 0.007813 0.035156 0.011719 0.070313 0.007813 0.10547-0.003907 0.03125-0.015625 0.066406-0.03125 0.097656-0.046875 0.085938-4.5117 8.4531-4.1211 15.406 0 0.03125-0.003906 0.066407-0.015625 0.097657s-0.027344 0.0625-0.050781 0.085937c-0.023438 0.027344-0.050781 0.046875-0.078125 0.0625-0.03125 0.015625-0.066406 0.023437-0.097656 0.023437z" fill="#fbb040"/>
-<path d="m1078.5 911.32c-0.066406 0-0.12891-0.027344-0.17578-0.070312-0.046874-0.046875-0.074218-0.10938-0.078124-0.17188-0.39844-7.1016 4.2266-15.984 4.2656-16.066 0.011719-0.03125 0.035157-0.0625 0.058594-0.085937 0.027344-0.023437 0.058594-0.042969 0.089844-0.054687 0.035156-0.011719 0.070312-0.015626 0.10547-0.011719 0.035156 0.003906 0.066406 0.011719 0.097656 0.027343 0.03125 0.019532 0.058594 0.039063 0.082031 0.066407 0.023438 0.027343 0.039063 0.0625 0.046875 0.09375 0.007813 0.035156 0.011719 0.070312 0.007813 0.10547-0.007813 0.035156-0.019532 0.070312-0.039063 0.097656-0.046875 0.089844-4.6172 8.8477-4.2148 15.805 0.003906 0.035157 0 0.066407-0.011719 0.10156-0.011719 0.03125-0.03125 0.058594-0.050781 0.085937-0.023438 0.023438-0.050782 0.042969-0.082032 0.058594s-0.0625 0.023437-0.097656 0.027344z" fill="#fbb040"/>
-<path d="m1080.2 911.73c-0.0625 0-0.125-0.023437-0.17187-0.066406-0.046876-0.042968-0.074219-0.10547-0.082032-0.16797-0.625-7.0312 3.8477-15.453 3.9102-15.535 0.035157-0.050781 0.089844-0.089843 0.15234-0.10547 0.0625-0.011718 0.125-0.003906 0.17969 0.023438 0.058594 0.03125 0.097656 0.082031 0.12109 0.14062 0.019531 0.058594 0.019531 0.125-0.003907 0.18359-0.046875 0.082031-4.4453 8.3672-3.832 15.25 0.003906 0.066406-0.015625 0.13281-0.058594 0.18359-0.042968 0.054688-0.10547 0.085938-0.17188 0.09375z" fill="#fbb040"/>
-<path d="m1085.7 898.44h-0.066406c-0.23047-0.058594-0.76953-0.16406-1.125-0.23047l-0.28906-0.058593c-0.066407-0.011719-0.125-0.050782-0.16016-0.10938-0.039062-0.054687-0.050781-0.125-0.039062-0.19141 0.015625-0.066406 0.054687-0.125 0.10938-0.16016 0.054687-0.039062 0.125-0.050781 0.19141-0.039062l0.28125 0.054687c0.38672 0.074219 0.91016 0.17578 1.1562 0.23828 0.058594 0.019532 0.10938 0.054688 0.14062 0.10547 0.035156 0.050781 0.050781 0.11328 0.042969 0.17188-0.007813 0.0625-0.035156 0.11719-0.082032 0.15625-0.042968 0.042969-0.10156 0.066406-0.16016 0.070312z" fill="#fbb040"/>
-<path d="m1086.6 901.3c-0.027344 0.003906-0.054688 0.003906-0.082032 0l-0.39062-0.13281c-0.80078-0.26953-2.293-0.77734-2.8711-0.92578-0.03125-0.007813-0.0625-0.023438-0.089844-0.042969s-0.046875-0.042969-0.066406-0.074219c-0.015625-0.027344-0.027344-0.058594-0.03125-0.09375-0.003906-0.03125 0-0.066406 0.007812-0.097656 0.015625-0.066406 0.058594-0.12109 0.11719-0.15625 0.054687-0.035156 0.125-0.046875 0.19141-0.03125 0.59375 0.15625 2.0391 0.64453 2.9023 0.9375l0.39453 0.12891c0.0625 0.023438 0.11719 0.070313 0.14453 0.13281 0.03125 0.058593 0.035156 0.12891 0.015625 0.19531-0.019531 0.046875-0.050781 0.089844-0.09375 0.11719-0.042969 0.027343-0.09375 0.042969-0.14844 0.042969z" fill="#fbb040"/>
-<path d="m1087 902.3c-0.023437 0.003906-0.054687 0.003906-0.078125 0l-0.50781-0.17578c-1.1289-0.42188-2.2891-0.76953-3.4648-1.0391-0.03125-0.003906-0.0625-0.015625-0.09375-0.03125-0.027344-0.019531-0.050781-0.042969-0.070312-0.070312-0.019532-0.023438-0.035157-0.054688-0.042969-0.089844-0.007813-0.03125-0.007813-0.066406-0.003907-0.097656 0.003907-0.035157 0.015626-0.066407 0.035157-0.09375 0.015625-0.027344 0.039062-0.054688 0.066406-0.074219s0.058594-0.03125 0.089844-0.039062c0.03125-0.007813 0.066406-0.011719 0.097656-0.003907 1.207 0.27344 2.3945 0.62891 3.5547 1.0703l0.5 0.17188c0.058594 0.019531 0.10547 0.058593 0.13672 0.10938 0.03125 0.050781 0.042969 0.11328 0.035157 0.17188-0.011719 0.0625-0.042969 0.11719-0.085938 0.15625-0.046875 0.039062-0.10547 0.058593-0.16797 0.0625z" fill="#fbb040"/>
-<path d="m1087.2 903.18c-0.027343 0.007812-0.058593 0.007812-0.089843 0-1.3438-0.53516-2.7461-0.91797-4.1797-1.1445-0.066406-0.007812-0.125-0.042968-0.16797-0.09375-0.042969-0.054687-0.0625-0.12109-0.054687-0.1875 0.007812-0.066406 0.042968-0.12891 0.097656-0.17187 0.050781-0.042969 0.12109-0.0625 0.1875-0.054688 1.4688 0.23047 2.9102 0.62109 4.293 1.1719 0.0625 0.023437 0.11328 0.070313 0.14062 0.13281 0.03125 0.0625 0.035156 0.13281 0.011718 0.19531-0.019531 0.046875-0.054687 0.085938-0.097656 0.11328-0.039062 0.027344-0.089844 0.042969-0.14062 0.039063z" fill="#fbb040"/>
-<path d="m1087.2 904.07c-0.03125 0.003906-0.0625 0.003906-0.09375 0-1.5352-0.59766-3.125-1.0352-4.7461-1.3125-0.035156-0.003906-0.066406-0.015625-0.09375-0.03125-0.027344-0.019531-0.054688-0.042968-0.074219-0.066406-0.019531-0.027344-0.035156-0.058594-0.042969-0.089844-0.007812-0.035156-0.007812-0.066406-0.003906-0.10156 0.011719-0.066406 0.046875-0.12891 0.10156-0.16797 0.050782-0.039063 0.12109-0.058594 0.1875-0.050781 1.6562 0.28516 3.2852 0.73438 4.8555 1.3398 0.03125 0.011718 0.058594 0.03125 0.082031 0.050781 0.027344 0.023437 0.046876 0.050781 0.058594 0.082031 0.015625 0.03125 0.023438 0.0625 0.023438 0.097656s-0.003906 0.066406-0.015625 0.097656c-0.019531 0.046876-0.054688 0.085938-0.097657 0.10938-0.042968 0.027343-0.089843 0.042968-0.14062 0.042968z" fill="#fbb040"/>
-<path d="m1087.2 904.95c-0.046875 0.003907-0.089843-0.011718-0.12891-0.035156-1.0273-0.60156-2.6484-0.90234-4.0742-1.168-0.35547-0.0625-0.6875-0.125-0.99609-0.19141-0.035156-0.003906-0.066406-0.019531-0.09375-0.035156-0.027343-0.019531-0.050781-0.042969-0.070312-0.070313-0.019531-0.03125-0.03125-0.0625-0.039062-0.09375-0.003907-0.035156-0.003907-0.066406 0.003906-0.10156 0.011718-0.066406 0.054687-0.125 0.10938-0.16016 0.058593-0.039063 0.125-0.050782 0.19141-0.039063 0.30469 0.066407 0.64062 0.125 0.98438 0.19141 1.4688 0.27344 3.1367 0.58203 4.2422 1.2305 0.046874 0.027344 0.082031 0.070313 0.10156 0.125 0.019531 0.050782 0.023438 0.10547 0.007812 0.16016-0.011718 0.050782-0.042968 0.10156-0.085937 0.13281-0.042969 0.035156-0.097656 0.054687-0.15234 0.054687z" fill="#fbb040"/>
-<path d="m1081.7 904.86c-0.054688 0-0.11328-0.019531-0.15625-0.054687-0.042969-0.035157-0.074219-0.085938-0.089844-0.14063-0.011719-0.058593-0.007813-0.11719 0.019531-0.16797 0.023438-0.050782 0.0625-0.09375 0.11328-0.12109l1.0078-0.49609c0.0625-0.03125 0.13281-0.035156 0.19531-0.011718 0.0625 0.019531 0.11719 0.066406 0.14453 0.12891 0.03125 0.058594 0.035156 0.12891 0.015625 0.19531-0.023438 0.0625-0.070313 0.11328-0.12891 0.14453l-1.0117 0.5c-0.03125 0.015624-0.070313 0.023437-0.10938 0.023437z" fill="#fbb040"/>
-<path d="m1081.2 905.91c-0.035156 0.003906-0.074218 0-0.10937-0.007812-0.03125-0.011719-0.066407-0.03125-0.089844-0.054688-0.027344-0.023437-0.050782-0.054687-0.066406-0.085937-0.011719-0.035157-0.019532-0.070313-0.019532-0.10547 0-0.039062 0.007813-0.074219 0.019532-0.10547 0.015624-0.035156 0.039062-0.0625 0.066406-0.085937 0.023437-0.027344 0.058594-0.042969 0.089844-0.054688 0.035156-0.011718 0.074218-0.015625 0.10937-0.011718 0.80859-0.37109 1.5977-0.79297 2.3555-1.2617 0.027344-0.015625 0.0625-0.027344 0.09375-0.03125 0.03125-0.007813 0.066407-0.003907 0.097657 0.003906s0.0625 0.023437 0.089843 0.042969c0.027344 0.019531 0.046875 0.046875 0.066407 0.074218 0.015624 0.03125 0.027343 0.0625 0.03125 0.09375 0.003906 0.035157 0.003906 0.066407-0.003907 0.10156-0.011719 0.03125-0.023437 0.0625-0.046875 0.085937-0.019531 0.027344-0.042968 0.050782-0.070312 0.066407-1.0312 0.61328-2.3086 1.3359-2.6133 1.3359z" fill="#fbb040"/>
-<path d="m1081.2 906.76h-0.070312c-0.066407-0.015625-0.12109-0.058594-0.15625-0.11719-0.035157-0.054687-0.046875-0.125-0.03125-0.19141s0.054687-0.12109 0.11328-0.15625 0.125-0.046875 0.19141-0.03125c0.28906 0 2.0859-0.97266 3.5742-1.8672 0.03125-0.023438 0.0625-0.039063 0.097656-0.046876 0.035157-0.007812 0.074219-0.007812 0.10938 0 0.035156 0.003907 0.066406 0.019532 0.097656 0.039063 0.027344 0.023437 0.054688 0.050781 0.074219 0.082031 0.015625 0.027344 0.027344 0.0625 0.03125 0.10156 0.003907 0.035156 0 0.070312-0.007812 0.10547-0.011719 0.035156-0.03125 0.066406-0.054688 0.09375-0.023437 0.027343-0.054687 0.046874-0.085937 0.0625-1.4844 0.88672-3.3281 1.9258-3.8828 1.9258z" fill="#fbb040"/>
-<path d="m1081.2 907.61h-0.042968c-0.035157-0.003907-0.066407-0.011719-0.097657-0.027344-0.027343-0.015625-0.054687-0.035156-0.078125-0.0625-0.023437-0.023437-0.039062-0.054687-0.050781-0.085937-0.007813-0.03125-0.015625-0.066407-0.011719-0.10156 0.003906-0.03125 0.011719-0.066406 0.023438-0.09375 0.015625-0.03125 0.035156-0.058594 0.0625-0.082031 0.023437-0.019532 0.054687-0.035156 0.085937-0.046875s0.066407-0.015625 0.097657-0.011719c0.57812 0.042969 3-1.5156 4.3828-2.5 0.054688-0.039062 0.12109-0.054688 0.19141-0.042969 0.066406 0.011719 0.125 0.046875 0.16406 0.10156 0.019531 0.027344 0.035156 0.058594 0.042969 0.089844 0.007812 0.035156 0.007812 0.066406 0 0.10156-0.003907 0.03125-0.015626 0.066406-0.035157 0.09375-0.015625 0.027344-0.039062 0.050781-0.066406 0.070312-0.61328 0.43359-3.6758 2.5977-4.668 2.5977z" fill="#fbb040"/>
-<path d="m1079.5 894.98c-0.027344 0.003906-0.054688 0.003906-0.082031 0-0.23438-0.078125-0.45312-0.42578-0.53906-0.57031-0.019531-0.027343-0.03125-0.058593-0.035156-0.09375-0.003906-0.035156-0.003906-0.070312 0.003906-0.10156 0.011719-0.035156 0.023438-0.066406 0.046875-0.09375 0.019531-0.027344 0.046875-0.050781 0.074219-0.066406 0.03125-0.019532 0.0625-0.03125 0.097656-0.035156 0.035156-0.007813 0.070313-0.003907 0.10156 0.003906 0.035156 0.007812 0.066406 0.023437 0.09375 0.046875 0.027343 0.019531 0.046875 0.046875 0.0625 0.078125 0.070312 0.13281 0.16406 0.25391 0.27734 0.35547 0.0625 0.023438 0.11328 0.070313 0.14063 0.12891 0.03125 0.0625 0.035156 0.12891 0.015624 0.19141-0.023437 0.050781-0.058593 0.09375-0.10547 0.12109-0.046875 0.027343-0.097656 0.039062-0.15234 0.035156z" fill="#fbb040"/>
-<path d="m1078.4 897c-0.039063 0-0.078125-0.007812-0.10938-0.027344-0.44922-0.21094-1.0664-1.2383-1.1836-1.4258-0.019531-0.03125-0.03125-0.0625-0.039062-0.097656-0.007813-0.035156-0.007813-0.070313 0-0.10547 0.007812-0.035156 0.023437-0.070312 0.042968-0.097656 0.019532-0.027344 0.046876-0.054688 0.078126-0.070312 0.03125-0.019532 0.066406-0.03125 0.10156-0.035157 0.035156-0.003906 0.070312 0 0.10547 0.011719 0.03125 0.011719 0.0625 0.027344 0.089843 0.050781 0.027344 0.023438 0.046876 0.054688 0.0625 0.085938 0.26172 0.44922 0.73438 1.1328 0.96094 1.2383 0.054688 0.023438 0.097656 0.066406 0.125 0.11719 0.027344 0.054687 0.03125 0.11328 0.019531 0.17187-0.011719 0.058594-0.046875 0.10938-0.09375 0.14453-0.042969 0.035156-0.10156 0.054687-0.16016 0.050781z" fill="#fbb040"/>
-<path d="m1077.6 898.79c-0.027344 0.003906-0.058594 0.003906-0.085938 0-0.43359-0.15625-1.4805-1.5469-1.9141-2.1406-0.019532-0.027343-0.03125-0.058593-0.042969-0.089843-0.007813-0.035157-0.007813-0.066407-0.003907-0.10156 0.007813-0.03125 0.015626-0.066406 0.035157-0.09375 0.015625-0.027344 0.039062-0.054687 0.066406-0.074219 0.054687-0.039062 0.125-0.054687 0.19141-0.042968 0.066407 0.011718 0.125 0.046874 0.16406 0.10156 0.63672 0.87109 1.457 1.8633 1.6758 1.9531 0.0625 0.023437 0.10938 0.070313 0.14062 0.13281 0.027344 0.0625 0.03125 0.13281 0.007812 0.19531-0.019531 0.046875-0.050781 0.085938-0.09375 0.11719-0.042968 0.027343-0.089843 0.042968-0.14062 0.042968z" fill="#fbb040"/>
-<path d="m1077.3 899.56c-0.0625 0-0.12109-0.023438-0.16797-0.066406-0.71094-0.71875-1.3828-1.4805-2.0078-2.2812-0.039062-0.050782-0.058593-0.11719-0.050781-0.18359s0.039062-0.12891 0.089844-0.17188c0.027344-0.019531 0.054687-0.035157 0.089844-0.046875 0.03125-0.007813 0.0625-0.011719 0.097656-0.007813 0.03125 0.003907 0.066406 0.011719 0.09375 0.027344 0.027344 0.019531 0.054687 0.039063 0.074218 0.066406 0.60938 0.77344 1.2617 1.5117 1.9531 2.2148 0.035156 0.035156 0.0625 0.078125 0.074218 0.12891 0.011719 0.050781 0.007813 0.10156-0.007812 0.15234-0.019532 0.046875-0.050782 0.089844-0.09375 0.11719-0.042969 0.03125-0.09375 0.046876-0.14453 0.046876z" fill="#fbb040"/>
-<path d="m1076.8 900.82h-0.039063c-0.66016-0.10937-2.4883-2.0234-3.0156-2.6016-0.046875-0.050781-0.070312-0.11328-0.070312-0.17969 0-0.066406 0.023437-0.13281 0.070312-0.17969 0.050781-0.042969 0.11328-0.070313 0.17969-0.070313 0.066406 0 0.12891 0.027344 0.17578 0.070313 1.0664 1.1367 2.3906 2.3945 2.7188 2.4492 0.035156 0.003906 0.066406 0.011718 0.097656 0.027344 0.027344 0.015624 0.054687 0.035156 0.074219 0.0625 0.023437 0.023437 0.039062 0.054687 0.050781 0.085937 0.007813 0.03125 0.011719 0.0625 0.011719 0.097656-0.003906 0.03125-0.011719 0.066407-0.027344 0.09375-0.015625 0.03125-0.035156 0.058594-0.0625 0.078125-0.023438 0.023438-0.054688 0.039063-0.085938 0.050782-0.03125 0.007812-0.0625 0.011718-0.097656 0.011718z" fill="#fbb040"/>
-<path d="m1076.2 901.71c-0.039063 0-0.082031-0.011719-0.11719-0.03125-0.48438-0.25391-2.3945-2.293-2.7695-2.6953-0.050781-0.050781-0.074219-0.11719-0.074219-0.1875 0.003907-0.066406 0.03125-0.13281 0.082031-0.17969 0.046876-0.046875 0.11328-0.074219 0.18359-0.070313 0.066406 0 0.13281 0.03125 0.17969 0.078125 0.85156 0.91406 2.3164 2.4297 2.6328 2.5977 0.054688 0.023438 0.09375 0.066407 0.12109 0.11719 0.023438 0.054688 0.03125 0.11328 0.015625 0.17188-0.011719 0.054687-0.046875 0.10547-0.09375 0.14062-0.042969 0.035156-0.10156 0.054688-0.16016 0.050781z" fill="#fbb040"/>
-<path d="m1071.8 901h-0.066406c-0.03125-0.003906-0.066406-0.011719-0.09375-0.03125-0.03125-0.015625-0.058594-0.035156-0.078125-0.0625s-0.035157-0.058594-0.046875-0.089844c-0.007813-0.03125-0.007813-0.066406-0.003906-0.097656 0.007812-0.070313 0.039062-0.12891 0.09375-0.17188 0.050781-0.042969 0.12109-0.0625 0.1875-0.054688 0.14062 0 1.1133-0.097656 1.9727-0.20703 0.035156-0.003906 0.070312-0.003906 0.10156 0.003906 0.03125 0.007813 0.0625 0.023438 0.089844 0.042969 0.023438 0.023437 0.046875 0.046875 0.0625 0.078125 0.019531 0.027344 0.027344 0.058594 0.03125 0.09375 0.011719 0.066406-0.007812 0.13281-0.046875 0.1875-0.042969 0.054688-0.10156 0.089844-0.16797 0.10156-0.40234 0.046876-1.6641 0.20703-2.0352 0.20703z" fill="#fbb040"/>
-<path d="m1071.1 901.86h-0.054688c-0.066406-0.003907-0.12891-0.035157-0.17578-0.082031-0.046875-0.050782-0.070313-0.11719-0.070313-0.18359 0.003907-0.035156 0.011719-0.066406 0.023438-0.097656 0.015625-0.03125 0.035156-0.058594 0.058594-0.082032 0.027344-0.023437 0.054687-0.039062 0.085937-0.050781s0.066407-0.019531 0.10156-0.015625c0.4375 0 2.5781-0.27344 3.3672-0.38281 0.0625-0.003907 0.12891 0.019531 0.17578 0.058593 0.050782 0.042969 0.082032 0.097657 0.089844 0.16406 0.011719 0.0625-0.003906 0.125-0.042968 0.17969-0.035157 0.054688-0.089844 0.089844-0.15234 0.10547-0.11328 0.027344-2.7305 0.38672-3.4062 0.38672z" fill="#fbb040"/>
-<path d="m1071.1 903.56c-0.054687 0-0.10938-0.015625-0.15234-0.046875-0.042969-0.03125-0.074219-0.078125-0.089844-0.12891-0.011719-0.035156-0.015625-0.066406-0.011719-0.10156 0-0.03125 0.011719-0.066406 0.027344-0.09375 0.015625-0.03125 0.035156-0.058594 0.058593-0.078125 0.027344-0.023437 0.058594-0.039063 0.089844-0.050781 0.73047-0.23438 3.3047-0.58594 4.543-0.75391 0.3125-0.042969 0.52344-0.074219 0.56641-0.082032l0.058594 0.25 0.21484 0.12891c-0.0625 0.10938-0.0625 0.10938-0.76953 0.20703-1.1289 0.15625-3.7695 0.51562-4.457 0.73828-0.027344 0.007813-0.050781 0.011719-0.078125 0.011719z" fill="#fbb040"/>
-<path d="m1071.5 904.36c-0.0625 0-0.12109-0.019531-0.16797-0.058594s-0.078125-0.097656-0.085937-0.15625c-0.011719-0.0625 0.003906-0.125 0.035156-0.17578 0.03125-0.050782 0.082031-0.089844 0.14062-0.10547 0.71094-0.23438 4.2422-0.79297 4.3945-0.81641 0.03125-0.003907 0.066406-0.003907 0.097656 0.003906s0.0625 0.023437 0.089844 0.042969c0.027344 0.019531 0.050781 0.042968 0.066406 0.070312 0.019532 0.03125 0.03125 0.0625 0.035156 0.09375 0.011719 0.066406-0.003906 0.13672-0.046874 0.19141-0.039063 0.054688-0.097657 0.089844-0.16406 0.10156-0.035156 0-3.6406 0.57812-4.3164 0.79688-0.023438 0.007812-0.050781 0.011719-0.078125 0.011719z" fill="#fbb040"/>
-<path d="m1071.8 905.14c-0.0625-0.007813-0.12109-0.035156-0.16797-0.078125-0.042969-0.046875-0.066406-0.10547-0.070313-0.16797-0.003906-0.0625 0.019532-0.125 0.058594-0.17578 0.039063-0.046875 0.097656-0.082031 0.15625-0.089844 0.80078-0.066406 3.7148-0.51953 3.7461-0.52344 0.066406-0.011719 0.13281 0.003906 0.1875 0.046875 0.054688 0.039062 0.089844 0.097656 0.10156 0.16406 0.003907 0.035156 0.003907 0.070313-0.003906 0.10156-0.007812 0.03125-0.023437 0.0625-0.042968 0.089843-0.019532 0.027344-0.042969 0.050782-0.074219 0.066407-0.027344 0.015625-0.058594 0.027343-0.089844 0.03125-0.12109 0.023437-2.9609 0.46484-3.7812 0.53516z" fill="#fbb040"/>
-<path d="m1072.3 906.11c-0.23047 0-0.28125-0.050781-0.32422-0.089844-0.042969-0.042969-0.066406-0.097656-0.070312-0.15625-0.007813-0.0625 0.007812-0.12109 0.042968-0.17188 0.035156-0.046875 0.085938-0.082031 0.14062-0.097656 0.058594-0.015625 0.12109-0.011719 0.17578 0.011719 1.0781-0.12891 2.1445-0.32812 3.1992-0.59766 0.0625-0.015624 0.13281-0.007812 0.19141 0.03125 0.054687 0.035157 0.097656 0.089844 0.11328 0.15625 0.015625 0.066407 0.003906 0.13672-0.03125 0.19141-0.035157 0.058593-0.09375 0.10156-0.15625 0.11719-2.0586 0.48047-2.9102 0.60547-3.2812 0.60547z" fill="#fbb040"/>
-<path d="m1072.5 907.13c-0.054687 0.003906-0.10938-0.007812-0.15625-0.035156-0.050781-0.035156-0.089844-0.082031-0.10547-0.14062-0.019531-0.058594-0.015625-0.11719 0.007813-0.17578 0.019531-0.054688 0.0625-0.10156 0.11719-0.12891 0.050782-0.027344 0.11328-0.035157 0.17188-0.023438 0.92578-0.21094 1.8438-0.47656 2.7383-0.79688 0.035157-0.007813 0.066407-0.011719 0.10156-0.011719 0.03125 0.003906 0.066406 0.011719 0.09375 0.027344 0.03125 0.015625 0.058594 0.035156 0.082031 0.0625 0.019532 0.027344 0.035156 0.054688 0.046875 0.085938 0.011719 0.035156 0.015625 0.066406 0.011719 0.10156 0 0.03125-0.011719 0.066406-0.027344 0.09375-0.015625 0.03125-0.035156 0.058594-0.058594 0.078125-0.027343 0.023437-0.058593 0.039063-0.089843 0.050781-2.0391 0.67578-2.6875 0.8125-2.9336 0.8125z" fill="#fbb040"/>
-<path d="m1073.2 907.98c-0.0625-0.007812-0.12109-0.039062-0.16406-0.085937-0.039063-0.046875-0.0625-0.10547-0.0625-0.16797s0.023437-0.125 0.0625-0.17188c0.042968-0.046875 0.10156-0.078125 0.16406-0.085937 0.69141-0.17969 1.3672-0.41797 2.0195-0.71094 0.054687-0.003906 0.10937 0.007813 0.15625 0.035156 0.046874 0.027344 0.082031 0.070313 0.10156 0.12109 0.023438 0.050782 0.027344 0.10547 0.011719 0.16016-0.011719 0.054688-0.042969 0.10156-0.082031 0.13672-0.41406 0.17969-1.832 0.76953-2.207 0.76953z" fill="#fbb040"/>
-<path d="m1073.8 908.94c-0.046875 0-0.09375-0.015625-0.13672-0.042968-0.039063-0.027344-0.074219-0.0625-0.09375-0.10938-0.027344-0.0625-0.027344-0.13281-0.003907-0.19531 0.023438-0.0625 0.070313-0.11328 0.13281-0.14453l1.5273-0.67578c0.03125-0.015626 0.0625-0.023438 0.097656-0.023438 0.03125 0 0.066406 0.003906 0.097656 0.015625s0.058594 0.03125 0.082031 0.054687c0.023438 0.023438 0.042969 0.050782 0.058594 0.082032s0.023437 0.066406 0.027344 0.10156c0 0.035156-0.003907 0.070313-0.015625 0.10156-0.011719 0.035156-0.03125 0.066406-0.054688 0.089843-0.023437 0.027344-0.054687 0.046876-0.085937 0.0625l-1.5273 0.67969c-0.035156 0.007812-0.070313 0.007812-0.10547 0.003906z" fill="#fbb040"/>
-<path d="m1070.8 902.73c-0.0625-0.003907-0.125-0.027344-0.17187-0.074219-0.042969-0.042969-0.074219-0.10156-0.078126-0.16406-0.003906-0.066407 0.015626-0.12891 0.054688-0.17969s0.097656-0.082031 0.16016-0.09375l4.5586-0.64844c0.066406-0.003906 0.12891 0.015626 0.17578 0.058594 0.050781 0.039063 0.082031 0.097656 0.089844 0.16016 0.011719 0.066407-0.003906 0.12891-0.042969 0.18359-0.035156 0.050782-0.089844 0.089844-0.15234 0.10156l-4.5703 0.65234z" fill="#fbb040"/>
-<path d="m1072.2 895.98c-0.058594 0-0.11719-0.023437-0.16406-0.0625-0.023437-0.023437-0.046875-0.050781-0.058594-0.078124-0.015625-0.03125-0.027343-0.0625-0.027343-0.097657-0.003907-0.03125 0-0.066406 0.011718-0.097656 0.007813-0.03125 0.027344-0.058594 0.046875-0.085937 2.1836-2.6094 5.2148-4.3594 8.5547-4.9453 0.035156-0.003906 0.066406 0 0.097656 0.011719 0.035156 0.007812 0.0625 0.023437 0.089844 0.042968 0.027343 0.023438 0.046875 0.046876 0.0625 0.078126 0.015625 0.027343 0.027343 0.058593 0.03125 0.09375 0.003906 0.035156 0 0.066406-0.007813 0.097656-0.007812 0.035156-0.023437 0.0625-0.046875 0.089844-0.019531 0.027343-0.046875 0.046874-0.074219 0.0625-0.03125 0.019531-0.0625 0.027343-0.09375 0.03125-3.207 0.59375-6.1133 2.2773-8.2305 4.7695-0.023438 0.027343-0.050782 0.050781-0.085938 0.066406-0.03125 0.015625-0.066406 0.023437-0.10547 0.023437z" fill="#fbb040"/>
-<path d="m1090.8 904.35c-0.03125 0-0.066406-0.007812-0.097656-0.019531s-0.058594-0.03125-0.082031-0.054687c-0.023438-0.023438-0.042969-0.050782-0.054688-0.082032-0.015625-0.03125-0.019531-0.066406-0.019531-0.097656 0-7.4102-4.3125-10.758-4.3555-10.793-0.054687-0.039063-0.089843-0.10156-0.097656-0.16797-0.011719-0.066407 0.003906-0.13281 0.042969-0.1875 0.023437-0.027344 0.046875-0.050781 0.074218-0.066407 0.03125-0.019531 0.0625-0.027343 0.09375-0.035156 0.035157-0.003906 0.066407 0 0.10156 0.007813 0.03125 0.007812 0.0625 0.023437 0.085937 0.042969 0.19141 0.14062 4.5703 3.5352 4.5625 11.199 0 0.066406-0.027343 0.12891-0.074218 0.17969-0.046875 0.046875-0.11328 0.074218-0.17969 0.074218z" fill="#fbb040"/>
-<path d="m1077.9 897.76c-0.035156 0-0.070312-0.007813-0.10156-0.023438-0.035156-0.011719-0.0625-0.035156-0.085938-0.0625-0.25781-0.28125-1.2812-1.4258-1.2812-1.4258l0.37891-0.33984s1.0195 1.1445 1.2773 1.4258c0.046876 0.046874 0.070313 0.11328 0.070313 0.17969s-0.023437 0.12891-0.070313 0.17969c-0.027343 0.023438-0.054687 0.039063-0.085937 0.050782-0.03125 0.011718-0.066406 0.015625-0.10156 0.015625z" fill="#fbb040"/>
-<path d="m1076.8 899.93c-0.050781 0-0.10156-0.015625-0.14453-0.046875-0.69531-0.62109-1.3555-1.2812-1.9766-1.9727-0.046874-0.046875-0.074218-0.11328-0.074218-0.17969 0-0.066406 0.027344-0.12891 0.074218-0.17578 0.046876-0.046875 0.10938-0.074219 0.17578-0.074219s0.13281 0.027344 0.17969 0.074219c0.59766 0.66406 1.2266 1.2969 1.8906 1.8984 0.054688 0.039062 0.09375 0.097656 0.10547 0.16406 0.015625 0.066407 0 0.13672-0.039063 0.19141-0.019531 0.035156-0.046874 0.0625-0.082031 0.082031-0.03125 0.023437-0.070312 0.035156-0.10938 0.039062z" fill="#fbb040"/>
-<path d="m1078.8 896.33c-0.03125 0-0.066407-0.003906-0.097657-0.019531-0.058593-0.019531-0.22656-0.085938-1.1641-1.1953-0.035156-0.050782-0.050781-0.11328-0.042969-0.17969 0.007813-0.0625 0.039063-0.12109 0.089844-0.16016 0.046875-0.042969 0.10938-0.0625 0.17188-0.0625 0.0625 0.003906 0.125 0.027344 0.17188 0.070312 0.30078 0.37891 0.62891 0.73828 0.98047 1.0703 0.027344 0.015625 0.054687 0.03125 0.078125 0.054687 0.023437 0.023438 0.042969 0.050782 0.054687 0.082032 0.015625 0.03125 0.019532 0.0625 0.019532 0.09375 0 0.035156-0.007813 0.066406-0.019532 0.097656-0.019531 0.042968-0.054687 0.082031-0.097656 0.10938-0.042969 0.027343-0.09375 0.039062-0.14453 0.039062z" fill="#fbb040"/>
-<path d="m1079.1 895.79c-0.03125 0.003906-0.0625 0.003906-0.089844 0-0.33203-0.22656-0.60547-0.53125-0.80469-0.88281-0.019532-0.027344-0.035157-0.058594-0.046876-0.09375-0.007812-0.035156-0.011718-0.070313-0.003906-0.10547 0.003906-0.035156 0.015625-0.066406 0.035156-0.097656 0.019532-0.03125 0.042969-0.054688 0.070313-0.074219 0.03125-0.019531 0.0625-0.035156 0.097656-0.042969 0.03125-0.007812 0.066407-0.003906 0.10156 0 0.035156 0.007813 0.066406 0.023438 0.097656 0.042969 0.027344 0.019531 0.050781 0.046875 0.070312 0.078125 0.16406 0.25781 0.35547 0.49609 0.57031 0.71484 0.03125 0.007812 0.058594 0.027343 0.082031 0.050781 0.027344 0.019531 0.046875 0.046875 0.058594 0.078125 0.015625 0.027344 0.019531 0.0625 0.023438 0.09375 0 0.035156-0.007813 0.066406-0.019532 0.097656-0.019531 0.042969-0.054687 0.082031-0.10156 0.10547-0.042969 0.027344-0.089844 0.039062-0.14062 0.035156z" fill="#fbb040"/>
-<path d="m1072.5 900.12c-0.058594 0.003906-0.11719-0.015625-0.16406-0.054688-0.042969-0.039062-0.074219-0.089843-0.085937-0.14844-0.015625-0.066406 0-0.13281 0.035156-0.1875 0.039062-0.058594 0.09375-0.097656 0.16016-0.10938l1.0039-0.20703c0.035157-0.007813 0.066407-0.007813 0.10156-0.003907 0.03125 0.007813 0.0625 0.019532 0.089844 0.039063 0.03125 0.019531 0.054687 0.042969 0.070312 0.070313 0.019531 0.027343 0.035157 0.058593 0.039063 0.089843 0.007812 0.035157 0.007812 0.066407 0.003906 0.10156-0.007812 0.03125-0.019531 0.0625-0.039062 0.089844-0.019532 0.03125-0.042969 0.054687-0.070313 0.074218-0.027344 0.015625-0.058594 0.03125-0.089844 0.035156l-1.0078 0.20703z" fill="#fbb040"/>
-<path d="m1086.6 900.39c-0.03125 0-0.058594-0.007813-0.085937-0.019531-0.21875-0.082032-1.8867-0.53516-2.9531-0.82031-0.0625-0.019531-0.12109-0.0625-0.15234-0.12109-0.035156-0.058594-0.042969-0.12891-0.027344-0.19141 0.007813-0.035156 0.023438-0.066406 0.042969-0.089843 0.023437-0.027344 0.046875-0.050782 0.078125-0.066407 0.027344-0.015625 0.058594-0.027343 0.09375-0.03125 0.03125-0.003906 0.066406-0.003906 0.097656 0.007813 0.27344 0.070312 2.6875 0.71484 3 0.83984 0.058594 0.019531 0.10547 0.058593 0.13672 0.10937 0.027344 0.054688 0.039063 0.11719 0.027344 0.17578s-0.042969 0.11328-0.089844 0.15234c-0.046875 0.035156-0.10547 0.054687-0.16797 0.054687z" fill="#fbb040"/>
-<path d="m1086 899.38c-0.054688 0-0.10547-0.015625-0.14844-0.042969-0.11719-0.058593-1.1641-0.32812-2.1016-0.55859-0.035157-0.003907-0.070313-0.015626-0.10156-0.035157s-0.058594-0.042969-0.078125-0.074219-0.035156-0.0625-0.039062-0.097656c-0.007813-0.035156-0.007813-0.074218 0.003906-0.10938 0.007812-0.035156 0.023437-0.066406 0.042968-0.097656 0.023438-0.027344 0.050782-0.050781 0.082032-0.066406 0.035156-0.019531 0.066406-0.027344 0.10547-0.03125 0.035157 0 0.070313 0.003906 0.10547 0.015625 0.77344 0.15234 1.5312 0.36719 2.2734 0.63672 0.046875 0.027344 0.078125 0.074219 0.097656 0.125 0.019531 0.050782 0.019531 0.10938 0.003906 0.16016-0.015625 0.054687-0.050781 0.097656-0.09375 0.12891-0.046875 0.035156-0.097656 0.050781-0.15234 0.046875z" fill="#fbb040"/>
-<path d="m1084.9 897.5c0.11719 0 0.21484-0.085937 0.21484-0.19141 0-0.10938-0.097656-0.19531-0.21484-0.19531-0.11719 0-0.21094 0.085937-0.21094 0.19531 0 0.10547 0.09375 0.19141 0.21094 0.19141z" fill="#fbb040"/>
-<path d="m1079.8 894.16c0.15625 0 0.28125-0.066406 0.28125-0.15234 0-0.082031-0.125-0.14844-0.28125-0.14844-0.15234 0-0.28125 0.066406-0.28125 0.14844 0 0.085938 0.12891 0.15234 0.28125 0.15234z" fill="#fbb040"/>
-<path d="m1074.5 909.41c-0.058594 0-0.11328-0.023437-0.16016-0.0625-0.042969-0.039062-0.074219-0.089844-0.082032-0.14844-0.011718-0.058594 0-0.11719 0.027344-0.17188 0.03125-0.050782 0.074219-0.089844 0.12891-0.11328l0.66406-0.24219c0.0625-0.023437 0.13281-0.019531 0.19531 0.011719 0.058594 0.027344 0.10547 0.078125 0.12891 0.14453 0.011718 0.03125 0.019531 0.0625 0.015624 0.097656 0 0.035157-0.007812 0.066407-0.023437 0.097657-0.011719 0.03125-0.03125 0.058593-0.058594 0.078124-0.023437 0.023438-0.054687 0.042969-0.085937 0.054688l-0.66016 0.24219c-0.027344 0.007812-0.058594 0.015624-0.089844 0.011718z" fill="#fbb040"/>
-<path d="m1075.8 909.95c0.14453-0.10547 0.21875-0.25 0.16406-0.32422-0.054687-0.078125-0.21484-0.054688-0.35938 0.046875s-0.21875 0.25-0.16406 0.32422c0.050781 0.074218 0.21484 0.054687 0.35938-0.046875z" fill="#fbb040"/>
-<path d="m1080.9 908.61c-0.054688 0-0.11328-0.023438-0.15625-0.058594-0.046875-0.035156-0.078125-0.085937-0.089844-0.14453-0.011718-0.054688-0.003906-0.11719 0.019532-0.16797 0.027343-0.050781 0.070312-0.09375 0.12109-0.11719 1.3555-0.61719 5.0039-2.3594 5.6055-3.0273 0.023438-0.027344 0.050781-0.046875 0.082031-0.058594 0.03125-0.015625 0.066407-0.023438 0.097657-0.023438 0.035156 0 0.070312 0.003907 0.10156 0.015626 0.03125 0.011718 0.058594 0.03125 0.085938 0.054687 0.023437 0.023437 0.042968 0.050781 0.058593 0.082031 0.011719 0.03125 0.019531 0.066406 0.019531 0.097656 0.003907 0.035157-0.003906 0.070313-0.015624 0.10156-0.011719 0.03125-0.03125 0.0625-0.054688 0.085937-0.78125 0.86719-5.2617 2.9219-5.7695 3.1523-0.035157 0.007813-0.070313 0.011719-0.10547 0.007813z" fill="#fbb040"/>
-<path d="m1080.7 909.82c-0.058594 0-0.11328-0.019531-0.16016-0.058594-0.046875-0.035156-0.078125-0.085937-0.089843-0.14453-0.011719-0.054687-0.003907-0.11328 0.023437-0.16797 0.027344-0.050781 0.070313-0.09375 0.12109-0.11719 1.5703-0.71094 5.7695-2.7578 6.3984-3.8008 0.015625-0.03125 0.035156-0.0625 0.0625-0.085938 0.027344-0.023437 0.058594-0.042968 0.09375-0.054687s0.070313-0.011719 0.10547-0.007813c0.039063 0.003906 0.070313 0.015625 0.10156 0.03125 0.03125 0.019532 0.058593 0.042969 0.082031 0.074219 0.019531 0.03125 0.035156 0.0625 0.039062 0.097656 0.007813 0.039063 0.007813 0.074219 0 0.10938-0.007812 0.035156-0.023437 0.066406-0.046875 0.097656-0.80859 1.3711-6.0195 3.7422-6.6094 4.0039-0.039062 0.015625-0.082031 0.023437-0.12109 0.023437z" fill="#fbb040"/>
-<path d="m1080.7 910.7c-0.046875 0-0.09375-0.011718-0.13672-0.039062-0.039062-0.023438-0.070312-0.058594-0.089843-0.10156-0.019531-0.03125-0.027344-0.066407-0.03125-0.10156-0.003907-0.035156 0-0.070313 0.011719-0.10547 0.011718-0.03125 0.027343-0.0625 0.050781-0.089844 0.023437-0.027343 0.050781-0.046874 0.085937-0.0625 2.9727-1.4258 6.168-3.2109 6.3789-3.6562 0.011719-0.03125 0.03125-0.058593 0.054688-0.082031 0.023438-0.023437 0.054688-0.042969 0.085938-0.054687 0.03125-0.011719 0.0625-0.015625 0.097656-0.015625 0.03125 0 0.0625 0.007812 0.09375 0.023437 0.0625 0.027344 0.10938 0.078125 0.13281 0.14062 0.023438 0.066407 0.023438 0.13672-0.003906 0.19922-0.38672 0.84766-5.582 3.4023-6.6211 3.9258-0.035156 0.015625-0.074218 0.023438-0.10938 0.019531z" fill="#fbb040"/>
-<path d="m1080.9 911.31c-0.058594 0-0.11328-0.023438-0.15625-0.058594-0.046875-0.039062-0.074219-0.09375-0.085938-0.14844-0.011718-0.058594 0-0.11719 0.027344-0.16797s0.070313-0.09375 0.12109-0.11719c2.4062-0.97656 5.9102-2.6172 6.1641-3.2109 0.027344-0.0625 0.078126-0.11328 0.14063-0.13672 0.0625-0.023437 0.13281-0.023437 0.19531 0.003906 0.058594 0.027344 0.10938 0.078126 0.13281 0.14063 0.023438 0.0625 0.023438 0.13281-0.003906 0.19531-0.42969 0.98047-5.4375 3.0625-6.4375 3.4688-0.03125 0.015625-0.0625 0.027344-0.097656 0.03125z" fill="#fbb040"/>
-<path d="m1081.7 911.73c-0.0625 0-0.11719-0.019531-0.16406-0.058593-0.046874-0.039063-0.078124-0.089844-0.085937-0.15234-0.011719-0.058594-0.003906-0.11719 0.027344-0.16797 0.027343-0.054687 0.074219-0.09375 0.12891-0.11719 2.3555-0.92188 4.9336-2.043 5.1719-2.332 0.015625-0.027344 0.039062-0.054688 0.066406-0.078126 0.027344-0.019531 0.058594-0.035156 0.089844-0.042968 0.035156-0.011719 0.070312-0.011719 0.10547-0.003906 0.03125 0.003906 0.066406 0.019531 0.09375 0.039062 0.027343 0.015625 0.054687 0.039062 0.074219 0.066406 0.023437 0.027344 0.035156 0.058594 0.046874 0.089844 0.007813 0.035156 0.007813 0.070312 0.003907 0.10156-0.003907 0.035157-0.015625 0.066407-0.03125 0.097657-0.27734 0.48828-3.8867 1.9414-5.4219 2.5469-0.035156 0.007812-0.070313 0.015625-0.10547 0.011718z" fill="#fbb040"/>
-<path d="m1091.3 901.85c-0.058594 0-0.11719-0.023437-0.16406-0.0625-0.046874-0.039062-0.078124-0.09375-0.085937-0.15234-0.98438-6.1836-3.3398-7.9609-3.5547-8.1055-0.050782-0.015625-0.097657-0.046875-0.12891-0.089844-0.035156-0.042968-0.050781-0.09375-0.054687-0.14844 0-0.0625 0.023437-0.125 0.066406-0.17578 0.042969-0.046876 0.10156-0.078126 0.16797-0.085938 0.39062-0.023438 2.9922 2.1641 4.0039 8.5234 0.011719 0.066406-0.007813 0.13672-0.046875 0.19141-0.039062 0.054687-0.10156 0.089844-0.16797 0.10156z" fill="#fbb040"/>
-<g clip-path="url(#b)">
-<path d="m1080.9 890.55c2.1016 0 4.1523 0.625 5.9023 1.7969 1.7461 1.1719 3.1055 2.8398 3.9102 4.7852 0.80469 1.9492 1.0156 4.0938 0.60547 6.1641-0.40625 2.0703-1.418 3.9727-2.9023 5.4648-1.4883 1.4922-3.3789 2.5078-5.4375 2.918-2.0625 0.41406-4.1992 0.20312-6.1367-0.60547-1.9414-0.80859-3.6016-2.1758-4.7695-3.9297-1.1641-1.7539-1.7891-3.8164-1.7891-5.9258 0-2.8281 1.1211-5.5391 3.1094-7.5391 1.9922-2 4.6914-3.125 7.5078-3.1289zm0-1.2852c-2.3555 0-4.6562 0.69922-6.6133 2.0117-1.957 1.3164-3.4844 3.1836-4.3828 5.3672-0.90234 2.1836-1.1367 4.5859-0.67969 6.9062 0.46094 2.3203 1.5938 4.4492 3.2578 6.1211s3.7852 2.8125 6.0938 3.2734c2.3125 0.46094 4.7031 0.22266 6.8789-0.67969 2.1758-0.90625 4.0352-2.4375 5.3398-4.4062 1.3086-1.9648 2.0078-4.2773 2.0078-6.6406-0.003907-3.168-1.2578-6.207-3.4883-8.4492-2.2344-2.2422-5.2578-3.5039-8.4141-3.5039z" fill="#231f20"/>
-</g>
-<path d="m1236.4 876.89c0 3.7422-2.2891 7.0742-3.3828 10.441-1.1367 3.5-1.2812 7.5312-3.3984 10.445-2.1406 2.9375-5.9453 4.3125-8.8867 6.4531-2.9102 2.1172-5.3828 5.3242-8.8789 6.4609-3.375 1.0977-7.2422-0.011718-10.984-0.011718-3.7383 0-7.6055 1.1094-10.98 0.011718-3.4961-1.1367-5.9688-4.3438-8.8789-6.4609-2.9414-2.1406-6.7461-3.5156-8.8867-6.4531-2.1172-2.9102-2.2617-6.9453-3.3984-10.445-1.0938-3.3711-3.3828-6.7031-3.3828-10.441 0-3.7344 2.2891-7.0703 3.3828-10.441 1.1367-3.4961 1.2812-7.5312 3.3984-10.441 2.1406-2.9375 5.9453-4.3164 8.8867-6.4531 2.9102-2.1172 5.3828-5.3281 8.8789-6.4609 3.375-1.0977 7.2422 0.007813 10.984 0.007813 3.7383 0 7.6055-1.1055 10.98-0.007813 3.4961 1.1328 5.9688 4.3438 8.8789 6.4609 2.9414 2.1367 6.7461 3.5156 8.8867 6.4531 2.1172 2.9102 2.2617 6.9453 3.3984 10.441 1.0938 3.3711 3.3828 6.7031 3.3828 10.441z" fill="#326ce5"/>
-<g clip-path="url(#a)">
-<g transform="translate(1172 860)">
-<g clip-path="url(#ca)">
-<g clip-path="url(#ag)">
-<g transform="translate(0 -1.1369e-13)">
-<g clip-path="url(#bs)">
-<g clip-path="url(#by)">
-<path d="m57.906 15.086c-2.082 0-3.1406-0.5-4.1602-0.98047-1.043-0.49219-2.0234-0.95312-4.043-0.95312s-3.0039 0.46094-4.043 0.95312c-1.0234 0.48047-2.082 0.98047-4.1641 0.98047-2.082 0-3.1367-0.5-4.1602-0.98047-1.0391-0.49219-2.0234-0.95312-4.043-0.95312s-3 0.46094-4.043 0.95312c-1.0195 0.48047-2.0781 0.98047-4.1602 0.98047-2.082 0-3.1406-0.5-4.1602-0.98047-1.043-0.49219-2.0234-0.95312-4.043-0.95312s-3.0039 0.46094-4.043 0.95312c-1.0234 0.48047-2.0781 0.98047-4.1602 0.98047-2.082 0-3.1406-0.5-4.1641-0.98047-1.0391-0.49219-2.0234-0.95312-4.043-0.95312v-0.28125c2.0859 0 3.1406 0.49609 4.1641 0.98047 1.0391 0.48828 2.0234 0.95313 4.043 0.95313 2.0156 0 3-0.46484 4.0391-0.95313 1.0234-0.48437 2.082-0.98047 4.1641-0.98047s3.1406 0.49609 4.1602 0.98047c1.043 0.48828 2.0234 0.95313 4.043 0.95313 2.0195 0 3.0039-0.46484 4.043-0.95313 1.0195-0.48437 2.0781-0.98047 4.1602-0.98047s3.1406 0.49609 4.1641 0.98047c1.0391 0.48828 2.0195 0.95313 4.0391 0.95313 2.0195 0 3.0039-0.46484 4.043-0.95313 1.0234-0.48437 2.082-0.98047 4.1641-0.98047s3.1367 0.49609 4.1602 0.98047c1.0391 0.48828 2.0234 0.95313 4.043 0.95313z" fill="#fff"/>
-</g>
-<g clip-path="url(#q)">
-<path d="m57.906 19.047c-2.1016 0-3.1719-0.50391-4.2031-0.98828-1.0273-0.48828-2.0039-0.94531-4-0.94531-2 0-2.9727 0.45703-4.0039 0.94531-1.0312 0.48438-2.0977 0.98828-4.2031 0.98828-2.1016 0-3.168-0.50391-4.1992-0.98828-1.0312-0.48828-2.0039-0.94531-4.0039-0.94531-1.9961 0-2.9727 0.45703-4 0.94531-1.0312 0.48438-2.0977 0.98828-4.2031 0.98828-2.1016 0-3.1719-0.50391-4.2031-0.98828-1.0273-0.48828-2-0.94531-4-0.94531s-2.9727 0.45703-4.0039 0.94531c-1.0312 0.48438-2.0977 0.98828-4.1992 0.98828-2.1055 0-3.1719-0.50391-4.2031-0.98828-1.0312-0.48828-2.0039-0.94531-4.0039-0.94531v-0.46875c2.1055 0 3.1719 0.50391 4.2031 0.98828 1.0312 0.48828 2.0039 0.94531 4.0039 0.94531 1.9961 0 2.9688-0.45703 4-0.94531 1.0312-0.48437 2.0977-0.98828 4.2031-0.98828 2.1016 0 3.168 0.50391 4.2031 0.98828 1.0273 0.48828 2 0.94531 4 0.94531s2.9727-0.45703 4-0.94531c1.0352-0.48437 2.1016-0.98828 4.2031-0.98828 2.1055 0 3.1719 0.50391 4.2031 0.98828 1.0312 0.48828 2.0039 0.94531 4 0.94531 2 0 2.9727-0.45703 4.0039-0.94531 1.0312-0.48437 2.0977-0.98828 4.2031-0.98828 2.1016 0 3.168 0.50391 4.1992 0.98828 1.0312 0.48828 2.0039 0.94531 4.0039 0.94531z" fill="#fff"/>
-</g>
-<g clip-path="url(#be)">
-<path d="m57.906 23.781c-2.125 0-3.1992-0.50781-4.2422-1-1.0195-0.48047-1.9844-0.93359-3.9609-0.93359-1.9805 0-2.9414 0.45312-3.9648 0.9375-1.0391 0.48828-2.1172 0.99609-4.2422 0.99609-2.1211 0-3.1992-0.50781-4.2383-0.99609-1.0234-0.48438-1.9883-0.9375-3.9648-0.9375-1.9766 0-2.9414 0.45312-3.9609 0.93359-1.043 0.49219-2.1172 1-4.2422 1s-3.1992-0.50781-4.2422-1c-1.0195-0.48047-1.9844-0.93359-3.9609-0.93359-1.9766 0-2.9414 0.45312-3.9648 0.9375-1.0391 0.48828-2.1172 0.99609-4.2383 0.99609-2.125 0-3.2031-0.50781-4.2422-0.99609-1.0234-0.48438-1.9844-0.9375-3.9648-0.9375v-0.65625c2.125 0 3.2031 0.50781 4.2422 1 1.0234 0.48047 1.9844 0.93359 3.9648 0.93359 1.9766 0 2.9375-0.45312 3.9609-0.93359 1.0391-0.49219 2.1172-1 4.2422-1s3.1992 0.50781 4.2422 1c1.0195 0.48047 1.9844 0.93359 3.9609 0.93359 1.9766 0 2.9414-0.45312 3.9609-0.93359 1.043-0.49219 2.1172-1 4.2422-1s3.2031 0.50781 4.2422 1c1.0195 0.48047 1.9844 0.93359 3.9609 0.93359 1.9766 0 2.9414-0.45312 3.9648-0.93359 1.0391-0.49219 2.1172-1 4.2422-1s3.1992 0.50781 4.2422 1c1.0195 0.48047 1.9844 0.93359 3.9609 0.93359z" fill="#fff"/>
-</g>
-</g>
-</g>
-<g transform="translate(0 -1.1369e-13)">
-<g clip-path="url(#ba)">
-<g clip-path="url(#d)">
-<path d="m57.906 15.086c-2.082 0-3.1406-0.5-4.1602-0.98047-1.043-0.49219-2.0234-0.95312-4.043-0.95312s-3.0039 0.46094-4.043 0.95312c-1.0234 0.48047-2.082 0.98047-4.1641 0.98047-2.082 0-3.1367-0.5-4.1602-0.98047-1.0391-0.49219-2.0234-0.95312-4.043-0.95312s-3 0.46094-4.043 0.95312c-1.0195 0.48047-2.0781 0.98047-4.1602 0.98047-2.082 0-3.1406-0.5-4.1602-0.98047-1.043-0.49219-2.0234-0.95312-4.043-0.95312s-3.0039 0.46094-4.043 0.95312c-1.0234 0.48047-2.0781 0.98047-4.1602 0.98047-2.082 0-3.1406-0.5-4.1641-0.98047-1.0391-0.49219-2.0234-0.95312-4.043-0.95312v-0.28125c2.0859 0 3.1406 0.49609 4.1641 0.98047 1.0391 0.48828 2.0234 0.95313 4.043 0.95313 2.0156 0 3-0.46484 4.0391-0.95313 1.0234-0.48437 2.082-0.98047 4.1641-0.98047s3.1406 0.49609 4.1602 0.98047c1.043 0.48828 2.0234 0.95313 4.043 0.95313 2.0195 0 3.0039-0.46484 4.043-0.95313 1.0195-0.48437 2.0781-0.98047 4.1602-0.98047s3.1406 0.49609 4.1641 0.98047c1.0391 0.48828 2.0195 0.95313 4.0391 0.95313 2.0195 0 3.0039-0.46484 4.043-0.95313 1.0234-0.48437 2.082-0.98047 4.1641-0.98047s3.1367 0.49609 4.1602 0.98047c1.0391 0.48828 2.0234 0.95313 4.043 0.95313z" fill="#fff"/>
-</g>
-<g clip-path="url(#bl)">
-<path d="m57.906 19.047c-2.1016 0-3.1719-0.50391-4.2031-0.98828-1.0273-0.48828-2.0039-0.94531-4-0.94531-2 0-2.9727 0.45703-4.0039 0.94531-1.0312 0.48438-2.0977 0.98828-4.2031 0.98828-2.1016 0-3.168-0.50391-4.1992-0.98828-1.0312-0.48828-2.0039-0.94531-4.0039-0.94531-1.9961 0-2.9727 0.45703-4 0.94531-1.0312 0.48438-2.0977 0.98828-4.2031 0.98828-2.1016 0-3.1719-0.50391-4.2031-0.98828-1.0273-0.48828-2-0.94531-4-0.94531s-2.9727 0.45703-4.0039 0.94531c-1.0312 0.48438-2.0977 0.98828-4.1992 0.98828-2.1055 0-3.1719-0.50391-4.2031-0.98828-1.0312-0.48828-2.0039-0.94531-4.0039-0.94531v-0.46875c2.1055 0 3.1719 0.50391 4.2031 0.98828 1.0312 0.48828 2.0039 0.94531 4.0039 0.94531 1.9961 0 2.9688-0.45703 4-0.94531 1.0312-0.48437 2.0977-0.98828 4.2031-0.98828 2.1016 0 3.168 0.50391 4.2031 0.98828 1.0273 0.48828 2 0.94531 4 0.94531s2.9727-0.45703 4-0.94531c1.0352-0.48437 2.1016-0.98828 4.2031-0.98828 2.1055 0 3.1719 0.50391 4.2031 0.98828 1.0312 0.48828 2.0039 0.94531 4 0.94531 2 0 2.9727-0.45703 4.0039-0.94531 1.0312-0.48437 2.0977-0.98828 4.2031-0.98828 2.1016 0 3.168 0.50391 4.1992 0.98828 1.0312 0.48828 2.0039 0.94531 4.0039 0.94531z" fill="#fff"/>
-</g>
-<g clip-path="url(#k)">
-<path d="m57.906 23.781c-2.125 0-3.1992-0.50781-4.2422-1-1.0195-0.48047-1.9844-0.93359-3.9609-0.93359-1.9805 0-2.9414 0.45312-3.9648 0.9375-1.0391 0.48828-2.1172 0.99609-4.2422 0.99609-2.1211 0-3.1992-0.50781-4.2383-0.99609-1.0234-0.48438-1.9883-0.9375-3.9648-0.9375-1.9766 0-2.9414 0.45312-3.9609 0.93359-1.043 0.49219-2.1172 1-4.2422 1s-3.1992-0.50781-4.2422-1c-1.0195-0.48047-1.9844-0.93359-3.9609-0.93359-1.9766 0-2.9414 0.45312-3.9648 0.9375-1.0391 0.48828-2.1172 0.99609-4.2383 0.99609-2.125 0-3.2031-0.50781-4.2422-0.99609-1.0234-0.48438-1.9844-0.9375-3.9648-0.9375v-0.65625c2.125 0 3.2031 0.50781 4.2422 1 1.0234 0.48047 1.9844 0.93359 3.9648 0.93359 1.9766 0 2.9375-0.45312 3.9609-0.93359 1.0391-0.49219 2.1172-1 4.2422-1s3.1992 0.50781 4.2422 1c1.0195 0.48047 1.9844 0.93359 3.9609 0.93359 1.9766 0 2.9414-0.45312 3.9609-0.93359 1.043-0.49219 2.1172-1 4.2422-1s3.2031 0.50781 4.2422 1c1.0195 0.48047 1.9844 0.93359 3.9609 0.93359 1.9766 0 2.9414-0.45312 3.9648-0.93359 1.0391-0.49219 2.1172-1 4.2422-1s3.1992 0.50781 4.2422 1c1.0195 0.48047 1.9844 0.93359 3.9609 0.93359z" fill="#fff"/>
-</g>
-</g>
-</g>
-</g>
-</g>
-</g>
-</g>
-<path d="m1170.1 876.87c0.0625-17.074 13.715-30.516 30.238-30.801 17.551-0.30078 31.203 13.773 31.406 30.398 0.21094 17.297-13.703 31.25-30.789 31.258-17.051 0.007813-30.828-13.758-30.855-30.855zm58.953 0.011718c0.007812-15.473-12.438-27.949-27.777-28.129-15.883-0.1875-28.508 12.605-28.484 28.164-0.003906 0.92188 0.042969 1.8398 0.13281 2.7578 0.089844 0.91797 0.22266 1.8281 0.40234 2.7344 0.17969 0.90234 0.40234 1.7969 0.67188 2.6758 0.26562 0.88281 0.57422 1.75 0.92969 2.6016 0.35156 0.85156 0.74609 1.6836 1.1797 2.4961 0.43359 0.81641 0.90625 1.6055 1.418 2.3711 0.51172 0.76562 1.0625 1.5039 1.6484 2.2188 0.58203 0.71094 1.2031 1.3945 1.8555 2.043 0.64844 0.65234 1.332 1.2695 2.0469 1.8555 0.71094 0.58594 1.4492 1.1328 2.2188 1.6445 0.76562 0.51172 1.5547 0.98438 2.3672 1.418 0.81641 0.43359 1.6484 0.82812 2.5 1.1797 0.85156 0.35156 1.7188 0.66016 2.6016 0.92578 0.88281 0.26562 1.7734 0.48828 2.6797 0.66797 0.90234 0.17969 1.8125 0.3125 2.7305 0.40234 0.91797 0.089844 1.8398 0.13281 2.7617 0.13281 15.613-0.007813 28.145-12.664 28.117-28.16z" fill="#fdfdfe"/>
-<path d="m1202.2 879.19v5.207c0 0.42578 0.003906 0.42578 0.42578 0.40625 0.93359-0.050782 1.8555-0.18359 2.7617-0.40234 1.5039-0.33984 2.6016-1.2383 3.4531-2.4766 0.085938-0.12109 0.089844-0.20312-0.085938-0.25391-0.59766-0.17578-0.63672-0.33594-0.18359-0.77344 0.71484-0.6875 1.4297-1.3789 2.1523-2.0625 0.27734-0.26563 0.53125-0.20703 0.625 0.16406 0.25 0.99609 0.49609 1.9922 0.73047 2.9961 0.082031 0.34375-0.17188 0.58594-0.52344 0.50781-0.058594-0.015625-0.11328-0.03125-0.16797-0.050781-0.17578-0.070313-0.28125 0-0.36328 0.15234-0.34375 0.63672-0.73438 1.2422-1.1797 1.8125-0.89062 1.1172-1.9453 2.0508-3.207 2.7188-0.94922 0.5-1.9102 0.98438-2.957 1.2617-0.25 0.074218-0.50781 0.12109-0.76953 0.13672-0.23437 0.003906-0.39844 0.125-0.55859 0.28125-0.35156 0.35547-0.71484 0.70312-1.0742 1.0508-0.24609 0.23828-0.49609 0.23828-0.74219-0.003907-0.40234-0.39453-0.80078-0.78516-1.1992-1.1836-0.09375-0.097657-0.21094-0.16016-0.34375-0.1875-1.9531-0.37891-3.6367-1.3047-5.1523-2.5547-1.2266-1.0156-2.1953-2.2344-2.918-3.6523-0.16797-0.32422-0.34766-0.40625-0.71484-0.33203-0.36328 0.070313-0.55469-0.12891-0.44531-0.48438 0.32031-1.0273 0.64453-2.0508 0.96875-3.0742 0.089844-0.28125 0.35547-0.33984 0.55859-0.12109 0.74609 0.8125 1.4922 1.6289 2.2383 2.4453 0.19922 0.22266 0.082031 0.50391-0.18359 0.53125-0.058594 0.011719-0.11719 0.027344-0.17578 0.042969-0.17578 0.042969-0.1875 0.13281-0.10156 0.27734 0.47266 0.80859 1.0898 1.4766 1.8555 2.0117 0.41406 0.28125 0.90625 0.41797 1.3867 0.55078 1.082 0.30078 2.1836 0.5 3.3047 0.60156 0.23047 0.023437 0.30469-0.039063 0.30469-0.29297 0.003906-0.55859 0-1.1211 0-1.6836v-8.7969c0-0.33594-0.023437-0.36328-0.34766-0.36328-0.74219 0-1.4805 0.007813-2.2227 0-0.21875 0-0.42578 0.058594-0.61328 0.17578-0.51172 0.29687-1.0195 0.23437-1.4609-0.16016-0.37109-0.33203-0.47656-0.90625-0.26172-1.4023 0.27734-0.64063 1.1406-0.90625 1.7266-0.52344 0.18359 0.12109 0.38672 0.18359 0.60937 0.17969 0.75-0.007813 1.4961 0 2.2461-0.003907 0.28516 0 0.32422-0.039062 0.32422-0.32422 0-0.24609-0.011719-0.49219 0.003906-0.73828 0.011719-0.19141-0.070312-0.28125-0.23438-0.35156-0.68359-0.29297-1.293-0.69141-1.6914-1.3438-1.3867-2.2734-0.015625-4.832 2.2539-5.2852 0.37109-0.074218 0.74609-0.085937 1.1211-0.035156 0.375 0.046875 0.73047 0.15625 1.0703 0.32031 0.33984 0.16797 0.64453 0.38281 0.91406 0.64844 0.26953 0.26172 0.49219 0.5625 0.66406 0.90234 0.76172 1.5312 0.39062 3.6523-1.4727 4.6016-0.26172 0.13281-0.38281 0.28906-0.35547 0.58984 0.019532 0.27734 0.019532 0.55078 0.003907 0.82812-0.003907 0.13672 0.054687 0.19141 0.18359 0.19141 0.76563-0.003907 1.5273-0.003907 2.293-0.003907 0.13672-0.011719 0.25781-0.0625 0.36328-0.15234 0.23828-0.15625 0.49609-0.22266 0.77734-0.19922 0.28125 0.023437 0.52734 0.13281 0.73047 0.32812 0.19922 0.19531 0.31641 0.42969 0.35938 0.70312 0.042969 0.27344 0 0.53516-0.12891 0.78125-0.14062 0.24609-0.33984 0.42188-0.59766 0.53125-0.26172 0.11328-0.52734 0.12891-0.80078 0.058593-0.042968-0.007812-0.085937-0.023437-0.125-0.050781-0.38281-0.32422-0.83594-0.25781-1.2812-0.23828-0.5 0.035156-1 0.039062-1.5 0.015625-0.22266-0.015625-0.27734 0.066406-0.27344 0.27734 0.007812 1.7578 0.003906 3.5156 0.003906 5.2734zm-1.2656-10.195c0.9375 0.023437 1.7266-0.76562 1.75-1.75 0.003906-0.23438-0.039062-0.45703-0.12109-0.67578-0.085937-0.21875-0.21094-0.41016-0.37109-0.57812-0.16016-0.17188-0.34766-0.30078-0.5625-0.39844-0.21484-0.09375-0.4375-0.14453-0.67187-0.14844-0.23047-0.007812-0.45703 0.03125-0.67578 0.11719-0.21875 0.082031-0.41406 0.20312-0.58203 0.36328-0.17188 0.16016-0.30469 0.34766-0.39844 0.5625-0.097657 0.21094-0.14844 0.43359-0.15625 0.66797-0.027344 1.0547 0.71094 1.8164 1.7891 1.8398z" fill="#fdfdfe"/>
-<path d="m1183.1 890.09c-0.39062 0.25-0.72656 0.57031-1.0859 0.85937-0.054688 0.046876-0.11328 0.097657-0.17578 0.13672-0.10547 0.085938-0.21094 0.085938-0.31641 0.007813-0.21875-0.16797-0.37891-0.375-0.48828-0.62891-0.058594-0.15625 0.078125-0.26172 0.1875-0.34766 0.5-0.40625 1.0039-0.80469 1.5-1.207 0.38672-0.31641 0.77344-0.63672 1.1523-0.96094 0.15234-0.12891 0.28516-0.14844 0.42969 0.003907 0.070313 0.078125 0.15234 0.14062 0.22656 0.21484 0.23047 0.22656 0.25781 0.48047 0.13672 0.77734-0.19922 0.49609-0.37891 1-0.57812 1.5273 0.52344-0.074219 1.0156-0.14062 1.5078-0.21875 0.20703-0.035156 0.40625-0.007812 0.59766 0.085938s0.33594 0.23437 0.43359 0.42187c0.09375 0.17969 0.03125 0.30859-0.11328 0.42578-0.66797 0.53906-1.3359 1.0781-2 1.6211-0.22656 0.18359-0.44922 0.37109-0.67578 0.55078-0.26563 0.21094-0.36719 0.19141-0.56641-0.070313-0.074219-0.09375-0.14844-0.1875-0.23047-0.27734-0.16797-0.1875-0.16406-0.32812 0.035157-0.49219 0.32812-0.26953 0.66016-0.53516 0.98828-0.80469 0.046875-0.039063 0.13672-0.070313 0.10547-0.14453-0.023438-0.0625-0.11719-0.054687-0.17969-0.050781-0.14844 0.007813-0.29688 0.023437-0.44531 0.042969-0.49609 0.054687-0.78906-0.29297-0.64062-0.76562 0.070312-0.22656 0.14844-0.45312 0.22266-0.67969v-0.046875z" fill="#fdfdfe"/>
-<path d="m1175.2 877.3c0.30469 0.09375 0.59375 0.21875 0.87109 0.37109 1.5352 0.78125 3.168 0.95312 4.8555 0.82031 1.0938-0.085937 2.1016-0.43359 3.0742-0.91016 1.2852-0.65234 2.6484-0.98828 4.0898-1.0156 1.5273-0.015625 2.9766 0.25 4.3516 0.92969 0.74609 0.36719 1.5117 0.70312 2.3398 0.86328 0.9375 0.17188 1.8828 0.21875 2.832 0.13672 0.52344-0.039063 1.0391-0.12891 1.543-0.26953 0.11328-0.035156 0.13672-0.003906 0.14453 0.10938 0.015625 0.36328 0.023438 0.375-0.32031 0.44531-2.125 0.44141-4.1992 0.35938-6.1914-0.58594-0.47656-0.22656-0.94922-0.46875-1.4453-0.65625-0.55469-0.20703-1.125-0.33984-1.7148-0.40234-1.2852-0.13672-2.5664-0.11328-3.8203 0.25-0.66406 0.19141-1.2812 0.49219-1.9023 0.78516-1.1133 0.53516-2.2852 0.81641-3.5195 0.84766-1.0898 0.03125-2.1602-0.046875-3.207-0.37109-0.64844-0.19922-1.2539-0.50781-1.875-0.77734-0.078126-0.023438-0.11328-0.074219-0.10547-0.15234 0.007812-0.13281 0-0.26953 0-0.41797z" fill="#fdfdfe"/>
-<path d="m1207.1 855.11c-0.023438 0.56641-0.19141 1.0547-0.75781 1.3125-0.16797 0.074219-0.19922 0.1875-0.14453 0.35938 0.12109 0.38281 0.23047 0.76953 0.33594 1.1602 0.054688 0.21094-0.011718 0.30859-0.23047 0.29297-0.58984-0.042969-0.83203-0.03125-1.0391-0.71875-0.078125-0.26562-0.16797-0.52344-0.23438-0.79297-0.070312-0.29297-0.25-0.32812-0.52734-0.31641-0.09375 0.003906-0.10937 0.074219-0.125 0.15625-0.050781 0.25391-0.10547 0.51172-0.16797 0.76172-0.054688 0.20703-0.15234 0.38672-0.37891 0.42578-0.26953 0.042969-0.50391-0.023437-0.71094-0.19531-0.125-0.097656-0.070312-0.25391-0.042969-0.38281 0.17969-0.92188 0.35938-1.8438 0.54297-2.7656 0.050781-0.26562 0.10156-0.52734 0.16016-0.78906 0.03125-0.14844 0.11719-0.25 0.28516-0.21875 0.78906 0.15234 1.5977 0.23438 2.3359 0.57422 0.46094 0.21484 0.69922 0.63281 0.69922 1.1367zm-2.4727-0.097656c-0.019531 0.30859 0.18359 0.55078 0.51563 0.50781 0.09375-0.003907 0.19141 0.003906 0.28516 0.019531 0.19531 0.019531 0.37109-0.03125 0.46094-0.23438 0.097657-0.19141 0.0625-0.35547-0.10938-0.48438-0.20703-0.17969-0.44531-0.26172-0.71875-0.24609-0.29688 0.007813-0.4375 0.14453-0.43359 0.4375z" fill="#fdfdfe"/>
-<path d="m1195.6 898.1c0.13672-0.50391 0.26953-1.0078 0.40625-1.5117 0.10156-0.38281 0.20703-0.44531 0.59375-0.33594 0.058593 0.015625 0.11328 0.03125 0.17187 0.050781 0.40625 0.11328 0.45703 0.19922 0.33984 0.60938-0.25781 0.91016-0.51953 1.8242-0.77734 2.7344-0.046874 0.17969-0.082031 0.36328-0.12109 0.54688-0.007813 0.0625-0.035157 0.11328-0.085938 0.15234s-0.10547 0.050781-0.16797 0.039062c-0.60937-0.042968-0.75781-0.13672-0.91797-0.66016-0.16797-0.55859-0.375-1.1133-0.56641-1.668-0.03125-0.070313-0.066407-0.14063-0.10547-0.21094-0.12891 0.47656-0.25 0.89453-0.35547 1.3164-0.16797 0.69141-0.23047 0.66406-0.82812 0.49609-0.38281-0.10938-0.4375-0.20703-0.32812-0.59766 0.30859-1.0898 0.64844-2.1719 0.89844-3.2812 0.007812-0.070313 0.039062-0.125 0.09375-0.16797 0.058593-0.042969 0.12109-0.058594 0.19141-0.042969 0.52734 0.027344 0.72656 0.17578 0.89062 0.67578 0.20703 0.62109 0.41406 1.2422 0.62109 1.8594z" fill="#fdfdfe"/>
-<path d="m1217.8 888.2c0.76562 0.023437 1.2891 0.5 1.3828 1.2109 0.050781 0.39062 0.066406 0.39844 0.46875 0.46094 0.31641 0.054687 0.62891 0.11328 0.94531 0.17969 0.22266 0.046875 0.25781 0.125 0.15234 0.32812-0.23438 0.46094-0.59766 0.80078-1.2305 0.57812-0.21484-0.0625-0.43359-0.10938-0.65625-0.13672-0.11328-0.015624-0.21484 0.007813-0.30859 0.074219-0.089844 0.0625-0.14844 0.15234-0.17188 0.26172-0.027344 0.10547 0.054687 0.12891 0.10547 0.17188 0.23047 0.1875 0.46484 0.37109 0.69922 0.55469 0.074219 0.046876 0.11328 0.10938 0.12891 0.19141 0.011719 0.085937-0.007812 0.16016-0.0625 0.22266-0.09375 0.14453-0.19531 0.28125-0.3125 0.40625-0.16406 0.17969-0.29297 0.1875-0.48828 0.035156-0.42578-0.32812-0.83984-0.66406-1.2656-0.99219-0.4375-0.34375-0.88281-0.6875-1.3242-1.0273-0.33984-0.25781-0.36719-0.39844-0.10156-0.73047 0.32812-0.41797 0.64844-0.83594 0.99219-1.2383 0.28516-0.33594 0.63672-0.56641 1.0469-0.55078zm0.33984 1.5156c0.007813-0.26172-0.31641-0.48438-0.51172-0.37109-0.25391 0.14844-0.46484 0.34766-0.625 0.59375-0.035156 0.050781-0.058593 0.10938-0.015624 0.16406 0.14453 0.17188 0.3125 0.31641 0.5 0.4375 0.039062 0.023438 0.074218 0.019532 0.10547-0.011718 0.25-0.22266 0.43359-0.49609 0.54688-0.8125z" fill="#fdfdfe"/>
-<path d="m1195.3 854.14c0.011719-0.25781 0.14844-0.33984 0.33594-0.37109 0.46875-0.074219 0.94141-0.14453 1.4141-0.22266 0.32422-0.054687 0.64453-0.12891 0.96484-0.17969 0.33984-0.050782 0.40234 0.003906 0.47266 0.33984 0.10938 0.57031 0.085938 0.60156-0.5 0.69141-0.375 0.054687-0.75 0.11719-1.125 0.17969-0.21094 0.039063-0.29297 0.14844-0.26172 0.34375 0.039062 0.25391 0.10938 0.32422 0.35156 0.28516 0.38672-0.058594 0.77734-0.13281 1.1641-0.21094 0.33594-0.0625 0.43359-0.007812 0.51172 0.32031 0.019531 0.070313 0.023437 0.14453 0.035156 0.21875 0.050781 0.30469-0.027344 0.41797-0.32031 0.46875-0.375 0.0625-0.75 0.13281-1.125 0.17969-0.36719 0.046875-0.36719 0.18359-0.29688 0.52344 0.039063 0.18359 0.21094 0.16797 0.35156 0.14453 0.44141-0.078125 0.88281-0.16016 1.3203-0.23828 0.082031-0.011719 0.16406-0.011719 0.24609-0.019532 0.0625 0 0.11719 0.019532 0.16406 0.0625 0.054687 0.042969 0.19141 0.71094 0.15625 0.77344-0.058594 0.10938-0.17188 0.13672-0.28125 0.15625-0.74609 0.13672-1.4961 0.26953-2.2422 0.40234-0.09375 0.015624-0.19141 0.035156-0.28516 0.046874-0.29688 0.046876-0.37891-0.007812-0.43359-0.30078-0.15234-0.875-0.30078-1.75-0.44922-2.6211-0.058593-0.33984-0.11719-0.67578-0.16797-0.97266z" fill="#fdfdfe"/>
-<path d="m1209.9 898.08c0.007812 0.58203-0.30859 0.98047-0.75 1.3047-0.71875 0.52734-1.6992 0.53906-2.3555 0.027344-0.25781-0.20312-0.40625-0.48047-0.52344-0.76953-0.15625-0.38281-0.27344-0.77344-0.35156-1.1758-0.10156-0.49609 0.046875-0.92969 0.38672-1.2969 0.30078-0.32031 0.66016-0.52734 1.0859-0.63281 0.42578-0.10156 0.84375-0.082031 1.2539 0.058594 0.26953 0.10156 0.48047 0.26953 0.64062 0.50781 0.097657 0.14844 0.0625 0.26172-0.097656 0.31641-0.38672 0.13672-0.76562 0.26953-1.1914 0.089843-0.11719-0.046874-0.23438-0.0625-0.35938-0.046874-0.125 0.015624-0.23438 0.0625-0.33594 0.14062-0.097657 0.074219-0.17188 0.17188-0.21875 0.28516-0.046876 0.11719-0.0625 0.23438-0.046876 0.35938 0.042969 0.47266 0.20313 0.89844 0.47266 1.2891 0.17188 0.23828 0.41797 0.29688 0.76172 0.1875 0.28906-0.085937 0.52344-0.35156 0.53125-0.60156 0.003906-0.12109-0.054688-0.18359-0.17969-0.16797-0.042969 0.011719-0.082031 0.027344-0.125 0.042969-0.054688 0.023437-0.11328 0.039062-0.17188 0.042968-0.35938-0.007812-0.28125-0.35156-0.39453-0.54297-0.078125-0.13281-0.058594-0.29688 0.10547-0.35938 0.41016-0.16016 0.82422-0.30469 1.2383-0.44141 0.15625-0.046874 0.26172 0.003907 0.3125 0.16016 0.1875 0.38672 0.29297 0.79297 0.3125 1.2227z" fill="#fdfdfe"/>
-<path d="m1211.5 882.99c0.60547 0.11328 1.2188 0.17969 1.8359 0.1875 1.3555 0.023438 2.6523-0.21875 3.8828-0.82031 1.0547-0.51172 2.1367-0.95703 3.3203-1.082 1.8008-0.1875 3.5469-0.03125 5.207 0.74609 0.10156 0.046875 0.28516 0.070313 0.28516 0.17969-0.011719 0.20312-0.050781 0.39844-0.12109 0.58984-0.03125 0.09375-0.11328 0.011719-0.16797-0.011718-0.62891-0.27344-1.25-0.55078-1.9297-0.6875-0.97266-0.20312-1.9531-0.21484-2.9414-0.14844-1.1289 0.078125-2.168 0.46094-3.168 0.96094-1.4414 0.71875-2.9688 1.0391-4.5742 0.95703-0.63672-0.015625-1.2656-0.09375-1.8867-0.22266-0.125-0.03125-0.17188-0.0625-0.085937-0.1875 0.074219-0.10547 0.13672-0.21875 0.1875-0.33203 0.046875-0.09375 0.10156-0.14844 0.15625-0.12891z" fill="#fdfdfe"/>
-<path d="m1214.1 892.86c0.011718 0.10156-0.0625 0.16797-0.15234 0.23047-0.35938 0.25391-0.72266 0.50391-1.0781 0.76172-0.085938 0.0625-0.21875 0.10938-0.19141 0.25 0.035157 0.15234 0.125 0.26953 0.26172 0.34766 0.082031 0.050781 0.16797-0.015625 0.24219-0.070313 0.34766-0.24609 0.69531-0.48828 1.0352-0.74609 0.054687-0.050781 0.11719-0.078124 0.19531-0.070312 0.074218 0.007812 0.13281 0.039062 0.17969 0.10156 0.023437 0.027344 0.054687 0.050782 0.078125 0.078126 0.39453 0.49219 0.32422 0.57031-0.070312 0.82812-0.27734 0.17969-0.53906 0.375-0.80469 0.57031-0.23047 0.16406-0.24219 0.25391-0.078125 0.47656 0.13281 0.18359 0.23047 0.19922 0.44922 0.042968 0.35547-0.25 0.69922-0.51172 1.0547-0.76172 0.26953-0.1875 0.35156-0.16797 0.55078 0.097656 0.33203 0.44141 0.32813 0.49219-0.11328 0.80859-0.60938 0.43359-1.2188 0.86719-1.8281 1.2969-0.23828 0.16797-0.32812 0.16016-0.5-0.078124-0.67578-0.94141-1.3438-1.8828-2.0117-2.832-0.16797-0.23828-0.13672-0.34766 0.10547-0.51953 0.63672-0.45312 1.2734-0.90625 1.9141-1.3633 0.22656-0.16406 0.35938-0.14844 0.51953 0.082031 0.097656 0.14062 0.23438 0.26172 0.24219 0.46875z" fill="#fdfdfe"/>
-<path d="m1188.8 897.12c0.050781-0.16406-0.035156-0.26953-0.19141-0.35938-0.30469-0.18359-0.60156-0.38281-0.89453-0.58203-0.11328-0.097656-0.21875-0.089843-0.31641 0.019531-0.32422 0.27344-0.4375 0.27344-0.78906 0.039063-0.082031-0.054687-0.15625-0.11719-0.23828-0.17188-0.24609-0.16797-0.25391-0.24219-0.011719-0.42969 0.97656-0.76953 1.9648-1.5312 2.9453-2.2969 0.066406-0.066407 0.14844-0.097657 0.24219-0.10156 0.089844-0.003906 0.17578 0.023437 0.24609 0.085937 0.22266 0.15625 0.49219 0.24219 0.69531 0.4375 0.14844 0.12109 0.19531 0.27344 0.14062 0.45703-0.24609 0.99219-0.48438 1.9883-0.72656 2.9805-0.050782 0.19141-0.125 0.37891-0.13281 0.58594-0.007812 0.19531-0.14062 0.28125-0.33984 0.25781-0.36719-0.039062-0.64844-0.4375-0.62891-0.92187zm0.58203-2.4805c-0.18359 0.14062-0.33203 0.25-0.47656 0.36328-0.53516 0.41797-0.52734 0.49609 0.0625 0.83594 0.097656 0.058593 0.14062 0.054687 0.17188-0.054688 0.12109-0.37109 0.20312-0.75391 0.24219-1.1445z" fill="#fdfdfe"/>
-<path d="m1201.6 896.62c0.37891 0 0.58984 0.20312 0.72656 0.5 0.22266 0.47266 0.39062 0.96484 0.57422 1.4531 0.23828 0.61719 0.46875 1.2344 0.70312 1.8555 0.10156 0.27734 0.054688 0.33594-0.24609 0.35156-0.10547 0.003906-0.20703 0.015625-0.3125 0.027344-0.30859 0.050781-0.5-0.042969-0.57812-0.34375-0.0625-0.23828-0.19922-0.28125-0.41016-0.26953-0.32812 0.019532-0.65625 0.03125-0.98438 0.023438-0.16797 0-0.28125 0.054688-0.31641 0.21484-0.078125 0.33984-0.70312 0.57031-1.0117 0.5-0.19922-0.046875-0.21875-0.19141-0.16016-0.36719 0.22656-0.71875 0.44922-1.4375 0.67188-2.1562 0.13281-0.41797 0.26562-0.83984 0.38672-1.2617 0.078126-0.26953 0.21484-0.44141 0.51953-0.46875 0.15234-0.015626 0.30859-0.042969 0.4375-0.058594zm-0.054688 1.3398c-0.023437 0.023437-0.035156 0.03125-0.039062 0.042968-0.074219 0.22656-0.14844 0.45703-0.21875 0.68359-0.1875 0.58984-0.14062 0.64453 0.48438 0.57812 0.17188-0.019531 0.22266-0.089844 0.16016-0.25-0.13281-0.34766-0.25781-0.69531-0.38672-1.0547z" fill="#fdfdfe"/>
-<path d="m1189.8 856.24c0.46484-0.015625 0.84766 0.15234 1.1484 0.50781 0.125 0.14453 0.125 0.28516-0.039063 0.39844-0.32812 0.23047-0.67188 0.37891-1.0859 0.20703-0.3125-0.12891-0.65625-0.015624-0.90625 0.26953-0.20312 0.22656-0.22656 0.48438-0.050782 0.80859 0.15234 0.28125 0.32031 0.55469 0.49609 0.82422 0.16016 0.25 0.36719 0.4375 0.69922 0.37109 0.39453-0.078125 0.67188-0.33594 0.71875-0.69531 0.058594-0.43359 0.32031-0.69141 0.6875-0.86719 0.17969-0.082031 0.29297-0.023438 0.36328 0.16797 0.25781 0.69922 0.023438 1.2773-0.46094 1.7734-0.48047 0.48828-1.0664 0.75391-1.7734 0.6875-0.375-0.03125-0.6875-0.1875-0.94531-0.46484-0.39453-0.40625-0.69531-0.875-0.90625-1.4023-0.33984-0.89844 0.027343-1.7969 0.88281-2.2656 0.36328-0.20312 0.75391-0.30859 1.1719-0.32031z" fill="#fdfdfe"/>
-<path d="m1175.8 882.15c0.75 0.32812 1.4375 0.67578 2.1992 0.82031 1.875 0.35938 3.7109 0.30078 5.4844-0.48828 0.67578-0.30078 1.3359-0.63672 2.0391-0.86328 0.99219-0.30859 2.0078-0.44531 3.0469-0.41016 0.21094 0.003907 0.47266-0.078125 0.60937 0.050781 0.11328 0.11328-0.019531 0.375 0.054688 0.57031 0.042969 0.11328-0.058594 0.09375-0.12109 0.089844-0.41016-0.007813-0.82031-0.015625-1.2305-0.003907-1.2109 0.023438-2.3359 0.35938-3.418 0.88281-0.95703 0.46094-1.9336 0.85547-3.0039 0.98047-1.8438 0.20703-3.6367 0.085937-5.3359-0.73047-0.0625-0.027344-0.125-0.046875-0.14453-0.125-0.054688-0.24609-0.11328-0.49219-0.17969-0.77344z" fill="#fdfdfe"/>
-<path d="m1196.8 874.95c-1.5117 0.078126-2.9258-0.28516-4.2695-0.96484-2.207-1.1094-4.5-1.2461-6.8555-0.58203-0.61719 0.17578-1.1914 0.46875-1.7695 0.75-1.3516 0.65234-2.7773 0.875-4.2656 0.82422-0.84766-0.015625-1.6758-0.15234-2.4844-0.41406-0.54297-0.18359-1.0586-0.4375-1.5859-0.66016-0.16797-0.070313-0.125-0.20313-0.085938-0.30078 0.046875-0.12891 0.13672-0.011718 0.19141 0.015625 0.92188 0.42578 1.8477 0.84375 2.8711 0.96484 1.6641 0.19922 3.3047 0.13672 4.875-0.55078 0.8125-0.35547 1.5977-0.76953 2.4609-1.0078 1.1289-0.30859 2.2812-0.34766 3.4414-0.27344 1.2539 0.078125 2.4023 0.5 3.5117 1.0508 1.3398 0.65625 2.7539 0.94922 4.2461 0.875 0.71094-0.019531 1.4102-0.11328 2.1016-0.28125 0.058593-0.015625 0.16797-0.11328 0.1875 0.039063 0.015625 0.10547 0.035156 0.21875-0.12891 0.25781-0.51562 0.13281-1.0391 0.21875-1.5703 0.25391-0.28906 0.019532-0.58203 0.003906-0.87109 0.003906z" fill="#fdfdfe"/>
-<path d="m1211.8 878.41c0.58203 0.085938 1.1719 0.125 1.7617 0.125 1.3438 0.007812 2.6211-0.28906 3.8242-0.88672 0.93359-0.45703 1.8945-0.84766 2.9375-0.98047 1.043-0.13281 2.0859-0.12891 3.125 0.015626 1.082 0.14453 2.0547 0.59766 3.0273 1.0508 0.082031 0.039062 0.13672 0.47266 0.066406 0.53125-0.070312 0.054687-0.125-0.015625-0.18359-0.039063-0.57422-0.26562-1.1445-0.54297-1.7422-0.75-1.0469-0.36328-2.1289-0.42969-3.2227-0.40625-1.2773 0.035156-2.4805 0.34766-3.6094 0.94141-1.375 0.71094-2.8359 1.0508-4.3828 1.0234-0.43359-0.007812-0.86328-0.027344-1.2969-0.074219-0.11719 0.003907-0.18359-0.054687-0.19922-0.17188-0.023438-0.11328-0.0625-0.22656-0.10547-0.37891z" fill="#fdfdfe"/>
-<path d="m1214.4 858.61c-0.046875-0.011719-0.09375-0.027344-0.14062-0.046875-0.082031-0.039062-0.15625-0.085938-0.23438-0.13281-0.54688-0.30859-0.60938-0.32031-0.92578 0.1875-0.39844 0.63281-0.80078 1.2656-1.207 1.8945-0.18359 0.28125-0.29297 0.29688-0.5625 0.11328-0.09375-0.0625-0.1875-0.125-0.28125-0.18359-0.30078-0.1875-0.32422-0.28906-0.12891-0.59375 0.29297-0.46484 0.58984-0.92578 0.88281-1.3906 0.1875-0.29688 0.35938-0.60156 0.55859-0.88672 0.0625-0.097656 0.039063-0.14062-0.023437-0.20703-0.14453-0.15625-0.34375-0.22656-0.52344-0.33203-0.30078-0.17969-0.35547-0.34766-0.17969-0.64062 0.23828-0.39844 0.38281-0.44922 0.70312-0.25 0.78516 0.49609 1.5703 0.99219 2.3516 1.4922 0.28125 0.17969 0.30469 0.27734 0.12891 0.56641-0.097656 0.16797-0.17188 0.37109-0.41797 0.41016z" fill="#fdfdfe"/>
-<path d="m1226.4 874.19c-0.62109-0.26953-1.2109-0.57031-1.8438-0.78125-1.0234-0.34375-2.0859-0.40625-3.1562-0.39062-1.3516 0.023437-2.6055 0.39844-3.7969 1.0039-1.8555 0.94531-3.8164 1.1289-5.8438 0.82812-0.89844-0.12891-1.7227-0.46875-2.5352-0.84766-0.55859-0.26953-1.1289-0.5-1.7227-0.6875-0.13672-0.042969-0.13281-0.097656-0.10938-0.20312 0.027344-0.14062 0.10547-0.10938 0.19531-0.082031 0.61719 0.17969 1.2109 0.41797 1.7812 0.71094 2.0938 1.0508 4.2773 1.1797 6.5156 0.63281 0.69922-0.16797 1.3438-0.5 1.9883-0.80859 1.1406-0.54297 2.3438-0.82812 3.6094-0.84766 1.2617-0.027344 2.4922 0.10547 3.6641 0.58984 0.34766 0.14062 0.67969 0.30859 1.0234 0.44922 0.19922 0.082032 0.28125 0.20312 0.23047 0.43359z" fill="#fdfdfe"/>
-<path d="m1210.6 878.08c-0.027344 0.03125-0.035157 0.039063-0.042969 0.050781-0.27344 0.35547-0.57031 0.25-0.91016 0.089844-0.82031-0.38672-1.6367-0.78906-2.5391-0.97266-0.91797-0.17969-1.8477-0.23438-2.7812-0.16016-0.44922 0.023437-0.89062 0.089844-1.3242 0.19922-0.13672 0.035157-0.18359 0.003907-0.18359-0.14453 0-0.33203-0.007813-0.33984 0.32031-0.39844 1.6914-0.29297 3.3672-0.27734 5.0117 0.28906 0.73047 0.25 1.4141 0.625 2.1328 0.91406 0.10156 0.042969 0.20313 0.085937 0.31641 0.13281z" fill="#fdfdfe"/>
-<path d="m1205.1 881.89c-0.72266-0.003906-1.4336 0.074219-2.1328 0.24219-0.16406 0.042969-0.1875-0.015624-0.1875-0.16016-0.003907-0.53125-0.007813-0.53906 0.48438-0.61719 1.4492-0.23438 2.8867-0.21875 4.3125 0.14844 0.23828 0.058594 0.26172 0.30078 0.41406 0.43359 0.050782 0.046875-0.27734 0.32422-0.37109 0.29297-0.49609-0.14844-1-0.24219-1.5156-0.28125-0.33594-0.027344-0.67188-0.039063-1.0039-0.058594z" fill="#fdfdfe"/>
-<path d="m1195.7 883.15c0.44531-0.003907 0.88672 0.042968 1.332 0.027343 0.74219-0.015625 1.4688-0.12109 2.1836-0.3125 0.11719-0.03125 0.15234-0.03125 0.16016 0.10547 0.023438 0.57422 0.019531 0.54688-0.52734 0.71094-0.67578 0.19922-1.3164 0.042968-1.957-0.12109-0.40625-0.10547-0.81641-0.20703-1.1914-0.41016z" fill="#fdfdfe"/>
-<path d="m1367.2 881.75c-0.097657-0.019531-0.19141-0.023437-0.28906-0.019531-0.16797 0.007813-0.32422 0.046875-0.47656 0.12109-0.14453 0.070312-0.27344 0.16406-0.37891 0.28125-0.10938 0.11719-0.19141 0.25-0.25 0.40234-0.054687 0.14844-0.082031 0.30078-0.078125 0.46094 0.003907 0.16016 0.039063 0.3125 0.10156 0.46094l-0.007813 0.011718 2.8594 6.8477c1.3672-0.86328 2.5586-1.9258 3.5703-3.1836 1.0078-1.2578 1.7852-2.6484 2.332-4.1641l-7.3711-1.2344zm-11.469 0.97266c-0.0625-0.27734-0.20703-0.50781-0.42969-0.6875-0.22266-0.17969-0.47656-0.26953-0.76562-0.27734-0.082031 0-0.16406 0.007812-0.24609 0.023437l-0.011719-0.015625-7.3047 1.2305c0.54688 1.5039 1.3242 2.8789 2.332 4.1289 1.0078 1.25 2.1914 2.3047 3.5508 3.168l2.8281-6.7852-0.019531-0.023438c0.10547-0.24609 0.12891-0.5 0.066407-0.76172zm6.1211 2.6602c-0.23828-0.4375-0.60547-0.65234-1.1016-0.65234-0.5 0-0.86328 0.21875-1.0977 0.65234h-0.007812l-3.5938 6.4414c2.625 0.88672 5.2852 1.0195 7.9883 0.40625 0.49219-0.10938 0.96875-0.24219 1.4375-0.39844l-3.5977-6.4531zm11.371-14.961-5.5273 4.9023 0.003907 0.015625c-0.375 0.32812-0.50781 0.73047-0.39844 1.2109 0.11328 0.48047 0.40625 0.78516 0.88672 0.91797l0.007812 0.027344 7.1602 2.0469c0.15234-1.5977 0.046874-3.1719-0.31641-4.7344-0.36328-1.5586-0.96875-3.0234-1.8164-4.3867zm-10.27 0.55078c0.023437 0.49219 0.25781 0.84375 0.70703 1.0586 0.44922 0.21094 0.875 0.17578 1.2773-0.11719l0.019531 0.011719 6.0508-4.2539c-1.1523-1.1172-2.4531-2.0234-3.9062-2.7148-1.4492-0.69531-2.9766-1.1406-4.5742-1.3359l0.41797 7.3477zm-6.4062 0.96875c0.40234 0.28906 0.82812 0.32813 1.2773 0.11328 0.44922-0.21484 0.68359-0.56641 0.70312-1.0586l0.03125-0.015625 0.42188-7.3594c-0.50781 0.058594-1.0117 0.14453-1.5117 0.25781-2.7031 0.60156-5.043 1.8672-7.0195 3.793l6.0859 4.2773zm-3.2422 5.5625c0.48047-0.12891 0.77344-0.4375 0.88672-0.91797 0.10938-0.48047-0.023437-0.88281-0.39844-1.207l0.007812-0.03125-5.5586-4.9297c-0.84766 1.3711-1.4492 2.8359-1.8047 4.4023-0.35156 1.5664-0.44141 3.1484-0.26562 4.7461l7.125-2.0391zm5.3984 2.1641 2.0469 0.97656 2.0469-0.97266 0.50781-2.1875-1.4141-1.7578h-2.2773l-1.4219 1.7539z" fill="#326ce5"/>
-<path d="m1394.6 883.98-5.8398-25.16c-0.16016-0.65625-0.45312-1.25-0.88281-1.7812-0.42578-0.52734-0.94922-0.9375-1.5625-1.2344l-23.648-11.191c-0.62109-0.29688-1.2773-0.44141-1.9648-0.44141s-1.3398 0.14453-1.9609 0.44141l-23.645 11.199c-0.61328 0.29297-1.1367 0.70703-1.5664 1.2344-0.42578 0.52734-0.71875 1.1211-0.87891 1.7812l-5.832 25.156c-0.14844 0.64453-0.14844 1.2852-0.003906 1.9297 0.042968 0.19531 0.097656 0.38672 0.16406 0.57031 0.11719 0.32031 0.26562 0.625 0.45312 0.90625 0.078125 0.125 0.16406 0.24219 0.25391 0.35547l16.367 20.172c0.070313 0.085937 0.14844 0.16797 0.22656 0.25 0.25781 0.26953 0.54687 0.50781 0.86328 0.70703 0.40234 0.25391 0.83594 0.4375 1.2969 0.55859 0.375 0.10156 0.75781 0.15625 1.1484 0.15625h0.25391l25.992-0.003906c0.15625 0 0.3125-0.011719 0.47266-0.027344 0.22266-0.027344 0.44531-0.070312 0.66406-0.125 0.16016-0.042969 0.3125-0.09375 0.46484-0.14844 0.11719-0.046874 0.23437-0.089843 0.35156-0.14453 0.16797-0.082031 0.33594-0.17188 0.49609-0.27344 0.41406-0.25781 0.77344-0.57422 1.082-0.95312l0.5-0.61328 15.863-19.562c0.30469-0.37891 0.53906-0.79688 0.70703-1.2578 0.066406-0.1875 0.12109-0.37891 0.16406-0.57422 0.14844-0.64062 0.14844-1.2852 0-1.9297zm-24.527 9.7812c0.066406 0.19531 0.14453 0.38281 0.23438 0.56641-0.14844 0.26172-0.1875 0.53906-0.10938 0.82812 0.34375 0.78516 0.76562 1.5273 1.2539 2.2266 0.27734 0.35938 0.52734 0.73047 0.76172 1.1211 0.054688 0.10156 0.12891 0.26563 0.18359 0.375 0.10156 0.17188 0.16797 0.35547 0.19141 0.55469 0.023438 0.19531 0.007813 0.39062-0.050781 0.57812-0.058594 0.19141-0.15234 0.36328-0.28516 0.51172-0.12891 0.15234-0.28516 0.26953-0.46875 0.35547-0.17969 0.085938-0.37109 0.12891-0.57031 0.13281-0.20312 0.007813-0.39453-0.03125-0.57812-0.10547-0.1875-0.078125-0.34766-0.1875-0.48828-0.33203-0.13672-0.14062-0.24219-0.30859-0.30859-0.49609-0.054687-0.10938-0.12891-0.25391-0.17578-0.35938-0.16016-0.42188-0.29688-0.84766-0.41016-1.2852-0.24609-0.81641-0.57031-1.6055-0.96875-2.3594-0.18359-0.24219-0.42188-0.38672-0.72266-0.43359-0.046876-0.078125-0.21484-0.38281-0.30469-0.53906-2.1055 0.78906-4.2812 1.1797-6.5312 1.1758-2.2539-0.007812-4.4297-0.41016-6.5273-1.2109l-0.32031 0.57422c-0.23438 0.039063-0.4375 0.13672-0.61328 0.29688-0.48437 0.78906-0.84766 1.6289-1.0938 2.5195-0.11328 0.4375-0.24609 0.86719-0.41016 1.2852-0.042968 0.10547-0.12109 0.25-0.17188 0.35938l-0.003906 0.003906c-0.066406 0.1875-0.17188 0.35547-0.30859 0.49609-0.14062 0.14453-0.30078 0.25781-0.48828 0.33203-0.18359 0.078125-0.37891 0.11328-0.57812 0.10547-0.19922-0.003907-0.39062-0.050781-0.57422-0.13281-0.17969-0.085937-0.33594-0.20312-0.46875-0.35547-0.12891-0.15234-0.22266-0.32422-0.28125-0.51172-0.058594-0.19141-0.074218-0.38672-0.050781-0.58203 0.027344-0.19922 0.089844-0.38281 0.19531-0.55469 0.050781-0.10938 0.125-0.26953 0.17969-0.375 0.23047-0.39062 0.48438-0.76172 0.75781-1.1211 0.50391-0.72266 0.92969-1.4805 1.2812-2.2852 0.039062-0.27734-0.003907-0.53906-0.125-0.79297l0.25781-0.60938c-1.9375-1.1328-3.6094-2.5703-5.0156-4.3125-1.4023-1.7383-2.4531-3.668-3.1445-5.7891l-0.61719 0.10156c-0.24609-0.17188-0.51562-0.26562-0.81641-0.28516-0.84375 0.16406-1.668 0.40234-2.4648 0.72266-0.41406 0.18359-0.83984 0.34375-1.2695 0.48047-0.10156 0.027344-0.25 0.054687-0.36719 0.082031-0.007813 0.003906-0.019532 0.007813-0.027344 0.007813-0.007813 0.003906-0.015625 0.003906-0.023438 0.003906-0.1875 0.0625-0.38281 0.082031-0.58203 0.0625s-0.38672-0.078125-0.55859-0.17578c-0.17578-0.097656-0.32031-0.22656-0.44141-0.38281-0.11719-0.16016-0.19922-0.33594-0.24609-0.53125-0.042969-0.19141-0.046875-0.38672-0.007812-0.57812 0.039062-0.19531 0.11328-0.375 0.22656-0.53906 0.11719-0.16016 0.25781-0.29297 0.42969-0.39844 0.17188-0.10156 0.35547-0.16406 0.55469-0.19141l0.019532-0.003906 0.011718-0.003906c0.11719-0.027344 0.26953-0.066407 0.37891-0.085938 0.44922-0.0625 0.90234-0.10156 1.3555-0.10938 0.85938-0.054687 1.707-0.19531 2.5391-0.41406 0.25-0.15625 0.44922-0.35937 0.60938-0.60937l0.58984-0.17188c-0.32031-2.2109-0.23437-4.4102 0.26563-6.5898 0.49609-2.1836 1.3711-4.2031 2.625-6.0664l-0.45703-0.39844c-0.015625-0.29688-0.10938-0.56641-0.28125-0.8125-0.65625-0.55469-1.3555-1.043-2.1055-1.4648-0.40625-0.20312-0.79688-0.42969-1.1758-0.67969-0.085937-0.0625-0.19922-0.16016-0.29297-0.23438l-0.019532-0.015625c-0.16016-0.11328-0.29297-0.25391-0.39844-0.42188s-0.17188-0.34766-0.20703-0.53906c-0.03125-0.19531-0.027344-0.38672 0.019531-0.57812 0.042969-0.19141 0.125-0.36719 0.23828-0.52734 0.29297-0.35547 0.66797-0.51953 1.1289-0.49609 0.36719 0.015625 0.69531 0.14062 0.98438 0.37109 0.097657 0.074218 0.23047 0.17187 0.3125 0.24609 0.33203 0.30859 0.64062 0.63672 0.93359 0.98047 0.57812 0.63281 1.2148 1.2031 1.9102 1.7109 0.26562 0.14062 0.54688 0.16406 0.83984 0.078124 0.16797 0.12109 0.33594 0.24219 0.50781 0.35938 1.2461-1.3086 2.6562-2.4102 4.2305-3.3008 1.5742-0.89453 3.25-1.5391 5.0195-1.9336 0.84375-0.19141 1.6953-0.32031 2.5586-0.39062l0.03125-0.59375c0.22656-0.19922 0.37891-0.44141 0.46094-0.72656 0.03125-0.85156-0.023438-1.7031-0.15625-2.543-0.089844-0.44141-0.15625-0.88672-0.19531-1.3359-0.003906-0.10156 0.003906-0.24219 0.003906-0.35938 0-0.011719-0.003906-0.027344-0.003906-0.039063-0.019531-0.19922 0-0.39062 0.0625-0.58203 0.0625-0.1875 0.16406-0.35938 0.29688-0.50391 0.13672-0.14844 0.29297-0.26562 0.48047-0.34375 0.18359-0.082032 0.375-0.12109 0.57422-0.12109 0.20312-0.003906 0.39453 0.039062 0.57812 0.12109 0.18359 0.078125 0.34375 0.19141 0.47656 0.33984 0.13672 0.14844 0.23438 0.31641 0.29688 0.50781 0.0625 0.1875 0.085938 0.38281 0.066407 0.58203 0 0.12109 0.007812 0.28516 0.003906 0.39844-0.039063 0.44922-0.10547 0.89062-0.19531 1.332-0.13672 0.84375-0.19141 1.6914-0.16016 2.5469 0.058594 0.29688 0.21094 0.52734 0.46094 0.69922 0.003907 0.10156 0.023438 0.44141 0.035157 0.62891 2.2383 0.19922 4.3672 0.78516 6.3906 1.7539 2.0195 0.96875 3.8086 2.2617 5.3555 3.8711l0.53906-0.37891c0.29688 0.050781 0.58203 0.019531 0.85938-0.09375 0.69141-0.50781 1.3281-1.0781 1.9062-1.7109 0.29297-0.34375 0.60547-0.67188 0.9375-0.98047 0.085938-0.074219 0.21484-0.17188 0.3125-0.25 0.14453-0.14063 0.30859-0.24609 0.5-0.31641 0.1875-0.066406 0.38281-0.097656 0.58203-0.085937 0.20312 0.011718 0.39453 0.0625 0.57422 0.15625 0.17578 0.09375 0.32812 0.21484 0.45312 0.37109 0.12891 0.15625 0.21484 0.33203 0.26562 0.52734 0.050781 0.19141 0.058594 0.38672 0.027344 0.58594-0.035156 0.19531-0.10547 0.37891-0.21875 0.54688-0.10938 0.16406-0.25 0.30078-0.42188 0.41016-0.09375 0.074219-0.21875 0.18359-0.30859 0.25-0.37891 0.25-0.77344 0.47656-1.1758 0.67969-0.75 0.42187-1.4531 0.91016-2.1055 1.4648-0.19922 0.23047-0.28516 0.49609-0.26562 0.79688-0.078125 0.070313-0.35547 0.3125-0.50391 0.44531 1.2539 1.8555 2.1367 3.8672 2.6445 6.043 0.50781 2.1758 0.60938 4.3711 0.30469 6.582l0.57031 0.16797c0.14844 0.25781 0.35156 0.46094 0.61328 0.60547 0.83203 0.22266 1.6758 0.35938 2.5352 0.41406 0.45703 0.011719 0.90625 0.046875 1.3594 0.10938 0.11719 0.019531 0.28906 0.070312 0.41016 0.097656 0.19922 0.023438 0.38281 0.089844 0.55469 0.19141 0.17188 0.10547 0.3125 0.23828 0.42578 0.39844 0.11328 0.16406 0.19141 0.34375 0.23047 0.53516 0.035157 0.19531 0.035157 0.39062-0.011719 0.58203-0.042968 0.19531-0.125 0.37109-0.24609 0.53125-0.11719 0.15625-0.26562 0.28516-0.4375 0.38281-0.17578 0.097656-0.36328 0.15625-0.5625 0.17578s-0.39062-0.003906-0.58203-0.066406h-0.019532c-0.011718-0.003907-0.019531-0.007813-0.027344-0.011719-0.11719-0.023438-0.26562-0.050781-0.36719-0.074219-0.43359-0.14062-0.85547-0.30078-1.2695-0.48828-0.80078-0.32031-1.6211-0.55859-2.4688-0.71875-0.30469-0.011719-0.56641 0.085938-0.79297 0.29297-0.19922-0.039063-0.40234-0.074219-0.60547-0.10547-0.68359 2.1328-1.7266 4.0781-3.1328 5.8281-1.4062 1.7539-3.082 3.2031-5.0234 4.3438z" fill="#326ce5"/>
-<path d="m1397.7 884.63-6.375-27.449c-0.17188-0.71875-0.49219-1.3633-0.96094-1.9414-0.46484-0.57422-1.0352-1.0273-1.707-1.3477l-25.797-12.211c-0.67969-0.32031-1.3945-0.48047-2.1445-0.48047s-1.4609 0.16016-2.1406 0.48047l-25.797 12.219c-0.67187 0.32031-1.2383 0.76953-1.707 1.3477-0.46875 0.57422-0.78906 1.2227-0.96094 1.9414l-6.3633 27.445c-0.14453 0.64063-0.16016 1.2812-0.042968 1.9297 0.11719 0.64453 0.35156 1.2422 0.71094 1.7891 0.089844 0.13281 0.17969 0.26172 0.28125 0.38672l17.855 22.012c0.47266 0.57031 1.0469 1.0195 1.7227 1.3359 0.67578 0.32031 1.3867 0.48047 2.1328 0.48828l28.633-0.007813c0.75-0.003906 1.4609-0.16797 2.1328-0.48438 0.67578-0.32031 1.25-0.76562 1.7266-1.3398l17.848-22.008c0.46094-0.57812 0.77734-1.2266 0.94531-1.9453s0.16797-1.4414 0.007813-2.1602zm-3.0859 1.2852c-0.042969 0.19141-0.097656 0.38281-0.16406 0.57031-0.16797 0.46094-0.40234 0.87891-0.70703 1.2578l-15.863 19.562-0.49609 0.61328c-0.3125 0.37891-0.67188 0.69531-1.0898 0.95312-0.15625 0.10156-0.32422 0.19141-0.49219 0.27344-0.11719 0.054688-0.23047 0.10156-0.35156 0.14453-0.15234 0.054688-0.30469 0.10547-0.46484 0.14844-0.21875 0.058594-0.44141 0.097656-0.66406 0.125-0.16016 0.015625-0.31641 0.027344-0.47266 0.027344l-25.992 0.003906h-0.25391c-0.39062 0-0.77344-0.054688-1.1484-0.15625-0.46094-0.12109-0.89062-0.30469-1.293-0.55859-0.32031-0.19922-0.60547-0.43359-0.86328-0.70703-0.078125-0.082031-0.16016-0.16016-0.23047-0.25l-16.367-20.172c-0.089844-0.11328-0.17578-0.23047-0.25391-0.35547-0.1875-0.28516-0.33594-0.58594-0.45312-0.90625-0.066406-0.18359-0.12109-0.375-0.16406-0.57031-0.14453-0.64453-0.14453-1.2891 0.003906-1.9297l5.832-25.16c0.16016-0.65625 0.45312-1.25 0.87891-1.7773 0.42969-0.52734 0.95312-0.94141 1.5664-1.2344l23.645-11.199c0.62109-0.29297 1.2734-0.44141 1.9609-0.44141s1.3438 0.14844 1.9648 0.44141l23.648 11.191c0.61328 0.29688 1.1367 0.70703 1.5625 1.2383 0.42969 0.52734 0.72266 1.1211 0.88281 1.7773l5.8398 25.16c0.14844 0.64062 0.14844 1.2852 0 1.9297z" fill="#fff"/>
-<path d="m1384.4 881.97c-0.12109-0.027344-0.29297-0.074219-0.41016-0.097656-0.45313-0.0625-0.90234-0.097656-1.3594-0.10938-0.85937-0.054688-1.7031-0.19141-2.5352-0.41016-0.26172-0.14844-0.46484-0.35156-0.61328-0.60937l-0.57031-0.16797c0.30469-2.2109 0.20313-4.4062-0.30469-6.582-0.50781-2.1719-1.3867-4.1875-2.6445-6.043 0.14844-0.13281 0.42578-0.375 0.50391-0.44531-0.019531-0.30078 0.066406-0.56641 0.26562-0.79688 0.65234-0.55469 1.3555-1.043 2.1055-1.4648 0.40234-0.20313 0.79688-0.42969 1.1758-0.67969 0.089844-0.066406 0.21484-0.17578 0.30859-0.25 0.17188-0.10547 0.3125-0.24609 0.42188-0.41016 0.11328-0.16797 0.18359-0.34766 0.21875-0.54688 0.03125-0.19531 0.023437-0.39062-0.027344-0.58594-0.050781-0.19141-0.13672-0.36719-0.26172-0.52344-0.12891-0.15625-0.28125-0.28125-0.45703-0.375-0.17969-0.089844-0.37109-0.14453-0.57031-0.15625-0.20313-0.011719-0.39844 0.019531-0.58594 0.089844-0.1875 0.070312-0.35547 0.17187-0.5 0.3125-0.097656 0.078124-0.22656 0.17578-0.3125 0.25-0.33203 0.30859-0.64453 0.63672-0.9375 0.98047-0.57812 0.63281-1.2148 1.2031-1.9062 1.7109-0.27734 0.11328-0.5625 0.14453-0.85938 0.09375l-0.53906 0.37891c-1.5469-1.6094-3.3359-2.9023-5.3555-3.8711-2.0234-0.96875-4.1523-1.5547-6.3906-1.7539-0.011719-0.1875-0.03125-0.52344-0.035157-0.625-0.25-0.17188-0.40234-0.40625-0.46094-0.70312-0.03125-0.85547 0.023437-1.7031 0.16016-2.5469 0.089844-0.4375 0.15625-0.88281 0.19141-1.332 0.007812-0.11328 0-0.27734 0-0.39844 0.019531-0.19922-0.003907-0.39453-0.066407-0.58203-0.0625-0.19141-0.16016-0.35938-0.29688-0.50781-0.13281-0.14453-0.29297-0.26172-0.47656-0.33984-0.18359-0.082032-0.375-0.12109-0.57812-0.12109-0.19922 0-0.39062 0.039062-0.57422 0.12109-0.1875 0.078125-0.34375 0.19531-0.48047 0.34375-0.13281 0.14844-0.23438 0.31641-0.29688 0.50391-0.0625 0.19141-0.082031 0.38281-0.0625 0.58203 0 0.011719 0.003906 0.027344 0.003906 0.039063 0 0.11719-0.007812 0.25781-0.003906 0.35938 0.039063 0.44922 0.10547 0.89453 0.19531 1.3359 0.13281 0.84375 0.1875 1.6914 0.15625 2.543-0.082031 0.28516-0.23438 0.52734-0.46094 0.72656l-0.03125 0.59375c-0.86328 0.070312-1.7148 0.19922-2.5586 0.39062-1.7695 0.39453-3.4453 1.0391-5.0195 1.9336-1.5742 0.89062-2.9844 1.9922-4.2266 3.3008-0.17188-0.11719-0.34375-0.23438-0.51172-0.35938-0.29297 0.085938-0.57422 0.0625-0.83984-0.078124-0.69531-0.50781-1.332-1.0781-1.9102-1.7109-0.29297-0.34375-0.60156-0.67188-0.92969-0.98047-0.085938-0.074219-0.21875-0.17188-0.31641-0.25-0.28906-0.23047-0.61719-0.35156-0.98438-0.36719-0.46094-0.023438-0.83984 0.14062-1.1289 0.49609-0.11328 0.16016-0.19531 0.33594-0.23828 0.52734-0.046875 0.19141-0.050781 0.38281-0.019531 0.57812 0.035156 0.19141 0.10156 0.37109 0.20703 0.53906s0.23828 0.30859 0.39844 0.42188l0.023438 0.015625c0.089844 0.074219 0.20312 0.17188 0.28906 0.23438 0.37891 0.25 0.76953 0.47656 1.1758 0.67969 0.75 0.42188 1.4492 0.91016 2.1055 1.4648 0.17188 0.24609 0.26562 0.51562 0.28125 0.8125l0.45312 0.39844c-1.25 1.8633-2.125 3.8828-2.6211 6.0664-0.5 2.1797-0.58594 4.3789-0.26563 6.5938l-0.58984 0.16797c-0.16016 0.25-0.35938 0.45312-0.60938 0.60937-0.83203 0.21875-1.6797 0.35938-2.5391 0.41406-0.45312 0.011719-0.90625 0.046875-1.3555 0.10938-0.10937 0.019531-0.26172 0.058594-0.37891 0.085938l-0.011718 0.003906-0.019532 0.003906c-0.19922 0.027344-0.38281 0.089844-0.55469 0.19531-0.17188 0.10156-0.3125 0.23438-0.42578 0.39844-0.11719 0.16016-0.19141 0.33984-0.23047 0.53516-0.039063 0.19531-0.035157 0.38672 0.011719 0.58203 0.042968 0.19141 0.125 0.36719 0.24219 0.52734 0.12109 0.16016 0.26953 0.28906 0.44141 0.38281 0.17578 0.097656 0.35938 0.15625 0.55859 0.17578s0.39453 0 0.58594-0.0625l0.019532-0.003906c0.007812 0 0.019531-0.003907 0.027344-0.007813 0.11719-0.027344 0.26172-0.054687 0.36719-0.082031 0.42969-0.13672 0.85547-0.29688 1.2695-0.48047 0.79688-0.32031 1.6211-0.55859 2.4648-0.72266 0.30078 0.019531 0.57031 0.11328 0.81641 0.28516l0.61719-0.10156c0.69141 2.1211 1.7383 4.0508 3.1445 5.7891 1.4062 1.7422 3.0781 3.1797 5.0156 4.3125l-0.25781 0.60938c0.12109 0.25391 0.16406 0.51562 0.125 0.79297-0.35156 0.80078-0.77734 1.5625-1.2812 2.2852-0.27344 0.35547-0.52734 0.73047-0.75781 1.1211-0.054687 0.10547-0.12891 0.26562-0.17969 0.375-0.10547 0.17188-0.16797 0.35547-0.19141 0.55469-0.027343 0.19531-0.011719 0.39062 0.046875 0.57812 0.058594 0.19141 0.15234 0.36328 0.28516 0.51172 0.12891 0.15234 0.28516 0.26953 0.46875 0.35547 0.17969 0.085938 0.37109 0.12891 0.57031 0.13672 0.19922 0.003906 0.39453-0.03125 0.57812-0.10938 0.1875-0.074219 0.34766-0.18359 0.48828-0.32812 0.13672-0.14453 0.24219-0.30859 0.30859-0.49609l0.003906-0.003906c0.050781-0.11328 0.12891-0.25391 0.17188-0.35938 0.16406-0.41797 0.29688-0.84766 0.41016-1.2852 0.24609-0.89063 0.60938-1.7305 1.0938-2.5195 0.17578-0.16016 0.37891-0.25781 0.61328-0.29688l0.32031-0.57422c2.1016 0.80078 4.2734 1.2031 6.5273 1.2109 2.25 0.003906 4.4258-0.38672 6.5312-1.1758 0.089844 0.15625 0.25781 0.46094 0.30078 0.53906 0.30078 0.046875 0.54297 0.19141 0.72266 0.43359 0.40234 0.75391 0.72656 1.543 0.97266 2.3594 0.11328 0.4375 0.25 0.86328 0.41016 1.2852 0.046875 0.10547 0.12109 0.25 0.17578 0.35938 0.066407 0.1875 0.17188 0.35547 0.30859 0.49609 0.14062 0.14453 0.30078 0.25391 0.48828 0.33203 0.18359 0.074219 0.375 0.11328 0.57812 0.10547 0.19922-0.003906 0.39062-0.046875 0.57031-0.13281 0.18359-0.085937 0.33984-0.20312 0.46875-0.35547 0.13281-0.14844 0.22656-0.32031 0.28516-0.51172 0.058594-0.1875 0.074219-0.38281 0.050781-0.57812-0.023437-0.19922-0.089843-0.38281-0.19141-0.55469-0.054687-0.10937-0.12891-0.26953-0.18359-0.375-0.23047-0.39062-0.48438-0.76172-0.75781-1.1211-0.49219-0.69922-0.91016-1.4414-1.2578-2.2266-0.078125-0.28906-0.039062-0.56641 0.10938-0.82812-0.089843-0.18359-0.16797-0.37109-0.23438-0.56641 1.9414-1.1406 3.6172-2.5898 5.0234-4.3438 1.4062-1.75 2.4492-3.6953 3.1328-5.8281 0.18359 0.027344 0.50391 0.082031 0.60547 0.10547 0.22656-0.20703 0.48828-0.30078 0.79297-0.29297 0.84766 0.16016 1.668 0.39844 2.4688 0.71875 0.41406 0.1875 0.83594 0.34766 1.2695 0.48828 0.10156 0.023438 0.24609 0.050781 0.36719 0.074219 0.007813 0.003906 0.015626 0.007812 0.027344 0.011719l0.019532 0.003906c0.1875 0.058594 0.38281 0.082031 0.58203 0.0625s0.38672-0.078125 0.55859-0.17578c0.17578-0.097656 0.32031-0.22656 0.44141-0.38672 0.11719-0.15625 0.19922-0.33203 0.24609-0.52734 0.042969-0.19141 0.046876-0.38672 0.007813-0.57812-0.039063-0.19531-0.11328-0.375-0.22656-0.53906-0.11328-0.16016-0.25781-0.29297-0.42578-0.39844-0.17188-0.10156-0.35547-0.16797-0.55469-0.19141zm-13.445-14.293-6.0508 4.2539-0.019531-0.011719c-0.40234 0.28906-0.82812 0.32812-1.2773 0.11719-0.44922-0.21484-0.68359-0.56641-0.70703-1.0625h-0.007813l-0.41797-7.3477c1.5977 0.19531 3.125 0.64062 4.5742 1.3359 1.4531 0.69141 2.7539 1.5977 3.9062 2.7148zm-11.395 8.0547h2.2734l1.418 1.7539-0.50781 2.1875-2.043 0.97656-2.0508-0.97656-0.50781-2.1914zm-2.1406-11.852c0.49609-0.10938 1-0.19531 1.5078-0.25391l-0.42188 7.3594-0.03125 0.011719c-0.019531 0.49219-0.25391 0.84766-0.70312 1.0625-0.44531 0.21484-0.87109 0.17578-1.2734-0.11328l-0.011719 0.007813-6.0898-4.2812c1.9766-1.9258 4.3164-3.1875 7.0234-3.793zm-9.2305 6.543 5.5586 4.9297-0.007812 0.03125c0.37891 0.32422 0.50781 0.72656 0.39844 1.207-0.10938 0.48047-0.40625 0.78516-0.88672 0.91797l-0.007812 0.023438-7.1211 2.0391c-0.17969-1.5977-0.089844-3.1797 0.26172-4.7461 0.35547-1.5664 0.95703-3.0312 1.8047-4.4023zm7.4414 13.094-2.832 6.7812c-1.3555-0.86328-2.5391-1.918-3.5469-3.168-1.0078-1.25-1.7852-2.625-2.332-4.1289l7.3047-1.2305 0.011719 0.015625c0.082031-0.015625 0.16406-0.023437 0.24609-0.023437 0.20703 0.003906 0.40234 0.054687 0.58594 0.15625 0.17969 0.097656 0.32813 0.23438 0.44141 0.41016 0.11328 0.17188 0.17969 0.35938 0.19531 0.56641 0.019531 0.20703-0.011719 0.40234-0.09375 0.59375zm8.3555 8.7188c-2.6992 0.61328-5.3633 0.47656-7.9844-0.40625l3.5898-6.4414h0.007812c0.23438-0.43359 0.60156-0.64844 1.0977-0.65234 0.49609 0 0.86328 0.21875 1.1016 0.65234h0.027344l3.6016 6.4492c-0.46875 0.15625-0.94922 0.28906-1.4414 0.39844zm4.6406-1.9102-2.8594-6.8516 0.007813-0.011718c-0.0625-0.14844-0.097656-0.30078-0.10156-0.46094 0-0.15625 0.023438-0.3125 0.082031-0.46094 0.054688-0.14844 0.13672-0.28516 0.24609-0.40234 0.10938-0.11719 0.23438-0.21094 0.37891-0.28125 0.15234-0.070313 0.30859-0.11328 0.47656-0.12109 0.097656-0.003906 0.19531 0.003906 0.28906 0.019531l0.011718-0.015625 7.3711 1.2344c-0.54688 1.5156-1.3242 2.9062-2.332 4.1641-1.0117 1.2578-2.2031 2.3203-3.5703 3.1875zm6.6758-10.781-7.1602-2.043-0.007812-0.03125c-0.48047-0.12891-0.77344-0.4375-0.88672-0.91797-0.10938-0.48047 0.023438-0.88281 0.39844-1.207l-0.003907-0.011719 5.5273-4.9062c0.84766 1.3633 1.4531 2.8281 1.8164 4.3867 0.36328 1.5625 0.46875 3.1367 0.31641 4.7344z" fill="#fff"/>
-<path d="m134.78 1059.9c19.77 0.003906 35.996 15.922 35.973 35.289-0.027344 19.664-16.188 35.363-36.387 35.348-19.746-0.011718-35.715-15.949-35.699-35.633 0.011719-19.246 16.273-35.008 36.113-35.004zm-10.93 12.395c0.45312 2.2031 0.015625 4.2578-0.65625 6.2812-0.46484 1.3984-1.1055 2.7461-1.4883 4.168-0.63281 2.3359-1.3477 4.6875-1.6094 7.0781-0.37891 3.4375 0.98828 6.4688 3.332 9.4805l-10.762-2.2383c0.019532 0.33594 0 0.46094 0.035157 0.57031 1.0195 2.9609 2.8164 5.4531 4.8281 7.8047 0.21094 0.24609 0.69531 0.375 1.0547 0.375 10.73 0.019531 21.461 0.019531 32.188 0.003906 0.33203 0 0.77734-0.0625 0.98047-0.27344 2.3008-2.3867 4.0586-5.1055 5.1602-8.5352l-11.395 2.2031c0.75391-1.4531 1.6094-2.7305 2.1055-4.1367 1.6836-4.8086 0.98438-9.457-1.4336-13.84-1.9453-3.5195-3.7344-7.0234-2.7656-11.262-2.0508 2-2.8398 4.5508-3.3398 7.1758-0.49219 2.5859-0.78516 5.207-1.1641 7.832-0.054688-0.078125-0.125-0.13672-0.13672-0.20703-0.042969-0.27344-0.085938-0.55078-0.097656-0.82813-0.23438-4.2969-1.082-8.4375-2.875-12.395-1.0586-2.3281-2.2227-4.707-1.1328-7.4844-0.73828 0.38281-1.4023 0.76562-1.8789 1.3086-1.4258 1.625-2.0156 3.5781-2.1641 5.7148-0.13281 1.8242-0.30859 3.6602-0.65234 5.4531-0.35938 1.8867-0.92969 3.7344-2.2109 5.4688-0.51953-3.7031-0.57812-7.3672-3.9219-9.7188zm27.664 36.766h-33.648v5.7734h33.648zm-26.977 8.7578c-0.027344 4.8086 4.9297 8.3906 11.059 8.1289 5.0781-0.21484 9.5703-4.1602 9.1836-8.1289z" fill="#e75225"/>
-<g clip-path="url(#w)">
-<g clip-path="url(#t)">
-<path d="m240.35 1057.1v79.059h72.816v-79.059z" fill="url(#ay)"/>
-</g>
-</g>
-<g fill="#303b54">
-<g transform="translate(82.521 103.74)">
-<path d="m5.2188-14.625v4.375h5.875v2.7812h-5.875v4.625h6.625v2.8438h-10.125v-17.469h10.125v2.8438z"/>
-</g>
-<g transform="translate(95.819 103.74)">
-<path d="m5.1719-17.453v10.797c0 1.1875 0.30469 2.0938 0.92188 2.7188 0.625 0.625 1.4922 0.9375 2.6094 0.9375 1.1328 0 2.0078-0.3125 2.625-0.9375 0.61328-0.625 0.92188-1.5312 0.92188-2.7188v-10.797h3.5312v10.781c0 1.4805-0.32422 2.7344-0.96875 3.7656-0.64844 1.0234-1.5078 1.793-2.5781 2.3125-1.0742 0.51172-2.2656 0.76562-3.5781 0.76562-1.3047 0-2.4844-0.25391-3.5469-0.76562-1.0547-0.51953-1.8906-1.2891-2.5156-2.3125-0.61719-1.0312-0.92188-2.2852-0.92188-3.7656v-10.781z"/>
-</g>
-<g transform="translate(113.24 103.74)"/>
-<g transform="translate(119.19 103.74)">
-<path d="m10.719 0-3.8438-6.7969h-1.6562v6.7969h-3.5v-17.453h6.5625c1.3438 0 2.4883 0.24219 3.4375 0.71875 0.95703 0.46875 1.6719 1.1094 2.1406 1.9219 0.47656 0.8125 0.71875 1.7188 0.71875 2.7188 0 1.1484-0.33594 2.1836-1 3.1094-0.66797 0.92969-1.6641 1.5625-2.9844 1.9062l4.1875 7.0781zm-5.5-9.4219h2.9375c0.94531 0 1.6484-0.22656 2.1094-0.6875 0.46875-0.45703 0.70312-1.0977 0.70312-1.9219 0-0.78906-0.23438-1.4062-0.70312-1.8438-0.46094-0.44531-1.1641-0.67188-2.1094-0.67188h-2.9375z"/>
-</g>
-<g transform="translate(135.21 103.74)">
-<path d="m14.594-7.2188c0 0.5-0.03125 0.94922-0.09375 1.3438h-10.125c0.082031 1 0.42969 1.7891 1.0469 2.3594 0.61328 0.5625 1.375 0.84375 2.2812 0.84375 1.3008 0 2.2227-0.55469 2.7656-1.6719h3.7812c-0.39844 1.3359-1.1641 2.4297-2.2969 3.2812-1.1367 0.85547-2.5273 1.2812-4.1719 1.2812-1.3359 0-2.5312-0.28906-3.5938-0.875-1.0625-0.59375-1.8906-1.4297-2.4844-2.5156-0.58594-1.082-0.875-2.332-0.875-3.75 0-1.4375 0.28906-2.6953 0.875-3.7812 0.58203-1.082 1.3945-1.9141 2.4375-2.5 1.0508-0.58203 2.2656-0.875 3.6406-0.875 1.3125 0 2.4883 0.28906 3.5312 0.85938 1.0391 0.5625 1.8477 1.3672 2.4219 2.4062 0.57031 1.043 0.85938 2.2422 0.85938 3.5938zm-3.625-1c-0.011719-0.90625-0.33594-1.6289-0.96875-2.1719-0.63672-0.53906-1.4141-0.8125-2.3281-0.8125-0.86719 0-1.5938 0.26562-2.1875 0.79688-0.59375 0.52344-0.95312 1.25-1.0781 2.1875z"/>
-</g>
-<g transform="translate(150.64 103.74)">
-<path d="m7.1562-14.078c1.0312 0 1.9375 0.21094 2.7188 0.625 0.78125 0.40625 1.3945 0.93359 1.8438 1.5781v-1.9688h3.5312v13.938c0 1.2891-0.26172 2.4375-0.78125 3.4375-0.51172 1.0078-1.2891 1.8125-2.3281 2.4062-1.0312 0.59375-2.2773 0.89062-3.7344 0.89062-1.9688 0-3.5859-0.46094-4.8438-1.375-1.2617-0.91797-1.9766-2.168-2.1406-3.75h3.4844c0.17578 0.63281 0.56641 1.1406 1.1719 1.5156 0.61328 0.375 1.3516 0.5625 2.2188 0.5625 1.0195 0 1.8438-0.30859 2.4688-0.92188 0.63281-0.60547 0.95312-1.5273 0.95312-2.7656v-2.1406c-0.44922 0.64844-1.0703 1.1875-1.8594 1.625-0.79297 0.42578-1.6953 0.64062-2.7031 0.64062-1.168 0-2.2344-0.29688-3.2031-0.89062-0.96875-0.60156-1.7344-1.4453-2.2969-2.5312-0.55469-1.0938-0.82812-2.3477-0.82812-3.7656 0-1.4062 0.27344-2.6484 0.82812-3.7344 0.5625-1.082 1.3203-1.9141 2.2812-2.5 0.95703-0.58203 2.0312-0.875 3.2188-0.875zm4.5625 7.1562c0-0.85156-0.16797-1.582-0.5-2.1875-0.33594-0.61328-0.78125-1.082-1.3438-1.4062-0.5625-0.32031-1.1719-0.48438-1.8281-0.48438-0.64844 0-1.2461 0.16406-1.7969 0.48438-0.55469 0.3125-1 0.77734-1.3438 1.3906-0.33594 0.60547-0.5 1.3242-0.5 2.1562 0 0.83594 0.16406 1.5625 0.5 2.1875 0.34375 0.625 0.78906 1.1055 1.3438 1.4375 0.5625 0.33594 1.1602 0.5 1.7969 0.5 0.65625 0 1.2656-0.16016 1.8281-0.48438 0.5625-0.33203 1.0078-0.80078 1.3438-1.4062 0.33203-0.61328 0.5-1.3438 0.5-2.1875z"/>
-</g>
-<g transform="translate(167.58 103.74)">
-<path d="m14.797-13.844v13.844h-3.5156v-1.75c-0.46094 0.60547-1.0547 1.0781-1.7812 1.4219-0.71875 0.33203-1.5 0.5-2.3438 0.5-1.0859 0-2.043-0.22656-2.875-0.6875-0.83594-0.45703-1.4922-1.1289-1.9688-2.0156-0.48047-0.89453-0.71875-1.957-0.71875-3.1875v-8.125h3.5v7.625c0 1.0938 0.27344 1.9375 0.82812 2.5312 0.55078 0.59375 1.3008 0.89062 2.25 0.89062 0.96875 0 1.7266-0.29688 2.2812-0.89062 0.55078-0.59375 0.82812-1.4375 0.82812-2.5312v-7.625z"/>
-</g>
-<g transform="translate(184.11 103.74)">
-<path d="m5.2188-18.5v18.5h-3.5v-18.5z"/>
-</g>
-<g transform="translate(191.05 103.74)">
-<path d="m0.82812-6.9688c0-1.4062 0.27344-2.6484 0.82812-3.7344 0.5625-1.082 1.3203-1.9141 2.2812-2.5 0.95703-0.58203 2.0312-0.875 3.2188-0.875 1.0312 0 1.9297 0.21094 2.7031 0.625 0.78125 0.41797 1.3984 0.94531 1.8594 1.5781v-1.9688h3.5312v13.844h-3.5312v-2.0312c-0.44922 0.65625-1.0703 1.1992-1.8594 1.625-0.79297 0.41406-1.7031 0.625-2.7344 0.625-1.168 0-2.2305-0.29688-3.1875-0.89062-0.96094-0.60156-1.7188-1.4453-2.2812-2.5312-0.55469-1.0938-0.82812-2.3477-0.82812-3.7656zm10.891 0.046875c0-0.85156-0.16797-1.582-0.5-2.1875-0.33594-0.61328-0.78125-1.082-1.3438-1.4062-0.5625-0.32031-1.1719-0.48438-1.8281-0.48438-0.64844 0-1.2461 0.16406-1.7969 0.48438-0.55469 0.3125-1 0.77734-1.3438 1.3906-0.33594 0.60547-0.5 1.3242-0.5 2.1562 0 0.83594 0.16406 1.5625 0.5 2.1875 0.34375 0.625 0.78906 1.1055 1.3438 1.4375 0.5625 0.33594 1.1602 0.5 1.7969 0.5 0.65625 0 1.2656-0.16016 1.8281-0.48438 0.5625-0.33203 1.0078-0.80078 1.3438-1.4062 0.33203-0.61328 0.5-1.3438 0.5-2.1875z"/>
-</g>
-<g transform="translate(208 103.74)">
-<path d="m5.7969-10.969v6.6875c0 0.46875 0.10938 0.80859 0.32812 1.0156 0.22656 0.21094 0.61328 0.3125 1.1562 0.3125h1.625v2.9531h-2.2031c-2.9492 0-4.4219-1.4297-4.4219-4.2969v-6.6719h-1.6562v-2.875h1.6562v-3.4375h3.5156v3.4375h3.1094v2.875z"/>
-</g>
-<g transform="translate(217.7 103.74)">
-<path d="m3.5-15.5c-0.61719 0-1.1328-0.19141-1.5469-0.57812-0.40625-0.39453-0.60938-0.88281-0.60938-1.4688 0-0.58203 0.20312-1.0664 0.60938-1.4531 0.41406-0.39453 0.92969-0.59375 1.5469-0.59375 0.61328 0 1.125 0.19922 1.5312 0.59375 0.41406 0.38672 0.625 0.87109 0.625 1.4531 0 0.58594-0.21094 1.0742-0.625 1.4688-0.40625 0.38672-0.91797 0.57812-1.5312 0.57812zm1.7188 1.6562v13.844h-3.5v-13.844z"/>
-</g>
-<g transform="translate(224.65 103.74)">
-<path d="m7.875 0.21875c-1.3359 0-2.5391-0.28906-3.6094-0.875-1.0625-0.59375-1.9023-1.4297-2.5156-2.5156-0.60547-1.082-0.90625-2.332-0.90625-3.75 0-1.4141 0.3125-2.6641 0.9375-3.75 0.625-1.082 1.4766-1.9219 2.5625-2.5156 1.082-0.59375 2.2891-0.89062 3.625-0.89062 1.332 0 2.5391 0.29688 3.625 0.89062 1.082 0.59375 1.9375 1.4336 2.5625 2.5156 0.625 1.0859 0.9375 2.3359 0.9375 3.75 0 1.418-0.32422 2.668-0.96875 3.75-0.63672 1.0859-1.5 1.9219-2.5938 2.5156-1.0859 0.58594-2.3047 0.875-3.6562 0.875zm0-3.0469c0.63281 0 1.2266-0.14844 1.7812-0.45312 0.5625-0.3125 1.0078-0.77344 1.3438-1.3906 0.33203-0.61328 0.5-1.3633 0.5-2.25 0-1.3203-0.35156-2.3359-1.0469-3.0469-0.6875-0.70703-1.5312-1.0625-2.5312-1.0625s-1.8398 0.35547-2.5156 1.0625c-0.66797 0.71094-1 1.7266-1 3.0469 0 1.3125 0.32812 2.3242 0.98438 3.0312 0.65625 0.71094 1.4844 1.0625 2.4844 1.0625z"/>
-</g>
-<g transform="translate(240.6 103.74)">
-<path d="m9.4062-14.047c1.6445 0 2.9727 0.52344 3.9844 1.5625 1.0195 1.043 1.5312 2.4961 1.5312 4.3594v8.125h-3.5v-7.6562c0-1.0938-0.27734-1.9375-0.82812-2.5312-0.54297-0.59375-1.293-0.89062-2.25-0.89062-0.96094 0-1.7188 0.29688-2.2812 0.89062s-0.84375 1.4375-0.84375 2.5312v7.6562h-3.5v-13.844h3.5v1.7188c0.46875-0.60156 1.0625-1.0703 1.7812-1.4062 0.72656-0.34375 1.5312-0.51562 2.4062-0.51562z"/>
-</g>
-<g transform="translate(257.12 103.74)">
-<path d="m7.0312 0.21875c-1.1367 0-2.1562-0.20312-3.0625-0.60938-0.89844-0.40625-1.6094-0.95703-2.1406-1.6562-0.52344-0.69531-0.80859-1.4727-0.85938-2.3281h3.5312c0.0625 0.53125 0.32031 0.97656 0.78125 1.3281 0.45703 0.34375 1.0312 0.51562 1.7188 0.51562 0.66406 0 1.1875-0.12891 1.5625-0.39062 0.375-0.26953 0.5625-0.61328 0.5625-1.0312 0-0.44531-0.23047-0.78125-0.6875-1-0.46094-0.22656-1.1875-0.47656-2.1875-0.75-1.0312-0.25-1.8828-0.50391-2.5469-0.76562-0.65625-0.26953-1.2266-0.67969-1.7031-1.2344-0.46875-0.55078-0.70312-1.2891-0.70312-2.2188 0-0.76953 0.21875-1.4688 0.65625-2.0938 0.44531-0.63281 1.082-1.1328 1.9062-1.5 0.82031-0.375 1.7969-0.5625 2.9219-0.5625 1.6445 0 2.957 0.41797 3.9375 1.25 0.98828 0.82422 1.5312 1.9336 1.625 3.3281h-3.3438c-0.054688-0.55078-0.28125-0.98828-0.6875-1.3125-0.40625-0.32031-0.95312-0.48438-1.6406-0.48438-0.63672 0-1.125 0.12109-1.4688 0.35938-0.33594 0.23047-0.5 0.55469-0.5 0.96875 0 0.46094 0.22656 0.8125 0.6875 1.0625 0.46875 0.24219 1.1953 0.48438 2.1875 0.73438 1 0.25 1.8203 0.51172 2.4688 0.78125 0.65625 0.26172 1.2188 0.67188 1.6875 1.2344 0.47656 0.55469 0.72266 1.2891 0.73438 2.2031 0 0.80469-0.21875 1.5234-0.65625 2.1562-0.4375 0.63672-1.0742 1.1328-1.9062 1.4844-0.82422 0.35156-1.7812 0.53125-2.875 0.53125z"/>
-</g>
-<g transform="translate(270.74 103.74)"/>
-<g transform="translate(276.69 103.74)">
-<path d="m0.82812-6.9688c0-1.4062 0.27344-2.6484 0.82812-3.7344 0.5625-1.082 1.3203-1.9141 2.2812-2.5 0.95703-0.58203 2.0312-0.875 3.2188-0.875 1.0312 0 1.9297 0.21094 2.7031 0.625 0.78125 0.41797 1.3984 0.94531 1.8594 1.5781v-1.9688h3.5312v13.844h-3.5312v-2.0312c-0.44922 0.65625-1.0703 1.1992-1.8594 1.625-0.79297 0.41406-1.7031 0.625-2.7344 0.625-1.168 0-2.2305-0.29688-3.1875-0.89062-0.96094-0.60156-1.7188-1.4453-2.2812-2.5312-0.55469-1.0938-0.82812-2.3477-0.82812-3.7656zm10.891 0.046875c0-0.85156-0.16797-1.582-0.5-2.1875-0.33594-0.61328-0.78125-1.082-1.3438-1.4062-0.5625-0.32031-1.1719-0.48438-1.8281-0.48438-0.64844 0-1.2461 0.16406-1.7969 0.48438-0.55469 0.3125-1 0.77734-1.3438 1.3906-0.33594 0.60547-0.5 1.3242-0.5 2.1562 0 0.83594 0.16406 1.5625 0.5 2.1875 0.34375 0.625 0.78906 1.1055 1.3438 1.4375 0.5625 0.33594 1.1602 0.5 1.7969 0.5 0.65625 0 1.2656-0.16016 1.8281-0.48438 0.5625-0.33203 1.0078-0.80078 1.3438-1.4062 0.33203-0.61328 0.5-1.3438 0.5-2.1875z"/>
-</g>
-<g transform="translate(293.64 103.74)">
-<path d="m9.4062-14.047c1.6445 0 2.9727 0.52344 3.9844 1.5625 1.0195 1.043 1.5312 2.4961 1.5312 4.3594v8.125h-3.5v-7.6562c0-1.0938-0.27734-1.9375-0.82812-2.5312-0.54297-0.59375-1.293-0.89062-2.25-0.89062-0.96094 0-1.7188 0.29688-2.2812 0.89062s-0.84375 1.4375-0.84375 2.5312v7.6562h-3.5v-13.844h3.5v1.7188c0.46875-0.60156 1.0625-1.0703 1.7812-1.4062 0.72656-0.34375 1.5312-0.51562 2.4062-0.51562z"/>
-</g>
-<g transform="translate(310.16 103.74)">
-<path d="m0.82812-6.9688c0-1.4062 0.27344-2.6484 0.82812-3.7344 0.5625-1.082 1.3281-1.9141 2.2969-2.5 0.96875-0.58203 2.0391-0.875 3.2188-0.875 0.90625 0 1.7656 0.19922 2.5781 0.59375 0.8125 0.38672 1.4609 0.90625 1.9531 1.5625v-6.5781h3.5469v18.5h-3.5469v-2.0469c-0.4375 0.67969-1.0469 1.2266-1.8281 1.6406-0.78125 0.41406-1.6875 0.625-2.7188 0.625-1.168 0-2.2344-0.29688-3.2031-0.89062-0.96875-0.60156-1.7344-1.4453-2.2969-2.5312-0.55469-1.0938-0.82812-2.3477-0.82812-3.7656zm10.891 0.046875c0-0.85156-0.16797-1.582-0.5-2.1875-0.33594-0.61328-0.78125-1.082-1.3438-1.4062-0.5625-0.32031-1.1719-0.48438-1.8281-0.48438-0.64844 0-1.2461 0.16406-1.7969 0.48438-0.55469 0.3125-1 0.77734-1.3438 1.3906-0.33594 0.60547-0.5 1.3242-0.5 2.1562 0 0.83594 0.16406 1.5625 0.5 2.1875 0.34375 0.625 0.78906 1.1055 1.3438 1.4375 0.5625 0.33594 1.1602 0.5 1.7969 0.5 0.65625 0 1.2656-0.16016 1.8281-0.48438 0.5625-0.33203 1.0078-0.80078 1.3438-1.4062 0.33203-0.61328 0.5-1.3438 0.5-2.1875z"/>
-</g>
-<g transform="translate(327.11 103.74)"/>
-<g transform="translate(333.06 103.74)">
-<path d="m7.8281-17.453c1.832 0 3.4414 0.35938 4.8281 1.0781 1.3945 0.71875 2.4727 1.7422 3.2344 3.0625 0.75781 1.3242 1.1406 2.8594 1.1406 4.6094s-0.38281 3.2812-1.1406 4.5938c-0.76172 1.3047-1.8398 2.3125-3.2344 3.0312-1.3867 0.71875-2.9961 1.0781-4.8281 1.0781h-6.1094v-17.453zm-0.125 14.484c1.832 0 3.25-0.5 4.25-1.5s1.5-2.4102 1.5-4.2344c0-1.8125-0.5-3.2266-1.5-4.25-1-1.0312-2.418-1.5469-4.25-1.5469h-2.4844v11.531z"/>
-</g>
-<g transform="translate(350.98 103.74)">
-<path d="m3.5-15.5c-0.61719 0-1.1328-0.19141-1.5469-0.57812-0.40625-0.39453-0.60938-0.88281-0.60938-1.4688 0-0.58203 0.20312-1.0664 0.60938-1.4531 0.41406-0.39453 0.92969-0.59375 1.5469-0.59375 0.61328 0 1.125 0.19922 1.5312 0.59375 0.41406 0.38672 0.625 0.87109 0.625 1.4531 0 0.58594-0.21094 1.0742-0.625 1.4688-0.40625 0.38672-0.91797 0.57812-1.5312 0.57812zm1.7188 1.6562v13.844h-3.5v-13.844z"/>
-</g>
-<g transform="translate(357.93 103.74)">
-<path d="m5.2188-11.703c0.45703-0.72656 1.0469-1.3008 1.7656-1.7188 0.72656-0.41406 1.5547-0.625 2.4844-0.625v3.6719h-0.92188c-1.0938 0-1.9219 0.26172-2.4844 0.78125-0.5625 0.51172-0.84375 1.4062-0.84375 2.6875v6.9062h-3.5v-13.844h3.5z"/>
-</g>
-<g transform="translate(368.03 103.74)">
-<path d="m14.594-7.2188c0 0.5-0.03125 0.94922-0.09375 1.3438h-10.125c0.082031 1 0.42969 1.7891 1.0469 2.3594 0.61328 0.5625 1.375 0.84375 2.2812 0.84375 1.3008 0 2.2227-0.55469 2.7656-1.6719h3.7812c-0.39844 1.3359-1.1641 2.4297-2.2969 3.2812-1.1367 0.85547-2.5273 1.2812-4.1719 1.2812-1.3359 0-2.5312-0.28906-3.5938-0.875-1.0625-0.59375-1.8906-1.4297-2.4844-2.5156-0.58594-1.082-0.875-2.332-0.875-3.75 0-1.4375 0.28906-2.6953 0.875-3.7812 0.58203-1.082 1.3945-1.9141 2.4375-2.5 1.0508-0.58203 2.2656-0.875 3.6406-0.875 1.3125 0 2.4883 0.28906 3.5312 0.85938 1.0391 0.5625 1.8477 1.3672 2.4219 2.4062 0.57031 1.043 0.85938 2.2422 0.85938 3.5938zm-3.625-1c-0.011719-0.90625-0.33594-1.6289-0.96875-2.1719-0.63672-0.53906-1.4141-0.8125-2.3281-0.8125-0.86719 0-1.5938 0.26562-2.1875 0.79688-0.59375 0.52344-0.95312 1.25-1.0781 2.1875z"/>
-</g>
-<g transform="translate(383.45 103.74)">
-<path d="m0.82812-6.9219c0-1.4375 0.28906-2.6914 0.875-3.7656 0.58203-1.0703 1.3906-1.9062 2.4219-2.5s2.2109-0.89062 3.5469-0.89062c1.7188 0 3.1406 0.43359 4.2656 1.2969 1.125 0.85547 1.8789 2.0586 2.2656 3.6094h-3.7812c-0.19922-0.60156-0.53906-1.0703-1.0156-1.4062-0.46875-0.34375-1.0547-0.51562-1.75-0.51562-1 0-1.793 0.36719-2.375 1.0938-0.58594 0.71875-0.875 1.7461-0.875 3.0781 0 1.3125 0.28906 2.3359 0.875 3.0625 0.58203 0.71875 1.375 1.0781 2.375 1.0781 1.4141 0 2.3359-0.62891 2.7656-1.8906h3.7812c-0.38672 1.5-1.1484 2.6953-2.2812 3.5781-1.1367 0.875-2.5547 1.3125-4.25 1.3125-1.3359 0-2.5156-0.28906-3.5469-0.875-1.0312-0.59375-1.8398-1.4258-2.4219-2.5-0.58594-1.082-0.875-2.3359-0.875-3.7656z"/>
-</g>
-<g transform="translate(398.5 103.74)">
-<path d="m5.7969-10.969v6.6875c0 0.46875 0.10938 0.80859 0.32812 1.0156 0.22656 0.21094 0.61328 0.3125 1.1562 0.3125h1.625v2.9531h-2.2031c-2.9492 0-4.4219-1.4297-4.4219-4.2969v-6.6719h-1.6562v-2.875h1.6562v-3.4375h3.5156v3.4375h3.1094v2.875z"/>
-</g>
-<g transform="translate(408.19 103.74)">
-<path d="m3.5-15.5c-0.61719 0-1.1328-0.19141-1.5469-0.57812-0.40625-0.39453-0.60938-0.88281-0.60938-1.4688 0-0.58203 0.20312-1.0664 0.60938-1.4531 0.41406-0.39453 0.92969-0.59375 1.5469-0.59375 0.61328 0 1.125 0.19922 1.5312 0.59375 0.41406 0.38672 0.625 0.87109 0.625 1.4531 0 0.58594-0.21094 1.0742-0.625 1.4688-0.40625 0.38672-0.91797 0.57812-1.5312 0.57812zm1.7188 1.6562v13.844h-3.5v-13.844z"/>
-</g>
-<g transform="translate(415.14 103.74)">
-<path d="m7.5-3.2188 3.5-10.625h3.7188l-5.125 13.844h-4.25l-5.0938-13.844h3.75z"/>
-</g>
-<g transform="translate(430.12 103.74)">
-<path d="m14.594-7.2188c0 0.5-0.03125 0.94922-0.09375 1.3438h-10.125c0.082031 1 0.42969 1.7891 1.0469 2.3594 0.61328 0.5625 1.375 0.84375 2.2812 0.84375 1.3008 0 2.2227-0.55469 2.7656-1.6719h3.7812c-0.39844 1.3359-1.1641 2.4297-2.2969 3.2812-1.1367 0.85547-2.5273 1.2812-4.1719 1.2812-1.3359 0-2.5312-0.28906-3.5938-0.875-1.0625-0.59375-1.8906-1.4297-2.4844-2.5156-0.58594-1.082-0.875-2.332-0.875-3.75 0-1.4375 0.28906-2.6953 0.875-3.7812 0.58203-1.082 1.3945-1.9141 2.4375-2.5 1.0508-0.58203 2.2656-0.875 3.6406-0.875 1.3125 0 2.4883 0.28906 3.5312 0.85938 1.0391 0.5625 1.8477 1.3672 2.4219 2.4062 0.57031 1.043 0.85938 2.2422 0.85938 3.5938zm-3.625-1c-0.011719-0.90625-0.33594-1.6289-0.96875-2.1719-0.63672-0.53906-1.4141-0.8125-2.3281-0.8125-0.86719 0-1.5938 0.26562-2.1875 0.79688-0.59375 0.52344-0.95312 1.25-1.0781 2.1875z"/>
-</g>
-<g transform="translate(445.54 103.74)">
-<path d="m7.0312 0.21875c-1.1367 0-2.1562-0.20312-3.0625-0.60938-0.89844-0.40625-1.6094-0.95703-2.1406-1.6562-0.52344-0.69531-0.80859-1.4727-0.85938-2.3281h3.5312c0.0625 0.53125 0.32031 0.97656 0.78125 1.3281 0.45703 0.34375 1.0312 0.51562 1.7188 0.51562 0.66406 0 1.1875-0.12891 1.5625-0.39062 0.375-0.26953 0.5625-0.61328 0.5625-1.0312 0-0.44531-0.23047-0.78125-0.6875-1-0.46094-0.22656-1.1875-0.47656-2.1875-0.75-1.0312-0.25-1.8828-0.50391-2.5469-0.76562-0.65625-0.26953-1.2266-0.67969-1.7031-1.2344-0.46875-0.55078-0.70312-1.2891-0.70312-2.2188 0-0.76953 0.21875-1.4688 0.65625-2.0938 0.44531-0.63281 1.082-1.1328 1.9062-1.5 0.82031-0.375 1.7969-0.5625 2.9219-0.5625 1.6445 0 2.957 0.41797 3.9375 1.25 0.98828 0.82422 1.5312 1.9336 1.625 3.3281h-3.3438c-0.054688-0.55078-0.28125-0.98828-0.6875-1.3125-0.40625-0.32031-0.95312-0.48438-1.6406-0.48438-0.63672 0-1.125 0.12109-1.4688 0.35938-0.33594 0.23047-0.5 0.55469-0.5 0.96875 0 0.46094 0.22656 0.8125 0.6875 1.0625 0.46875 0.24219 1.1953 0.48438 2.1875 0.73438 1 0.25 1.8203 0.51172 2.4688 0.78125 0.65625 0.26172 1.2188 0.67188 1.6875 1.2344 0.47656 0.55469 0.72266 1.2891 0.73438 2.2031 0 0.80469-0.21875 1.5234-0.65625 2.1562-0.4375 0.63672-1.0742 1.1328-1.9062 1.4844-0.82422 0.35156-1.7812 0.53125-2.875 0.53125z"/>
-</g>
-</g>
-<g fill="#192131">
-<g transform="translate(160.32 182.75)">
-<path d="m17.438-2.9844c-0.96094 1.125-2.0586 1.9609-3.2969 2.5-1.2422 0.53906-2.6016 0.80469-4.0781 0.79688-0.9375-0.011719-1.8047-0.15234-2.5938-0.42188-0.78125-0.28125-1.4844-0.66016-2.1094-1.1406-0.625-0.48828-1.1719-1.0625-1.6406-1.7188s-0.86719-1.3633-1.1875-2.125c-0.3125-0.76953-0.55469-1.5703-0.71875-2.4062-0.15625-0.84375-0.24219-1.6914-0.25-2.5469v-2.6406c0.007812-0.84375 0.082031-1.6797 0.21875-2.5156 0.14453-0.84375 0.36328-1.6484 0.65625-2.4219 0.28906-0.76953 0.65625-1.4844 1.0938-2.1406 0.4375-0.66406 0.95703-1.2383 1.5625-1.7188 0.61328-0.48828 1.3047-0.875 2.0781-1.1562 0.76953-0.28125 1.6328-0.42188 2.5938-0.42188 1.0625 0 2.0391 0.16797 2.9375 0.5 0.89453 0.32422 1.6758 0.79297 2.3438 1.4062 0.66406 0.60547 1.2031 1.3398 1.6094 2.2031 0.40625 0.85547 0.65625 1.8125 0.75 2.875h-2.8594c-0.11719-0.65625-0.29297-1.2578-0.53125-1.8125-0.24219-0.5625-0.55859-1.0391-0.95312-1.4375-0.38672-0.39453-0.85156-0.70312-1.3906-0.92188-0.54297-0.22656-1.1719-0.34375-1.8906-0.34375-0.6875 0-1.2969 0.12109-1.8281 0.35938-0.53125 0.23047-0.99609 0.54297-1.3906 0.9375-0.39844 0.39844-0.72656 0.85938-0.98438 1.3906-0.26172 0.52344-0.47656 1.0742-0.64062 1.6562-0.16797 0.58594-0.28906 1.1797-0.35938 1.7812-0.074219 0.60547-0.10938 1.1875-0.10938 1.75v2.6719c0.007812 0.57422 0.054688 1.168 0.14062 1.7812 0.09375 0.60547 0.23438 1.1992 0.42188 1.7812 0.1875 0.58594 0.42578 1.1367 0.71875 1.6562 0.28906 0.52344 0.64062 0.98047 1.0469 1.375 0.41406 0.39844 0.89453 0.71484 1.4375 0.95312 0.53906 0.23047 1.1562 0.35156 1.8438 0.35938 0.39453 0.011719 0.80469-0.003906 1.2344-0.046875 0.4375-0.039062 0.85938-0.125 1.2656-0.25s0.78516-0.28906 1.1406-0.5c0.35156-0.21875 0.64844-0.5 0.89062-0.84375l0.03125-5.1094h-4.625v-2.4375h7.375z"/>
-</g>
-<g transform="translate(179.52 182.75)">
-<path d="m2.4219 0v-22.75h5.2656c1.582 0.023438 2.9922 0.29297 4.2344 0.8125 1.25 0.51172 2.3008 1.2305 3.1562 2.1562 0.86328 0.91797 1.5195 2.0234 1.9688 3.3125 0.45703 1.2812 0.69141 2.7031 0.70312 4.2656v1.6719c-0.011719 1.5625-0.24609 2.9922-0.70312 4.2812-0.44922 1.2812-1.1055 2.3867-1.9688 3.3125-0.85547 0.91797-1.9062 1.6367-3.1562 2.1562-1.2422 0.51172-2.6523 0.77344-4.2344 0.78125zm2.9375-20.375v18.016h2.3281c1.2266-0.007813 2.2891-0.22266 3.1875-0.64062 0.89453-0.42578 1.6328-1.0039 2.2188-1.7344 0.59375-0.72656 1.0312-1.5859 1.3125-2.5781 0.28906-0.98828 0.44141-2.0625 0.45312-3.2188v-1.7031c-0.011719-1.1562-0.16406-2.2227-0.45312-3.2031-0.29297-0.98828-0.73047-1.8438-1.3125-2.5625-0.58594-0.72656-1.3242-1.3008-2.2188-1.7188-0.89844-0.41406-1.9609-0.63281-3.1875-0.65625z"/>
-</g>
-<g transform="translate(198.72 182.75)">
-<path d="m5.875-9.125v9.125h-2.8906v-22.75h7.375c1.0195 0.023438 1.9844 0.18359 2.8906 0.48438 0.91406 0.30469 1.7188 0.74219 2.4062 1.3125 0.6875 0.57422 1.2266 1.2812 1.625 2.125 0.40625 0.84375 0.60938 1.8125 0.60938 2.9062s-0.20312 2.0625-0.60938 2.9062c-0.39844 0.83594-0.9375 1.5391-1.625 2.1094-0.6875 0.57422-1.4922 1.0117-2.4062 1.3125-0.90625 0.30469-1.8711 0.46094-2.8906 0.46875zm0-2.375h4.4844c0.66406-0.007812 1.2812-0.11328 1.8438-0.3125 0.5625-0.20703 1.0508-0.5 1.4688-0.875 0.41406-0.375 0.73828-0.82812 0.96875-1.3594 0.23828-0.53906 0.35938-1.1562 0.35938-1.8438s-0.12109-1.3047-0.35938-1.8594c-0.23047-0.55078-0.55469-1.0195-0.96875-1.4062-0.40625-0.38281-0.89844-0.67969-1.4688-0.89062-0.5625-0.20703-1.1797-0.31641-1.8438-0.32812h-4.4844z"/>
-</g>
-<g transform="translate(217.92 182.75)">
-<path d="m10.25-9.2812h-4.5469v9.2812h-2.875v-22.75h6.6719c1.0625 0.023438 2.0625 0.17188 3 0.45312s1.7539 0.70312 2.4531 1.2656c0.70703 0.5625 1.2578 1.2734 1.6562 2.125 0.40625 0.84375 0.60938 1.8398 0.60938 2.9844 0 0.74219-0.10938 1.418-0.32812 2.0312-0.21094 0.61719-0.5 1.1719-0.875 1.6719s-0.82422 0.94531-1.3438 1.3281c-0.52344 0.38672-1.0938 0.71484-1.7188 0.98438l4.8281 9.7188-0.015625 0.1875h-3.0469zm-4.5469-2.375h3.875c0.64453-0.007812 1.2539-0.10938 1.8281-0.29688 0.57031-0.19531 1.0703-0.47656 1.5-0.84375 0.4375-0.36328 0.78125-0.80469 1.0312-1.3281 0.25-0.53125 0.375-1.1406 0.375-1.8281 0-0.72656-0.12109-1.3633-0.35938-1.9062-0.24219-0.55078-0.57422-1.0078-1-1.375-0.42969-0.375-0.9375-0.65625-1.5312-0.84375-0.58594-0.1875-1.2266-0.28516-1.9219-0.29688h-3.7969z"/>
-</g>
-<g transform="translate(303.1 184.7)">
-<path d="m16.969 0h-2.9375l-8.8281-17-0.046875 17h-2.9219v-22.75h2.9375l8.8281 16.969 0.046875-16.969h2.9219z"/>
-</g>
-<g transform="translate(322.3 184.7)">
-<path d="m2.7188-22.75h13.75v2.5156h-5.4531v17.734h5.4531v2.5h-13.75v-2.5h5.3281v-17.734h-5.3281z"/>
-</g>
-<g transform="translate(341.5 184.7)">
-<path d="m14.625-5.75c0-0.69531-0.16406-1.2852-0.48438-1.7656-0.3125-0.47656-0.71875-0.87891-1.2188-1.2031-0.5-0.33203-1.0547-0.60938-1.6562-0.82812-0.59375-0.21875-1.168-0.41406-1.7188-0.59375-0.80469-0.25781-1.6211-0.57031-2.4531-0.9375-0.82422-0.36328-1.5781-0.8125-2.2656-1.3438-0.67969-0.53125-1.2344-1.1562-1.6719-1.875-0.42969-0.72656-0.64062-1.582-0.64062-2.5625 0-0.97656 0.21094-1.8516 0.64062-2.625 0.4375-0.76953 1.0039-1.4219 1.7031-1.9531 0.69531-0.53125 1.4883-0.92969 2.375-1.2031 0.88281-0.28125 1.7734-0.42188 2.6719-0.42188 0.98828 0 1.9414 0.16797 2.8594 0.5 0.91406 0.32422 1.7266 0.78125 2.4375 1.375 0.70703 0.59375 1.2734 1.3125 1.7031 2.1562 0.42578 0.84375 0.64844 1.7891 0.67188 2.8281h-2.9688c-0.085937-0.65625-0.24609-1.25-0.48438-1.7812-0.24219-0.53906-0.55859-1.0039-0.95312-1.3906-0.39844-0.38281-0.87109-0.67969-1.4219-0.89062-0.54297-0.21875-1.1562-0.32812-1.8438-0.32812-0.55469 0-1.0938 0.078125-1.625 0.23438-0.52344 0.15625-0.99219 0.39062-1.4062 0.70312-0.40625 0.3125-0.73438 0.69922-0.98438 1.1562-0.24219 0.46094-0.35938 0.99219-0.35938 1.5938 0.007812 0.65625 0.17578 1.2148 0.5 1.6719 0.32031 0.44922 0.72656 0.82812 1.2188 1.1406 0.5 0.3125 1.0352 0.57422 1.6094 0.78125 0.58203 0.21094 1.1289 0.39062 1.6406 0.54688 0.5625 0.17969 1.1289 0.38281 1.7031 0.60938 0.57031 0.21875 1.125 0.47656 1.6562 0.76562 0.53125 0.29297 1.0234 0.62109 1.4844 0.98438 0.45703 0.36719 0.85938 0.78125 1.2031 1.25 0.34375 0.46094 0.60938 0.96875 0.79688 1.5312 0.19531 0.55469 0.29688 1.168 0.29688 1.8438 0 1.0234-0.23047 1.9141-0.6875 2.6719-0.44922 0.76172-1.0312 1.3984-1.75 1.9062-0.71875 0.5-1.5312 0.88281-2.4375 1.1406-0.90625 0.25-1.8125 0.375-2.7188 0.375-1.0117 0-2-0.15625-2.9688-0.46875s-1.8398-0.75781-2.6094-1.3438c-0.76172-0.59375-1.3828-1.3125-1.8594-2.1562-0.48047-0.85156-0.73438-1.8203-0.76562-2.9062h2.9531c0.09375 0.71094 0.28516 1.3398 0.57812 1.8906 0.28906 0.54297 0.66406 1.0078 1.125 1.3906 0.45703 0.375 0.98438 0.66406 1.5781 0.85938 0.60156 0.1875 1.2578 0.28125 1.9688 0.28125 0.5625 0 1.1133-0.066406 1.6562-0.20312 0.55078-0.14453 1.0391-0.36328 1.4688-0.65625 0.42578-0.30078 0.77344-0.67578 1.0469-1.125 0.26953-0.45703 0.40625-1 0.40625-1.625z"/>
-</g>
-<g transform="translate(360.7 184.7)">
-<path d="m16.672 0h-14.906v-2.0781l7.4531-8.2812c0.66406-0.73828 1.2227-1.3945 1.6719-1.9688 0.44531-0.57031 0.80469-1.0977 1.0781-1.5781 0.26953-0.48828 0.46094-0.94531 0.57812-1.375 0.11328-0.4375 0.17188-0.88281 0.17188-1.3438 0-0.5625-0.09375-1.0859-0.28125-1.5781-0.17969-0.5-0.44531-0.92969-0.79688-1.2969-0.34375-0.36328-0.76562-0.64844-1.2656-0.85938-0.49219-0.21875-1.0469-0.32812-1.6719-0.32812-0.76172 0-1.4219 0.10938-1.9844 0.32812-0.55469 0.21875-1.0156 0.53125-1.3906 0.9375-0.36719 0.39844-0.64062 0.88281-0.82812 1.4531-0.17969 0.57422-0.26562 1.2148-0.26562 1.9219h-2.9062c0-0.95703 0.16406-1.8594 0.5-2.7031 0.33203-0.85156 0.8125-1.5977 1.4375-2.2344 0.63281-0.63281 1.4062-1.1406 2.3125-1.5156 0.91406-0.375 1.957-0.5625 3.125-0.5625 1.0703 0 2.0352 0.16406 2.8906 0.48438 0.86328 0.3125 1.5938 0.75 2.1875 1.3125s1.0469 1.2305 1.3594 2c0.32031 0.77344 0.48438 1.6094 0.48438 2.5156 0 0.67969-0.11719 1.3516-0.34375 2.0156-0.23047 0.65625-0.54297 1.3086-0.9375 1.9531-0.38672 0.64844-0.83984 1.2891-1.3594 1.9219-0.51172 0.625-1.0547 1.25-1.625 1.875l-6.1094 6.625h11.422z"/>
-</g>
-</g>
-<g fill="#303b54">
-<g transform="translate(605.58 103.74)">
-<path d="m7.75 0.17188c-1.2188 0-2.3203-0.20703-3.2969-0.625-0.96875-0.41406-1.7422-1.0156-2.3125-1.7969-0.5625-0.78125-0.85156-1.707-0.85938-2.7812h3.75c0.039062 0.71875 0.28906 1.2891 0.75 1.7031 0.45703 0.41797 1.0859 0.625 1.8906 0.625 0.82031 0 1.4609-0.19141 1.9219-0.57812 0.46875-0.39453 0.70312-0.91016 0.70312-1.5469 0-0.50781-0.16406-0.92969-0.48438-1.2656-0.3125-0.33203-0.71094-0.59375-1.1875-0.78125-0.46875-0.19531-1.1211-0.41406-1.9531-0.65625-1.1367-0.33203-2.0586-0.66016-2.7656-0.98438-0.71094-0.32031-1.3203-0.8125-1.8281-1.4688-0.5-0.65625-0.75-1.5352-0.75-2.6406 0-1.0312 0.25391-1.9258 0.76562-2.6875 0.51953-0.76953 1.2422-1.3594 2.1719-1.7656 0.9375-0.41406 2.0039-0.625 3.2031-0.625 1.8008 0 3.2656 0.4375 4.3906 1.3125s1.7422 2.1016 1.8594 3.6719h-3.8438c-0.03125-0.60156-0.28906-1.0977-0.76562-1.4844-0.46875-0.39453-1.1016-0.59375-1.8906-0.59375-0.67969 0-1.2266 0.17969-1.6406 0.53125-0.40625 0.34375-0.60938 0.85156-0.60938 1.5156 0 0.46875 0.15625 0.85938 0.46875 1.1719 0.3125 0.30469 0.69531 0.55469 1.1562 0.75 0.45703 0.1875 1.1016 0.40625 1.9375 0.65625 1.125 0.33594 2.0469 0.66797 2.7656 1 0.71875 0.33594 1.332 0.83594 1.8438 1.5 0.51953 0.66797 0.78125 1.543 0.78125 2.625 0 0.92969-0.24609 1.793-0.73438 2.5938-0.48047 0.80469-1.1875 1.4453-2.125 1.9219-0.92969 0.46875-2.0312 0.70312-3.3125 0.70312z"/>
-</g>
-<g transform="translate(620.81 103.74)">
-<path d="m14.594-7.2188c0 0.5-0.03125 0.94922-0.09375 1.3438h-10.125c0.082031 1 0.42969 1.7891 1.0469 2.3594 0.61328 0.5625 1.375 0.84375 2.2812 0.84375 1.3008 0 2.2227-0.55469 2.7656-1.6719h3.7812c-0.39844 1.3359-1.1641 2.4297-2.2969 3.2812-1.1367 0.85547-2.5273 1.2812-4.1719 1.2812-1.3359 0-2.5312-0.28906-3.5938-0.875-1.0625-0.59375-1.8906-1.4297-2.4844-2.5156-0.58594-1.082-0.875-2.332-0.875-3.75 0-1.4375 0.28906-2.6953 0.875-3.7812 0.58203-1.082 1.3945-1.9141 2.4375-2.5 1.0508-0.58203 2.2656-0.875 3.6406-0.875 1.3125 0 2.4883 0.28906 3.5312 0.85938 1.0391 0.5625 1.8477 1.3672 2.4219 2.4062 0.57031 1.043 0.85938 2.2422 0.85938 3.5938zm-3.625-1c-0.011719-0.90625-0.33594-1.6289-0.96875-2.1719-0.63672-0.53906-1.4141-0.8125-2.3281-0.8125-0.86719 0-1.5938 0.26562-2.1875 0.79688-0.59375 0.52344-0.95312 1.25-1.0781 2.1875z"/>
-</g>
-<g transform="translate(636.23 103.74)">
-<path d="m0.82812-6.9219c0-1.4375 0.28906-2.6914 0.875-3.7656 0.58203-1.0703 1.3906-1.9062 2.4219-2.5s2.2109-0.89062 3.5469-0.89062c1.7188 0 3.1406 0.43359 4.2656 1.2969 1.125 0.85547 1.8789 2.0586 2.2656 3.6094h-3.7812c-0.19922-0.60156-0.53906-1.0703-1.0156-1.4062-0.46875-0.34375-1.0547-0.51562-1.75-0.51562-1 0-1.793 0.36719-2.375 1.0938-0.58594 0.71875-0.875 1.7461-0.875 3.0781 0 1.3125 0.28906 2.3359 0.875 3.0625 0.58203 0.71875 1.375 1.0781 2.375 1.0781 1.4141 0 2.3359-0.62891 2.7656-1.8906h3.7812c-0.38672 1.5-1.1484 2.6953-2.2812 3.5781-1.1367 0.875-2.5547 1.3125-4.25 1.3125-1.3359 0-2.5156-0.28906-3.5469-0.875-1.0312-0.59375-1.8398-1.4258-2.4219-2.5-0.58594-1.082-0.875-2.3359-0.875-3.7656z"/>
-</g>
-<g transform="translate(651.28 103.74)">
-<path d="m14.797-13.844v13.844h-3.5156v-1.75c-0.46094 0.60547-1.0547 1.0781-1.7812 1.4219-0.71875 0.33203-1.5 0.5-2.3438 0.5-1.0859 0-2.043-0.22656-2.875-0.6875-0.83594-0.45703-1.4922-1.1289-1.9688-2.0156-0.48047-0.89453-0.71875-1.957-0.71875-3.1875v-8.125h3.5v7.625c0 1.0938 0.27344 1.9375 0.82812 2.5312 0.55078 0.59375 1.3008 0.89062 2.25 0.89062 0.96875 0 1.7266-0.29688 2.2812-0.89062 0.55078-0.59375 0.82812-1.4375 0.82812-2.5312v-7.625z"/>
-</g>
-<g transform="translate(667.8 103.74)">
-<path d="m5.2188-11.703c0.45703-0.72656 1.0469-1.3008 1.7656-1.7188 0.72656-0.41406 1.5547-0.625 2.4844-0.625v3.6719h-0.92188c-1.0938 0-1.9219 0.26172-2.4844 0.78125-0.5625 0.51172-0.84375 1.4062-0.84375 2.6875v6.9062h-3.5v-13.844h3.5z"/>
-</g>
-<g transform="translate(677.9 103.74)">
-<path d="m3.5-15.5c-0.61719 0-1.1328-0.19141-1.5469-0.57812-0.40625-0.39453-0.60938-0.88281-0.60938-1.4688 0-0.58203 0.20312-1.0664 0.60938-1.4531 0.41406-0.39453 0.92969-0.59375 1.5469-0.59375 0.61328 0 1.125 0.19922 1.5312 0.59375 0.41406 0.38672 0.625 0.87109 0.625 1.4531 0 0.58594-0.21094 1.0742-0.625 1.4688-0.40625 0.38672-0.91797 0.57812-1.5312 0.57812zm1.7188 1.6562v13.844h-3.5v-13.844z"/>
-</g>
-<g transform="translate(684.85 103.74)">
-<path d="m5.7969-10.969v6.6875c0 0.46875 0.10938 0.80859 0.32812 1.0156 0.22656 0.21094 0.61328 0.3125 1.1562 0.3125h1.625v2.9531h-2.2031c-2.9492 0-4.4219-1.4297-4.4219-4.2969v-6.6719h-1.6562v-2.875h1.6562v-3.4375h3.5156v3.4375h3.1094v2.875z"/>
-</g>
-<g transform="translate(694.54 103.74)">
-<path d="m14.969-13.844-8.5625 20.391h-3.7344l3-6.8906-5.5469-13.5h3.9219l3.5781 9.6719 3.625-9.6719z"/>
-</g>
-<g transform="translate(709.67 103.74)"/>
-<g transform="translate(715.62 103.74)">
-<path d="m11.625-8.9531c0.97656 0.1875 1.7852 0.68359 2.4219 1.4844 0.63281 0.79297 0.95312 1.7109 0.95312 2.75 0 0.92969-0.23047 1.7461-0.6875 2.4531-0.46094 0.71094-1.1211 1.2656-1.9844 1.6719-0.86719 0.39844-1.8906 0.59375-3.0781 0.59375h-7.5312v-17.453h7.2031c1.1875 0 2.207 0.19531 3.0625 0.57812 0.86328 0.38672 1.5156 0.92188 1.9531 1.6094 0.4375 0.67969 0.65625 1.4492 0.65625 2.3125 0 1.0234-0.27344 1.875-0.8125 2.5625-0.54297 0.67969-1.2617 1.1562-2.1562 1.4375zm-6.4062-1.2969h3.2031c0.83203 0 1.4727-0.1875 1.9219-0.5625 0.45703-0.375 0.6875-0.91016 0.6875-1.6094 0-0.69531-0.23047-1.2383-0.6875-1.625-0.44922-0.38281-1.0898-0.57812-1.9219-0.57812h-3.2031zm3.5312 7.4062c0.85156 0 1.5156-0.19531 1.9844-0.59375 0.47656-0.40625 0.71875-0.97656 0.71875-1.7188 0-0.75-0.25-1.332-0.75-1.75-0.5-0.42578-1.1797-0.64062-2.0312-0.64062h-3.4531v4.7031z"/>
-</g>
-<g transform="translate(731.69 103.74)">
-<path d="m14.594-7.2188c0 0.5-0.03125 0.94922-0.09375 1.3438h-10.125c0.082031 1 0.42969 1.7891 1.0469 2.3594 0.61328 0.5625 1.375 0.84375 2.2812 0.84375 1.3008 0 2.2227-0.55469 2.7656-1.6719h3.7812c-0.39844 1.3359-1.1641 2.4297-2.2969 3.2812-1.1367 0.85547-2.5273 1.2812-4.1719 1.2812-1.3359 0-2.5312-0.28906-3.5938-0.875-1.0625-0.59375-1.8906-1.4297-2.4844-2.5156-0.58594-1.082-0.875-2.332-0.875-3.75 0-1.4375 0.28906-2.6953 0.875-3.7812 0.58203-1.082 1.3945-1.9141 2.4375-2.5 1.0508-0.58203 2.2656-0.875 3.6406-0.875 1.3125 0 2.4883 0.28906 3.5312 0.85938 1.0391 0.5625 1.8477 1.3672 2.4219 2.4062 0.57031 1.043 0.85938 2.2422 0.85938 3.5938zm-3.625-1c-0.011719-0.90625-0.33594-1.6289-0.96875-2.1719-0.63672-0.53906-1.4141-0.8125-2.3281-0.8125-0.86719 0-1.5938 0.26562-2.1875 0.79688-0.59375 0.52344-0.95312 1.25-1.0781 2.1875z"/>
-</g>
-<g transform="translate(747.11 103.74)">
-<path d="m7.0312 0.21875c-1.1367 0-2.1562-0.20312-3.0625-0.60938-0.89844-0.40625-1.6094-0.95703-2.1406-1.6562-0.52344-0.69531-0.80859-1.4727-0.85938-2.3281h3.5312c0.0625 0.53125 0.32031 0.97656 0.78125 1.3281 0.45703 0.34375 1.0312 0.51562 1.7188 0.51562 0.66406 0 1.1875-0.12891 1.5625-0.39062 0.375-0.26953 0.5625-0.61328 0.5625-1.0312 0-0.44531-0.23047-0.78125-0.6875-1-0.46094-0.22656-1.1875-0.47656-2.1875-0.75-1.0312-0.25-1.8828-0.50391-2.5469-0.76562-0.65625-0.26953-1.2266-0.67969-1.7031-1.2344-0.46875-0.55078-0.70312-1.2891-0.70312-2.2188 0-0.76953 0.21875-1.4688 0.65625-2.0938 0.44531-0.63281 1.082-1.1328 1.9062-1.5 0.82031-0.375 1.7969-0.5625 2.9219-0.5625 1.6445 0 2.957 0.41797 3.9375 1.25 0.98828 0.82422 1.5312 1.9336 1.625 3.3281h-3.3438c-0.054688-0.55078-0.28125-0.98828-0.6875-1.3125-0.40625-0.32031-0.95312-0.48438-1.6406-0.48438-0.63672 0-1.125 0.12109-1.4688 0.35938-0.33594 0.23047-0.5 0.55469-0.5 0.96875 0 0.46094 0.22656 0.8125 0.6875 1.0625 0.46875 0.24219 1.1953 0.48438 2.1875 0.73438 1 0.25 1.8203 0.51172 2.4688 0.78125 0.65625 0.26172 1.2188 0.67188 1.6875 1.2344 0.47656 0.55469 0.72266 1.2891 0.73438 2.2031 0 0.80469-0.21875 1.5234-0.65625 2.1562-0.4375 0.63672-1.0742 1.1328-1.9062 1.4844-0.82422 0.35156-1.7812 0.53125-2.875 0.53125z"/>
-</g>
-<g transform="translate(760.73 103.74)">
-<path d="m5.7969-10.969v6.6875c0 0.46875 0.10938 0.80859 0.32812 1.0156 0.22656 0.21094 0.61328 0.3125 1.1562 0.3125h1.625v2.9531h-2.2031c-2.9492 0-4.4219-1.4297-4.4219-4.2969v-6.6719h-1.6562v-2.875h1.6562v-3.4375h3.5156v3.4375h3.1094v2.875z"/>
-</g>
-<g transform="translate(770.43 103.74)"/>
-<g transform="translate(776.38 103.74)">
-<path d="m14.453-12.047c0 0.92969-0.22656 1.8047-0.67188 2.625-0.4375 0.8125-1.1328 1.4688-2.0781 1.9688-0.9375 0.5-2.1211 0.75-3.5469 0.75h-2.9375v6.7031h-3.5v-17.453h6.4375c1.3438 0 2.4883 0.23438 3.4375 0.70312 0.95703 0.46875 1.6719 1.1172 2.1406 1.9375 0.47656 0.8125 0.71875 1.7344 0.71875 2.7656zm-6.4531 2.5156c0.96875 0 1.6797-0.21875 2.1406-0.65625 0.46875-0.4375 0.70312-1.0547 0.70312-1.8594 0-1.6953-0.94922-2.5469-2.8438-2.5469h-2.7812v5.0625z"/>
-</g>
-<g transform="translate(791.58 103.74)">
-<path d="m5.2188-11.703c0.45703-0.72656 1.0469-1.3008 1.7656-1.7188 0.72656-0.41406 1.5547-0.625 2.4844-0.625v3.6719h-0.92188c-1.0938 0-1.9219 0.26172-2.4844 0.78125-0.5625 0.51172-0.84375 1.4062-0.84375 2.6875v6.9062h-3.5v-13.844h3.5z"/>
-</g>
-<g transform="translate(801.68 103.74)">
-<path d="m0.82812-6.9688c0-1.4062 0.27344-2.6484 0.82812-3.7344 0.5625-1.082 1.3203-1.9141 2.2812-2.5 0.95703-0.58203 2.0312-0.875 3.2188-0.875 1.0312 0 1.9297 0.21094 2.7031 0.625 0.78125 0.41797 1.3984 0.94531 1.8594 1.5781v-1.9688h3.5312v13.844h-3.5312v-2.0312c-0.44922 0.65625-1.0703 1.1992-1.8594 1.625-0.79297 0.41406-1.7031 0.625-2.7344 0.625-1.168 0-2.2305-0.29688-3.1875-0.89062-0.96094-0.60156-1.7188-1.4453-2.2812-2.5312-0.55469-1.0938-0.82812-2.3477-0.82812-3.7656zm10.891 0.046875c0-0.85156-0.16797-1.582-0.5-2.1875-0.33594-0.61328-0.78125-1.082-1.3438-1.4062-0.5625-0.32031-1.1719-0.48438-1.8281-0.48438-0.64844 0-1.2461 0.16406-1.7969 0.48438-0.55469 0.3125-1 0.77734-1.3438 1.3906-0.33594 0.60547-0.5 1.3242-0.5 2.1562 0 0.83594 0.16406 1.5625 0.5 2.1875 0.34375 0.625 0.78906 1.1055 1.3438 1.4375 0.5625 0.33594 1.1602 0.5 1.7969 0.5 0.65625 0 1.2656-0.16016 1.8281-0.48438 0.5625-0.33203 1.0078-0.80078 1.3438-1.4062 0.33203-0.61328 0.5-1.3438 0.5-2.1875z"/>
-</g>
-<g transform="translate(818.63 103.74)">
-<path d="m0.82812-6.9219c0-1.4375 0.28906-2.6914 0.875-3.7656 0.58203-1.0703 1.3906-1.9062 2.4219-2.5s2.2109-0.89062 3.5469-0.89062c1.7188 0 3.1406 0.43359 4.2656 1.2969 1.125 0.85547 1.8789 2.0586 2.2656 3.6094h-3.7812c-0.19922-0.60156-0.53906-1.0703-1.0156-1.4062-0.46875-0.34375-1.0547-0.51562-1.75-0.51562-1 0-1.793 0.36719-2.375 1.0938-0.58594 0.71875-0.875 1.7461-0.875 3.0781 0 1.3125 0.28906 2.3359 0.875 3.0625 0.58203 0.71875 1.375 1.0781 2.375 1.0781 1.4141 0 2.3359-0.62891 2.7656-1.8906h3.7812c-0.38672 1.5-1.1484 2.6953-2.2812 3.5781-1.1367 0.875-2.5547 1.3125-4.25 1.3125-1.3359 0-2.5156-0.28906-3.5469-0.875-1.0312-0.59375-1.8398-1.4258-2.4219-2.5-0.58594-1.082-0.875-2.3359-0.875-3.7656z"/>
-</g>
-<g transform="translate(833.67 103.74)">
-<path d="m5.7969-10.969v6.6875c0 0.46875 0.10938 0.80859 0.32812 1.0156 0.22656 0.21094 0.61328 0.3125 1.1562 0.3125h1.625v2.9531h-2.2031c-2.9492 0-4.4219-1.4297-4.4219-4.2969v-6.6719h-1.6562v-2.875h1.6562v-3.4375h3.5156v3.4375h3.1094v2.875z"/>
-</g>
-<g transform="translate(843.37 103.74)">
-<path d="m3.5-15.5c-0.61719 0-1.1328-0.19141-1.5469-0.57812-0.40625-0.39453-0.60938-0.88281-0.60938-1.4688 0-0.58203 0.20312-1.0664 0.60938-1.4531 0.41406-0.39453 0.92969-0.59375 1.5469-0.59375 0.61328 0 1.125 0.19922 1.5312 0.59375 0.41406 0.38672 0.625 0.87109 0.625 1.4531 0 0.58594-0.21094 1.0742-0.625 1.4688-0.40625 0.38672-0.91797 0.57812-1.5312 0.57812zm1.7188 1.6562v13.844h-3.5v-13.844z"/>
-</g>
-<g transform="translate(850.32 103.74)">
-<path d="m0.82812-6.9219c0-1.4375 0.28906-2.6914 0.875-3.7656 0.58203-1.0703 1.3906-1.9062 2.4219-2.5s2.2109-0.89062 3.5469-0.89062c1.7188 0 3.1406 0.43359 4.2656 1.2969 1.125 0.85547 1.8789 2.0586 2.2656 3.6094h-3.7812c-0.19922-0.60156-0.53906-1.0703-1.0156-1.4062-0.46875-0.34375-1.0547-0.51562-1.75-0.51562-1 0-1.793 0.36719-2.375 1.0938-0.58594 0.71875-0.875 1.7461-0.875 3.0781 0 1.3125 0.28906 2.3359 0.875 3.0625 0.58203 0.71875 1.375 1.0781 2.375 1.0781 1.4141 0 2.3359-0.62891 2.7656-1.8906h3.7812c-0.38672 1.5-1.1484 2.6953-2.2812 3.5781-1.1367 0.875-2.5547 1.3125-4.25 1.3125-1.3359 0-2.5156-0.28906-3.5469-0.875-1.0312-0.59375-1.8398-1.4258-2.4219-2.5-0.58594-1.082-0.875-2.3359-0.875-3.7656z"/>
-</g>
-<g transform="translate(865.37 103.74)">
-<path d="m14.594-7.2188c0 0.5-0.03125 0.94922-0.09375 1.3438h-10.125c0.082031 1 0.42969 1.7891 1.0469 2.3594 0.61328 0.5625 1.375 0.84375 2.2812 0.84375 1.3008 0 2.2227-0.55469 2.7656-1.6719h3.7812c-0.39844 1.3359-1.1641 2.4297-2.2969 3.2812-1.1367 0.85547-2.5273 1.2812-4.1719 1.2812-1.3359 0-2.5312-0.28906-3.5938-0.875-1.0625-0.59375-1.8906-1.4297-2.4844-2.5156-0.58594-1.082-0.875-2.332-0.875-3.75 0-1.4375 0.28906-2.6953 0.875-3.7812 0.58203-1.082 1.3945-1.9141 2.4375-2.5 1.0508-0.58203 2.2656-0.875 3.6406-0.875 1.3125 0 2.4883 0.28906 3.5312 0.85938 1.0391 0.5625 1.8477 1.3672 2.4219 2.4062 0.57031 1.043 0.85938 2.2422 0.85938 3.5938zm-3.625-1c-0.011719-0.90625-0.33594-1.6289-0.96875-2.1719-0.63672-0.53906-1.4141-0.8125-2.3281-0.8125-0.86719 0-1.5938 0.26562-2.1875 0.79688-0.59375 0.52344-0.95312 1.25-1.0781 2.1875z"/>
-</g>
-<g transform="translate(880.79 103.74)">
-<path d="m7.0312 0.21875c-1.1367 0-2.1562-0.20312-3.0625-0.60938-0.89844-0.40625-1.6094-0.95703-2.1406-1.6562-0.52344-0.69531-0.80859-1.4727-0.85938-2.3281h3.5312c0.0625 0.53125 0.32031 0.97656 0.78125 1.3281 0.45703 0.34375 1.0312 0.51562 1.7188 0.51562 0.66406 0 1.1875-0.12891 1.5625-0.39062 0.375-0.26953 0.5625-0.61328 0.5625-1.0312 0-0.44531-0.23047-0.78125-0.6875-1-0.46094-0.22656-1.1875-0.47656-2.1875-0.75-1.0312-0.25-1.8828-0.50391-2.5469-0.76562-0.65625-0.26953-1.2266-0.67969-1.7031-1.2344-0.46875-0.55078-0.70312-1.2891-0.70312-2.2188 0-0.76953 0.21875-1.4688 0.65625-2.0938 0.44531-0.63281 1.082-1.1328 1.9062-1.5 0.82031-0.375 1.7969-0.5625 2.9219-0.5625 1.6445 0 2.957 0.41797 3.9375 1.25 0.98828 0.82422 1.5312 1.9336 1.625 3.3281h-3.3438c-0.054688-0.55078-0.28125-0.98828-0.6875-1.3125-0.40625-0.32031-0.95312-0.48438-1.6406-0.48438-0.63672 0-1.125 0.12109-1.4688 0.35938-0.33594 0.23047-0.5 0.55469-0.5 0.96875 0 0.46094 0.22656 0.8125 0.6875 1.0625 0.46875 0.24219 1.1953 0.48438 2.1875 0.73438 1 0.25 1.8203 0.51172 2.4688 0.78125 0.65625 0.26172 1.2188 0.67188 1.6875 1.2344 0.47656 0.55469 0.72266 1.2891 0.73438 2.2031 0 0.80469-0.21875 1.5234-0.65625 2.1562-0.4375 0.63672-1.0742 1.1328-1.9062 1.4844-0.82422 0.35156-1.7812 0.53125-2.875 0.53125z"/>
-</g>
-</g>
-<g fill="#192131">
-<g transform="translate(590.28 182.75)">
-<path d="m16.969 0h-2.9375l-8.8281-17-0.046875 17h-2.9219v-22.75h2.9375l8.8281 16.969 0.046875-16.969h2.9219z"/>
-</g>
-<g transform="translate(609.48 182.75)">
-<path d="m2.7188-22.75h13.75v2.5156h-5.4531v17.734h5.4531v2.5h-13.75v-2.5h5.3281v-17.734h-5.3281z"/>
-</g>
-<g transform="translate(628.68 182.75)">
-<path d="m14.625-5.75c0-0.69531-0.16406-1.2852-0.48438-1.7656-0.3125-0.47656-0.71875-0.87891-1.2188-1.2031-0.5-0.33203-1.0547-0.60938-1.6562-0.82812-0.59375-0.21875-1.168-0.41406-1.7188-0.59375-0.80469-0.25781-1.6211-0.57031-2.4531-0.9375-0.82422-0.36328-1.5781-0.8125-2.2656-1.3438-0.67969-0.53125-1.2344-1.1562-1.6719-1.875-0.42969-0.72656-0.64062-1.582-0.64062-2.5625 0-0.97656 0.21094-1.8516 0.64062-2.625 0.4375-0.76953 1.0039-1.4219 1.7031-1.9531 0.69531-0.53125 1.4883-0.92969 2.375-1.2031 0.88281-0.28125 1.7734-0.42188 2.6719-0.42188 0.98828 0 1.9414 0.16797 2.8594 0.5 0.91406 0.32422 1.7266 0.78125 2.4375 1.375 0.70703 0.59375 1.2734 1.3125 1.7031 2.1562 0.42578 0.84375 0.64844 1.7891 0.67188 2.8281h-2.9688c-0.085937-0.65625-0.24609-1.25-0.48438-1.7812-0.24219-0.53906-0.55859-1.0039-0.95312-1.3906-0.39844-0.38281-0.87109-0.67969-1.4219-0.89062-0.54297-0.21875-1.1562-0.32812-1.8438-0.32812-0.55469 0-1.0938 0.078125-1.625 0.23438-0.52344 0.15625-0.99219 0.39062-1.4062 0.70312-0.40625 0.3125-0.73438 0.69922-0.98438 1.1562-0.24219 0.46094-0.35938 0.99219-0.35938 1.5938 0.007812 0.65625 0.17578 1.2148 0.5 1.6719 0.32031 0.44922 0.72656 0.82812 1.2188 1.1406 0.5 0.3125 1.0352 0.57422 1.6094 0.78125 0.58203 0.21094 1.1289 0.39062 1.6406 0.54688 0.5625 0.17969 1.1289 0.38281 1.7031 0.60938 0.57031 0.21875 1.125 0.47656 1.6562 0.76562 0.53125 0.29297 1.0234 0.62109 1.4844 0.98438 0.45703 0.36719 0.85938 0.78125 1.2031 1.25 0.34375 0.46094 0.60938 0.96875 0.79688 1.5312 0.19531 0.55469 0.29688 1.168 0.29688 1.8438 0 1.0234-0.23047 1.9141-0.6875 2.6719-0.44922 0.76172-1.0312 1.3984-1.75 1.9062-0.71875 0.5-1.5312 0.88281-2.4375 1.1406-0.90625 0.25-1.8125 0.375-2.7188 0.375-1.0117 0-2-0.15625-2.9688-0.46875s-1.8398-0.75781-2.6094-1.3438c-0.76172-0.59375-1.3828-1.3125-1.8594-2.1562-0.48047-0.85156-0.73438-1.8203-0.76562-2.9062h2.9531c0.09375 0.71094 0.28516 1.3398 0.57812 1.8906 0.28906 0.54297 0.66406 1.0078 1.125 1.3906 0.45703 0.375 0.98438 0.66406 1.5781 0.85938 0.60156 0.1875 1.2578 0.28125 1.9688 0.28125 0.5625 0 1.1133-0.066406 1.6562-0.20312 0.55078-0.14453 1.0391-0.36328 1.4688-0.65625 0.42578-0.30078 0.77344-0.67578 1.0469-1.125 0.26953-0.45703 0.40625-1 0.40625-1.625z"/>
-</g>
-<g transform="translate(647.88 182.75)">
-<path d="m18.062-20.281h-7.0312v20.281h-2.8125v-20.281h-7.0312v-2.4688h16.875z"/>
-</g>
-<g transform="translate(857.97 184.84)">
-<path d="m2.4219 0v-22.75h5.2656c1.582 0.023438 2.9922 0.29297 4.2344 0.8125 1.25 0.51172 2.3008 1.2305 3.1562 2.1562 0.86328 0.91797 1.5195 2.0234 1.9688 3.3125 0.45703 1.2812 0.69141 2.7031 0.70312 4.2656v1.6719c-0.011719 1.5625-0.24609 2.9922-0.70312 4.2812-0.44922 1.2812-1.1055 2.3867-1.9688 3.3125-0.85547 0.91797-1.9062 1.6367-3.1562 2.1562-1.2422 0.51172-2.6523 0.77344-4.2344 0.78125zm2.9375-20.375v18.016h2.3281c1.2266-0.007813 2.2891-0.22266 3.1875-0.64062 0.89453-0.42578 1.6328-1.0039 2.2188-1.7344 0.59375-0.72656 1.0312-1.5859 1.3125-2.5781 0.28906-0.98828 0.44141-2.0625 0.45312-3.2188v-1.7031c-0.011719-1.1562-0.16406-2.2227-0.45312-3.2031-0.29297-0.98828-0.73047-1.8438-1.3125-2.5625-0.58594-0.72656-1.3242-1.3008-2.2188-1.7188-0.89844-0.41406-1.9609-0.63281-3.1875-0.65625z"/>
-</g>
-<g transform="translate(877.17 184.84)">
-<path d="m1.9062-8.6094c0-1.2188 0.17578-2.3477 0.53125-3.3906 0.35156-1.0508 0.85938-1.9609 1.5156-2.7344 0.66406-0.76953 1.4727-1.375 2.4219-1.8125 0.94531-0.44531 2.0156-0.67188 3.2031-0.67188 1.1953 0 2.2695 0.22656 3.2188 0.67188 0.95703 0.4375 1.7656 1.043 2.4219 1.8125 0.66406 0.77344 1.1758 1.6836 1.5312 2.7344 0.35156 1.043 0.53125 2.1719 0.53125 3.3906v0.34375c0 1.2188-0.17969 2.3516-0.53125 3.3906-0.35547 1.043-0.86719 1.9492-1.5312 2.7188-0.65625 0.77344-1.4609 1.375-2.4062 1.8125-0.94922 0.4375-2.0156 0.65625-3.2031 0.65625-1.1992 0-2.2773-0.21875-3.2344-0.65625-0.94922-0.4375-1.7578-1.0391-2.4219-1.8125-0.65625-0.76953-1.1641-1.6758-1.5156-2.7188-0.35547-1.0391-0.53125-2.1719-0.53125-3.3906zm2.8906 0.34375c0 0.83594 0.097656 1.6328 0.29688 2.3906 0.19531 0.75 0.49219 1.4141 0.89062 1.9844 0.40625 0.57422 0.91016 1.0273 1.5156 1.3594 0.60156 0.33594 1.3047 0.5 2.1094 0.5 0.78906 0 1.4844-0.16406 2.0781-0.5 0.60156-0.33203 1.1016-0.78516 1.5-1.3594 0.40625-0.57031 0.70703-1.2344 0.90625-1.9844 0.19531-0.75781 0.29688-1.5547 0.29688-2.3906v-0.34375c0-0.82031-0.10547-1.6094-0.3125-2.3594-0.19922-0.75781-0.5-1.4258-0.90625-2-0.39844-0.57031-0.89844-1.0234-1.5-1.3594-0.59375-0.34375-1.293-0.51562-2.0938-0.51562-0.80469 0-1.5 0.17188-2.0938 0.51562-0.59375 0.33594-1.0938 0.78906-1.5 1.3594-0.39844 0.57422-0.69531 1.2422-0.89062 2-0.19922 0.75-0.29688 1.5391-0.29688 2.3594z"/>
-</g>
-<g transform="translate(896.37 184.84)">
-<path d="m2.4219 0v-22.75h5.2656c1.582 0.023438 2.9922 0.29297 4.2344 0.8125 1.25 0.51172 2.3008 1.2305 3.1562 2.1562 0.86328 0.91797 1.5195 2.0234 1.9688 3.3125 0.45703 1.2812 0.69141 2.7031 0.70312 4.2656v1.6719c-0.011719 1.5625-0.24609 2.9922-0.70312 4.2812-0.44922 1.2812-1.1055 2.3867-1.9688 3.3125-0.85547 0.91797-1.9062 1.6367-3.1562 2.1562-1.2422 0.51172-2.6523 0.77344-4.2344 0.78125zm2.9375-20.375v18.016h2.3281c1.2266-0.007813 2.2891-0.22266 3.1875-0.64062 0.89453-0.42578 1.6328-1.0039 2.2188-1.7344 0.59375-0.72656 1.0312-1.5859 1.3125-2.5781 0.28906-0.98828 0.44141-2.0625 0.45312-3.2188v-1.7031c-0.011719-1.1562-0.16406-2.2227-0.45312-3.2031-0.29297-0.98828-0.73047-1.8438-1.3125-2.5625-0.58594-0.72656-1.3242-1.3008-2.2188-1.7188-0.89844-0.41406-1.9609-0.63281-3.1875-0.65625z"/>
-</g>
-</g>
-<g fill="#303b54">
-<g transform="translate(1041.7 103.74)">
-<path d="m5.2188-17.453v17.453h-3.5v-17.453z"/>
-</g>
-<g transform="translate(1048.6 103.74)">
-<path d="m9.4062-14.047c1.6445 0 2.9727 0.52344 3.9844 1.5625 1.0195 1.043 1.5312 2.4961 1.5312 4.3594v8.125h-3.5v-7.6562c0-1.0938-0.27734-1.9375-0.82812-2.5312-0.54297-0.59375-1.293-0.89062-2.25-0.89062-0.96094 0-1.7188 0.29688-2.2812 0.89062s-0.84375 1.4375-0.84375 2.5312v7.6562h-3.5v-13.844h3.5v1.7188c0.46875-0.60156 1.0625-1.0703 1.7812-1.4062 0.72656-0.34375 1.5312-0.51562 2.4062-0.51562z"/>
-</g>
-<g transform="translate(1065.2 103.74)">
-<path d="m0.82812-6.9688c0-1.4062 0.27344-2.6484 0.82812-3.7344 0.5625-1.082 1.3281-1.9141 2.2969-2.5 0.96875-0.58203 2.0391-0.875 3.2188-0.875 0.90625 0 1.7656 0.19922 2.5781 0.59375 0.8125 0.38672 1.4609 0.90625 1.9531 1.5625v-6.5781h3.5469v18.5h-3.5469v-2.0469c-0.4375 0.67969-1.0469 1.2266-1.8281 1.6406-0.78125 0.41406-1.6875 0.625-2.7188 0.625-1.168 0-2.2344-0.29688-3.2031-0.89062-0.96875-0.60156-1.7344-1.4453-2.2969-2.5312-0.55469-1.0938-0.82812-2.3477-0.82812-3.7656zm10.891 0.046875c0-0.85156-0.16797-1.582-0.5-2.1875-0.33594-0.61328-0.78125-1.082-1.3438-1.4062-0.5625-0.32031-1.1719-0.48438-1.8281-0.48438-0.64844 0-1.2461 0.16406-1.7969 0.48438-0.55469 0.3125-1 0.77734-1.3438 1.3906-0.33594 0.60547-0.5 1.3242-0.5 2.1562 0 0.83594 0.16406 1.5625 0.5 2.1875 0.34375 0.625 0.78906 1.1055 1.3438 1.4375 0.5625 0.33594 1.1602 0.5 1.7969 0.5 0.65625 0 1.2656-0.16016 1.8281-0.48438 0.5625-0.33203 1.0078-0.80078 1.3438-1.4062 0.33203-0.61328 0.5-1.3438 0.5-2.1875z"/>
-</g>
-<g transform="translate(1082.1 103.74)">
-<path d="m14.797-13.844v13.844h-3.5156v-1.75c-0.46094 0.60547-1.0547 1.0781-1.7812 1.4219-0.71875 0.33203-1.5 0.5-2.3438 0.5-1.0859 0-2.043-0.22656-2.875-0.6875-0.83594-0.45703-1.4922-1.1289-1.9688-2.0156-0.48047-0.89453-0.71875-1.957-0.71875-3.1875v-8.125h3.5v7.625c0 1.0938 0.27344 1.9375 0.82812 2.5312 0.55078 0.59375 1.3008 0.89062 2.25 0.89062 0.96875 0 1.7266-0.29688 2.2812-0.89062 0.55078-0.59375 0.82812-1.4375 0.82812-2.5312v-7.625z"/>
-</g>
-<g transform="translate(1098.6 103.74)">
-<path d="m7.0312 0.21875c-1.1367 0-2.1562-0.20312-3.0625-0.60938-0.89844-0.40625-1.6094-0.95703-2.1406-1.6562-0.52344-0.69531-0.80859-1.4727-0.85938-2.3281h3.5312c0.0625 0.53125 0.32031 0.97656 0.78125 1.3281 0.45703 0.34375 1.0312 0.51562 1.7188 0.51562 0.66406 0 1.1875-0.12891 1.5625-0.39062 0.375-0.26953 0.5625-0.61328 0.5625-1.0312 0-0.44531-0.23047-0.78125-0.6875-1-0.46094-0.22656-1.1875-0.47656-2.1875-0.75-1.0312-0.25-1.8828-0.50391-2.5469-0.76562-0.65625-0.26953-1.2266-0.67969-1.7031-1.2344-0.46875-0.55078-0.70312-1.2891-0.70312-2.2188 0-0.76953 0.21875-1.4688 0.65625-2.0938 0.44531-0.63281 1.082-1.1328 1.9062-1.5 0.82031-0.375 1.7969-0.5625 2.9219-0.5625 1.6445 0 2.957 0.41797 3.9375 1.25 0.98828 0.82422 1.5312 1.9336 1.625 3.3281h-3.3438c-0.054688-0.55078-0.28125-0.98828-0.6875-1.3125-0.40625-0.32031-0.95312-0.48438-1.6406-0.48438-0.63672 0-1.125 0.12109-1.4688 0.35938-0.33594 0.23047-0.5 0.55469-0.5 0.96875 0 0.46094 0.22656 0.8125 0.6875 1.0625 0.46875 0.24219 1.1953 0.48438 2.1875 0.73438 1 0.25 1.8203 0.51172 2.4688 0.78125 0.65625 0.26172 1.2188 0.67188 1.6875 1.2344 0.47656 0.55469 0.72266 1.2891 0.73438 2.2031 0 0.80469-0.21875 1.5234-0.65625 2.1562-0.4375 0.63672-1.0742 1.1328-1.9062 1.4844-0.82422 0.35156-1.7812 0.53125-2.875 0.53125z"/>
-</g>
-<g transform="translate(1112.3 103.74)">
-<path d="m5.7969-10.969v6.6875c0 0.46875 0.10938 0.80859 0.32812 1.0156 0.22656 0.21094 0.61328 0.3125 1.1562 0.3125h1.625v2.9531h-2.2031c-2.9492 0-4.4219-1.4297-4.4219-4.2969v-6.6719h-1.6562v-2.875h1.6562v-3.4375h3.5156v3.4375h3.1094v2.875z"/>
-</g>
-<g transform="translate(1122 103.74)">
-<path d="m5.2188-11.703c0.45703-0.72656 1.0469-1.3008 1.7656-1.7188 0.72656-0.41406 1.5547-0.625 2.4844-0.625v3.6719h-0.92188c-1.0938 0-1.9219 0.26172-2.4844 0.78125-0.5625 0.51172-0.84375 1.4062-0.84375 2.6875v6.9062h-3.5v-13.844h3.5z"/>
-</g>
-<g transform="translate(1132.1 103.74)">
-<path d="m14.969-13.844-8.5625 20.391h-3.7344l3-6.8906-5.5469-13.5h3.9219l3.5781 9.6719 3.625-9.6719z"/>
-</g>
-<g transform="translate(1147.2 103.74)"/>
-<g transform="translate(1153.1 103.74)">
-<path d="m7.75 0.17188c-1.2188 0-2.3203-0.20703-3.2969-0.625-0.96875-0.41406-1.7422-1.0156-2.3125-1.7969-0.5625-0.78125-0.85156-1.707-0.85938-2.7812h3.75c0.039062 0.71875 0.28906 1.2891 0.75 1.7031 0.45703 0.41797 1.0859 0.625 1.8906 0.625 0.82031 0 1.4609-0.19141 1.9219-0.57812 0.46875-0.39453 0.70312-0.91016 0.70312-1.5469 0-0.50781-0.16406-0.92969-0.48438-1.2656-0.3125-0.33203-0.71094-0.59375-1.1875-0.78125-0.46875-0.19531-1.1211-0.41406-1.9531-0.65625-1.1367-0.33203-2.0586-0.66016-2.7656-0.98438-0.71094-0.32031-1.3203-0.8125-1.8281-1.4688-0.5-0.65625-0.75-1.5352-0.75-2.6406 0-1.0312 0.25391-1.9258 0.76562-2.6875 0.51953-0.76953 1.2422-1.3594 2.1719-1.7656 0.9375-0.41406 2.0039-0.625 3.2031-0.625 1.8008 0 3.2656 0.4375 4.3906 1.3125s1.7422 2.1016 1.8594 3.6719h-3.8438c-0.03125-0.60156-0.28906-1.0977-0.76562-1.4844-0.46875-0.39453-1.1016-0.59375-1.8906-0.59375-0.67969 0-1.2266 0.17969-1.6406 0.53125-0.40625 0.34375-0.60938 0.85156-0.60938 1.5156 0 0.46875 0.15625 0.85938 0.46875 1.1719 0.3125 0.30469 0.69531 0.55469 1.1562 0.75 0.45703 0.1875 1.1016 0.40625 1.9375 0.65625 1.125 0.33594 2.0469 0.66797 2.7656 1 0.71875 0.33594 1.332 0.83594 1.8438 1.5 0.51953 0.66797 0.78125 1.543 0.78125 2.625 0 0.92969-0.24609 1.793-0.73438 2.5938-0.48047 0.80469-1.1875 1.4453-2.125 1.9219-0.92969 0.46875-2.0312 0.70312-3.3125 0.70312z"/>
-</g>
-<g transform="translate(1168.4 103.74)">
-<path d="m5.2188-11.844c0.45703-0.63281 1.082-1.1641 1.875-1.5938 0.78906-0.42578 1.6914-0.64062 2.7031-0.64062 1.1875 0 2.2578 0.29297 3.2188 0.875 0.95703 0.58594 1.7109 1.418 2.2656 2.5 0.5625 1.0742 0.84375 2.3203 0.84375 3.7344 0 1.418-0.28125 2.6719-0.84375 3.7656-0.55469 1.0859-1.3086 1.9297-2.2656 2.5312-0.96094 0.59375-2.0312 0.89062-3.2188 0.89062-1.0117 0-1.9062-0.21094-2.6875-0.625-0.77344-0.41406-1.4023-0.9375-1.8906-1.5625v8.5625h-3.5v-20.438h3.5zm7.3281 4.875c0-0.83203-0.17188-1.5508-0.51562-2.1562-0.33594-0.61328-0.78125-1.0781-1.3438-1.3906-0.5625-0.32031-1.168-0.48438-1.8125-0.48438-0.63672 0-1.2344 0.16406-1.7969 0.48438-0.55469 0.32422-1 0.79688-1.3438 1.4219-0.34375 0.61719-0.51562 1.3398-0.51562 2.1719 0 0.83594 0.17188 1.5586 0.51562 2.1719 0.34375 0.61719 0.78906 1.0898 1.3438 1.4219 0.5625 0.32422 1.1602 0.48438 1.7969 0.48438 0.64453 0 1.25-0.16406 1.8125-0.5 0.5625-0.33203 1.0078-0.80469 1.3438-1.4219 0.34375-0.625 0.51562-1.3594 0.51562-2.2031z"/>
-</g>
-<g transform="translate(1185.3 103.74)">
-<path d="m14.594-7.2188c0 0.5-0.03125 0.94922-0.09375 1.3438h-10.125c0.082031 1 0.42969 1.7891 1.0469 2.3594 0.61328 0.5625 1.375 0.84375 2.2812 0.84375 1.3008 0 2.2227-0.55469 2.7656-1.6719h3.7812c-0.39844 1.3359-1.1641 2.4297-2.2969 3.2812-1.1367 0.85547-2.5273 1.2812-4.1719 1.2812-1.3359 0-2.5312-0.28906-3.5938-0.875-1.0625-0.59375-1.8906-1.4297-2.4844-2.5156-0.58594-1.082-0.875-2.332-0.875-3.75 0-1.4375 0.28906-2.6953 0.875-3.7812 0.58203-1.082 1.3945-1.9141 2.4375-2.5 1.0508-0.58203 2.2656-0.875 3.6406-0.875 1.3125 0 2.4883 0.28906 3.5312 0.85938 1.0391 0.5625 1.8477 1.3672 2.4219 2.4062 0.57031 1.043 0.85938 2.2422 0.85938 3.5938zm-3.625-1c-0.011719-0.90625-0.33594-1.6289-0.96875-2.1719-0.63672-0.53906-1.4141-0.8125-2.3281-0.8125-0.86719 0-1.5938 0.26562-2.1875 0.79688-0.59375 0.52344-0.95312 1.25-1.0781 2.1875z"/>
-</g>
-<g transform="translate(1200.7 103.74)">
-<path d="m0.82812-6.9219c0-1.4375 0.28906-2.6914 0.875-3.7656 0.58203-1.0703 1.3906-1.9062 2.4219-2.5s2.2109-0.89062 3.5469-0.89062c1.7188 0 3.1406 0.43359 4.2656 1.2969 1.125 0.85547 1.8789 2.0586 2.2656 3.6094h-3.7812c-0.19922-0.60156-0.53906-1.0703-1.0156-1.4062-0.46875-0.34375-1.0547-0.51562-1.75-0.51562-1 0-1.793 0.36719-2.375 1.0938-0.58594 0.71875-0.875 1.7461-0.875 3.0781 0 1.3125 0.28906 2.3359 0.875 3.0625 0.58203 0.71875 1.375 1.0781 2.375 1.0781 1.4141 0 2.3359-0.62891 2.7656-1.8906h3.7812c-0.38672 1.5-1.1484 2.6953-2.2812 3.5781-1.1367 0.875-2.5547 1.3125-4.25 1.3125-1.3359 0-2.5156-0.28906-3.5469-0.875-1.0312-0.59375-1.8398-1.4258-2.4219-2.5-0.58594-1.082-0.875-2.3359-0.875-3.7656z"/>
-</g>
-<g transform="translate(1215.8 103.74)">
-<path d="m3.5-15.5c-0.61719 0-1.1328-0.19141-1.5469-0.57812-0.40625-0.39453-0.60938-0.88281-0.60938-1.4688 0-0.58203 0.20312-1.0664 0.60938-1.4531 0.41406-0.39453 0.92969-0.59375 1.5469-0.59375 0.61328 0 1.125 0.19922 1.5312 0.59375 0.41406 0.38672 0.625 0.87109 0.625 1.4531 0 0.58594-0.21094 1.0742-0.625 1.4688-0.40625 0.38672-0.91797 0.57812-1.5312 0.57812zm1.7188 1.6562v13.844h-3.5v-13.844z"/>
-</g>
-<g transform="translate(1222.7 103.74)">
-<path d="m8.0781-10.969h-2.4219v10.969h-3.5625v-10.969h-1.5625v-2.875h1.5625v-0.70312c0-1.6953 0.48438-2.9453 1.4531-3.75 0.96875-0.80078 2.4258-1.1758 4.375-1.125v2.9531c-0.84375-0.019531-1.4336 0.12109-1.7656 0.42188-0.33594 0.30469-0.5 0.84375-0.5 1.625v0.57812h2.4219z"/>
-</g>
-<g transform="translate(1231.3 103.74)">
-<path d="m3.5-15.5c-0.61719 0-1.1328-0.19141-1.5469-0.57812-0.40625-0.39453-0.60938-0.88281-0.60938-1.4688 0-0.58203 0.20312-1.0664 0.60938-1.4531 0.41406-0.39453 0.92969-0.59375 1.5469-0.59375 0.61328 0 1.125 0.19922 1.5312 0.59375 0.41406 0.38672 0.625 0.87109 0.625 1.4531 0 0.58594-0.21094 1.0742-0.625 1.4688-0.40625 0.38672-0.91797 0.57812-1.5312 0.57812zm1.7188 1.6562v13.844h-3.5v-13.844z"/>
-</g>
-<g transform="translate(1238.3 103.74)">
-<path d="m0.82812-6.9219c0-1.4375 0.28906-2.6914 0.875-3.7656 0.58203-1.0703 1.3906-1.9062 2.4219-2.5s2.2109-0.89062 3.5469-0.89062c1.7188 0 3.1406 0.43359 4.2656 1.2969 1.125 0.85547 1.8789 2.0586 2.2656 3.6094h-3.7812c-0.19922-0.60156-0.53906-1.0703-1.0156-1.4062-0.46875-0.34375-1.0547-0.51562-1.75-0.51562-1 0-1.793 0.36719-2.375 1.0938-0.58594 0.71875-0.875 1.7461-0.875 3.0781 0 1.3125 0.28906 2.3359 0.875 3.0625 0.58203 0.71875 1.375 1.0781 2.375 1.0781 1.4141 0 2.3359-0.62891 2.7656-1.8906h3.7812c-0.38672 1.5-1.1484 2.6953-2.2812 3.5781-1.1367 0.875-2.5547 1.3125-4.25 1.3125-1.3359 0-2.5156-0.28906-3.5469-0.875-1.0312-0.59375-1.8398-1.4258-2.4219-2.5-0.58594-1.082-0.875-2.3359-0.875-3.7656z"/>
-</g>
-<g transform="translate(1253.3 103.74)"/>
-<g transform="translate(1259.3 103.74)">
-<path d="m10.719 0-3.8438-6.7969h-1.6562v6.7969h-3.5v-17.453h6.5625c1.3438 0 2.4883 0.24219 3.4375 0.71875 0.95703 0.46875 1.6719 1.1094 2.1406 1.9219 0.47656 0.8125 0.71875 1.7188 0.71875 2.7188 0 1.1484-0.33594 2.1836-1 3.1094-0.66797 0.92969-1.6641 1.5625-2.9844 1.9062l4.1875 7.0781zm-5.5-9.4219h2.9375c0.94531 0 1.6484-0.22656 2.1094-0.6875 0.46875-0.45703 0.70312-1.0977 0.70312-1.9219 0-0.78906-0.23438-1.4062-0.70312-1.8438-0.46094-0.44531-1.1641-0.67188-2.1094-0.67188h-2.9375z"/>
-</g>
-<g transform="translate(1275.3 103.74)">
-<path d="m14.594-7.2188c0 0.5-0.03125 0.94922-0.09375 1.3438h-10.125c0.082031 1 0.42969 1.7891 1.0469 2.3594 0.61328 0.5625 1.375 0.84375 2.2812 0.84375 1.3008 0 2.2227-0.55469 2.7656-1.6719h3.7812c-0.39844 1.3359-1.1641 2.4297-2.2969 3.2812-1.1367 0.85547-2.5273 1.2812-4.1719 1.2812-1.3359 0-2.5312-0.28906-3.5938-0.875-1.0625-0.59375-1.8906-1.4297-2.4844-2.5156-0.58594-1.082-0.875-2.332-0.875-3.75 0-1.4375 0.28906-2.6953 0.875-3.7812 0.58203-1.082 1.3945-1.9141 2.4375-2.5 1.0508-0.58203 2.2656-0.875 3.6406-0.875 1.3125 0 2.4883 0.28906 3.5312 0.85938 1.0391 0.5625 1.8477 1.3672 2.4219 2.4062 0.57031 1.043 0.85938 2.2422 0.85938 3.5938zm-3.625-1c-0.011719-0.90625-0.33594-1.6289-0.96875-2.1719-0.63672-0.53906-1.4141-0.8125-2.3281-0.8125-0.86719 0-1.5938 0.26562-2.1875 0.79688-0.59375 0.52344-0.95312 1.25-1.0781 2.1875z"/>
-</g>
-<g transform="translate(1290.7 103.74)">
-<path d="m7.1562-14.078c1.0312 0 1.9375 0.21094 2.7188 0.625 0.78125 0.40625 1.3945 0.93359 1.8438 1.5781v-1.9688h3.5312v13.938c0 1.2891-0.26172 2.4375-0.78125 3.4375-0.51172 1.0078-1.2891 1.8125-2.3281 2.4062-1.0312 0.59375-2.2773 0.89062-3.7344 0.89062-1.9688 0-3.5859-0.46094-4.8438-1.375-1.2617-0.91797-1.9766-2.168-2.1406-3.75h3.4844c0.17578 0.63281 0.56641 1.1406 1.1719 1.5156 0.61328 0.375 1.3516 0.5625 2.2188 0.5625 1.0195 0 1.8438-0.30859 2.4688-0.92188 0.63281-0.60547 0.95312-1.5273 0.95312-2.7656v-2.1406c-0.44922 0.64844-1.0703 1.1875-1.8594 1.625-0.79297 0.42578-1.6953 0.64062-2.7031 0.64062-1.168 0-2.2344-0.29688-3.2031-0.89062-0.96875-0.60156-1.7344-1.4453-2.2969-2.5312-0.55469-1.0938-0.82812-2.3477-0.82812-3.7656 0-1.4062 0.27344-2.6484 0.82812-3.7344 0.5625-1.082 1.3203-1.9141 2.2812-2.5 0.95703-0.58203 2.0312-0.875 3.2188-0.875zm4.5625 7.1562c0-0.85156-0.16797-1.582-0.5-2.1875-0.33594-0.61328-0.78125-1.082-1.3438-1.4062-0.5625-0.32031-1.1719-0.48438-1.8281-0.48438-0.64844 0-1.2461 0.16406-1.7969 0.48438-0.55469 0.3125-1 0.77734-1.3438 1.3906-0.33594 0.60547-0.5 1.3242-0.5 2.1562 0 0.83594 0.16406 1.5625 0.5 2.1875 0.34375 0.625 0.78906 1.1055 1.3438 1.4375 0.5625 0.33594 1.1602 0.5 1.7969 0.5 0.65625 0 1.2656-0.16016 1.8281-0.48438 0.5625-0.33203 1.0078-0.80078 1.3438-1.4062 0.33203-0.61328 0.5-1.3438 0.5-2.1875z"/>
-</g>
-<g transform="translate(1307.7 103.74)">
-<path d="m14.797-13.844v13.844h-3.5156v-1.75c-0.46094 0.60547-1.0547 1.0781-1.7812 1.4219-0.71875 0.33203-1.5 0.5-2.3438 0.5-1.0859 0-2.043-0.22656-2.875-0.6875-0.83594-0.45703-1.4922-1.1289-1.9688-2.0156-0.48047-0.89453-0.71875-1.957-0.71875-3.1875v-8.125h3.5v7.625c0 1.0938 0.27344 1.9375 0.82812 2.5312 0.55078 0.59375 1.3008 0.89062 2.25 0.89062 0.96875 0 1.7266-0.29688 2.2812-0.89062 0.55078-0.59375 0.82812-1.4375 0.82812-2.5312v-7.625z"/>
-</g>
-<g transform="translate(1324.2 103.74)">
-<path d="m5.2188-18.5v18.5h-3.5v-18.5z"/>
-</g>
-<g transform="translate(1331.2 103.74)">
-<path d="m0.82812-6.9688c0-1.4062 0.27344-2.6484 0.82812-3.7344 0.5625-1.082 1.3203-1.9141 2.2812-2.5 0.95703-0.58203 2.0312-0.875 3.2188-0.875 1.0312 0 1.9297 0.21094 2.7031 0.625 0.78125 0.41797 1.3984 0.94531 1.8594 1.5781v-1.9688h3.5312v13.844h-3.5312v-2.0312c-0.44922 0.65625-1.0703 1.1992-1.8594 1.625-0.79297 0.41406-1.7031 0.625-2.7344 0.625-1.168 0-2.2305-0.29688-3.1875-0.89062-0.96094-0.60156-1.7188-1.4453-2.2812-2.5312-0.55469-1.0938-0.82812-2.3477-0.82812-3.7656zm10.891 0.046875c0-0.85156-0.16797-1.582-0.5-2.1875-0.33594-0.61328-0.78125-1.082-1.3438-1.4062-0.5625-0.32031-1.1719-0.48438-1.8281-0.48438-0.64844 0-1.2461 0.16406-1.7969 0.48438-0.55469 0.3125-1 0.77734-1.3438 1.3906-0.33594 0.60547-0.5 1.3242-0.5 2.1562 0 0.83594 0.16406 1.5625 0.5 2.1875 0.34375 0.625 0.78906 1.1055 1.3438 1.4375 0.5625 0.33594 1.1602 0.5 1.7969 0.5 0.65625 0 1.2656-0.16016 1.8281-0.48438 0.5625-0.33203 1.0078-0.80078 1.3438-1.4062 0.33203-0.61328 0.5-1.3438 0.5-2.1875z"/>
-</g>
-<g transform="translate(1348.1 103.74)">
-<path d="m5.7969-10.969v6.6875c0 0.46875 0.10938 0.80859 0.32812 1.0156 0.22656 0.21094 0.61328 0.3125 1.1562 0.3125h1.625v2.9531h-2.2031c-2.9492 0-4.4219-1.4297-4.4219-4.2969v-6.6719h-1.6562v-2.875h1.6562v-3.4375h3.5156v3.4375h3.1094v2.875z"/>
-</g>
-<g transform="translate(1357.8 103.74)">
-<path d="m3.5-15.5c-0.61719 0-1.1328-0.19141-1.5469-0.57812-0.40625-0.39453-0.60938-0.88281-0.60938-1.4688 0-0.58203 0.20312-1.0664 0.60938-1.4531 0.41406-0.39453 0.92969-0.59375 1.5469-0.59375 0.61328 0 1.125 0.19922 1.5312 0.59375 0.41406 0.38672 0.625 0.87109 0.625 1.4531 0 0.58594-0.21094 1.0742-0.625 1.4688-0.40625 0.38672-0.91797 0.57812-1.5312 0.57812zm1.7188 1.6562v13.844h-3.5v-13.844z"/>
-</g>
-<g transform="translate(1364.7 103.74)">
-<path d="m7.875 0.21875c-1.3359 0-2.5391-0.28906-3.6094-0.875-1.0625-0.59375-1.9023-1.4297-2.5156-2.5156-0.60547-1.082-0.90625-2.332-0.90625-3.75 0-1.4141 0.3125-2.6641 0.9375-3.75 0.625-1.082 1.4766-1.9219 2.5625-2.5156 1.082-0.59375 2.2891-0.89062 3.625-0.89062 1.332 0 2.5391 0.29688 3.625 0.89062 1.082 0.59375 1.9375 1.4336 2.5625 2.5156 0.625 1.0859 0.9375 2.3359 0.9375 3.75 0 1.418-0.32422 2.668-0.96875 3.75-0.63672 1.0859-1.5 1.9219-2.5938 2.5156-1.0859 0.58594-2.3047 0.875-3.6562 0.875zm0-3.0469c0.63281 0 1.2266-0.14844 1.7812-0.45312 0.5625-0.3125 1.0078-0.77344 1.3438-1.3906 0.33203-0.61328 0.5-1.3633 0.5-2.25 0-1.3203-0.35156-2.3359-1.0469-3.0469-0.6875-0.70703-1.5312-1.0625-2.5312-1.0625s-1.8398 0.35547-2.5156 1.0625c-0.66797 0.71094-1 1.7266-1 3.0469 0 1.3125 0.32812 2.3242 0.98438 3.0312 0.65625 0.71094 1.4844 1.0625 2.4844 1.0625z"/>
-</g>
-<g transform="translate(1380.7 103.74)">
-<path d="m9.4062-14.047c1.6445 0 2.9727 0.52344 3.9844 1.5625 1.0195 1.043 1.5312 2.4961 1.5312 4.3594v8.125h-3.5v-7.6562c0-1.0938-0.27734-1.9375-0.82812-2.5312-0.54297-0.59375-1.293-0.89062-2.25-0.89062-0.96094 0-1.7188 0.29688-2.2812 0.89062s-0.84375 1.4375-0.84375 2.5312v7.6562h-3.5v-13.844h3.5v1.7188c0.46875-0.60156 1.0625-1.0703 1.7812-1.4062 0.72656-0.34375 1.5312-0.51562 2.4062-0.51562z"/>
-</g>
-<g transform="translate(1397.2 103.74)">
-<path d="m7.0312 0.21875c-1.1367 0-2.1562-0.20312-3.0625-0.60938-0.89844-0.40625-1.6094-0.95703-2.1406-1.6562-0.52344-0.69531-0.80859-1.4727-0.85938-2.3281h3.5312c0.0625 0.53125 0.32031 0.97656 0.78125 1.3281 0.45703 0.34375 1.0312 0.51562 1.7188 0.51562 0.66406 0 1.1875-0.12891 1.5625-0.39062 0.375-0.26953 0.5625-0.61328 0.5625-1.0312 0-0.44531-0.23047-0.78125-0.6875-1-0.46094-0.22656-1.1875-0.47656-2.1875-0.75-1.0312-0.25-1.8828-0.50391-2.5469-0.76562-0.65625-0.26953-1.2266-0.67969-1.7031-1.2344-0.46875-0.55078-0.70312-1.2891-0.70312-2.2188 0-0.76953 0.21875-1.4688 0.65625-2.0938 0.44531-0.63281 1.082-1.1328 1.9062-1.5 0.82031-0.375 1.7969-0.5625 2.9219-0.5625 1.6445 0 2.957 0.41797 3.9375 1.25 0.98828 0.82422 1.5312 1.9336 1.625 3.3281h-3.3438c-0.054688-0.55078-0.28125-0.98828-0.6875-1.3125-0.40625-0.32031-0.95312-0.48438-1.6406-0.48438-0.63672 0-1.125 0.12109-1.4688 0.35938-0.33594 0.23047-0.5 0.55469-0.5 0.96875 0 0.46094 0.22656 0.8125 0.6875 1.0625 0.46875 0.24219 1.1953 0.48438 2.1875 0.73438 1 0.25 1.8203 0.51172 2.4688 0.78125 0.65625 0.26172 1.2188 0.67188 1.6875 1.2344 0.47656 0.55469 0.72266 1.2891 0.73438 2.2031 0 0.80469-0.21875 1.5234-0.65625 2.1562-0.4375 0.63672-1.0742 1.1328-1.9062 1.4844-0.82422 0.35156-1.7812 0.53125-2.875 0.53125z"/>
-</g>
-<g transform="translate(1410.8 103.74)"/>
-</g>
-<g fill="#192131">
-<g transform="translate(1084.4 205.5)">
-<path d="m15.516 0h-2.5v-9.6094h-8.5156v9.6094h-2.4844v-20.766h2.4844v8.9219h8.5156v-8.9219h2.5z"/>
-</g>
-<g transform="translate(1101.9 205.5)">
-<path d="m9.2969 0.28125c-1.0859 0-2.0781-0.18359-2.9844-0.54688-0.90625-0.375-1.6836-0.89453-2.3281-1.5625-0.64844-0.66406-1.1523-1.4531-1.5156-2.3594-0.36719-0.91406-0.54688-1.9102-0.54688-2.9844v-0.60938c0-1.2383 0.19531-2.3477 0.59375-3.3281 0.40625-0.98828 0.9375-1.8203 1.5938-2.5 0.66406-0.6875 1.4219-1.207 2.2656-1.5625 0.84375-0.36328 1.7031-0.54688 2.5781-0.54688 1.1133 0 2.0859 0.19531 2.9219 0.57812 0.83203 0.38672 1.5234 0.91797 2.0781 1.5938 0.55078 0.67969 0.96094 1.4805 1.2344 2.4062 0.26953 0.91797 0.40625 1.918 0.40625 3v1.1719h-11.031c0.03125 0.71094 0.16406 1.375 0.40625 2 0.23828 0.61719 0.57031 1.1523 1 1.6094 0.42578 0.46094 0.92969 0.82422 1.5156 1.0938 0.59375 0.26172 1.2422 0.39062 1.9531 0.39062 0.94531 0 1.7852-0.1875 2.5156-0.5625 0.72656-0.38281 1.3359-0.89062 1.8281-1.5156l1.6094 1.25c-0.25 0.39844-0.57031 0.77344-0.95312 1.125-0.38672 0.35547-0.83594 0.67188-1.3438 0.95312-0.5 0.27344-1.0742 0.49219-1.7188 0.65625-0.63672 0.16406-1.3281 0.25-2.0781 0.25zm-0.34375-13.828c-0.53125 0-1.0391 0.10156-1.5156 0.29688-0.46875 0.1875-0.89844 0.46875-1.2812 0.84375-0.375 0.375-0.69531 0.83984-0.95312 1.3906-0.26172 0.54297-0.44531 1.1719-0.54688 1.8906h8.2969v-0.20312c-0.03125-0.50781-0.13281-1.0156-0.29688-1.5156-0.16797-0.50781-0.41406-0.96094-0.73438-1.3594-0.32422-0.40625-0.73047-0.72656-1.2188-0.96875-0.49219-0.25-1.0742-0.375-1.75-0.375z"/>
-</g>
-<g transform="translate(1119.5 205.5)">
-<path d="m12.625 0c-0.10547-0.19531-0.1875-0.44531-0.25-0.75-0.0625-0.30078-0.10938-0.61328-0.14062-0.9375-0.26172 0.27344-0.55859 0.52734-0.89062 0.76562-0.32422 0.23047-0.68359 0.4375-1.0781 0.625-0.39844 0.17969-0.82031 0.31641-1.2656 0.42188-0.44922 0.10156-0.92188 0.15625-1.4219 0.15625-0.82422 0-1.5703-0.11719-2.2344-0.34375-0.65625-0.23828-1.2148-0.5625-1.6719-0.96875-0.46094-0.40625-0.82031-0.88281-1.0781-1.4375-0.25-0.5625-0.375-1.1641-0.375-1.8125 0-0.84375 0.16406-1.582 0.5-2.2188 0.34375-0.64453 0.82031-1.1758 1.4375-1.5938 0.625-0.42578 1.3672-0.74219 2.2344-0.95312 0.875-0.20703 1.8477-0.3125 2.9219-0.3125h2.8906v-1.2188c0-0.45703-0.089844-0.875-0.26562-1.25-0.16797-0.375-0.40625-0.69141-0.71875-0.95312-0.3125-0.25781-0.69922-0.45703-1.1562-0.59375-0.44922-0.14453-0.95312-0.21875-1.5156-0.21875-0.52344 0-0.99219 0.070312-1.4062 0.20312-0.41797 0.125-0.77344 0.29688-1.0625 0.51562-0.28125 0.21875-0.5 0.48047-0.65625 0.78125-0.15625 0.30469-0.23438 0.61719-0.23438 0.9375h-2.6406c0-0.5625 0.14062-1.1133 0.42188-1.6562 0.28125-0.53906 0.6875-1.0234 1.2188-1.4531 0.53125-0.4375 1.1719-0.78516 1.9219-1.0469 0.75781-0.26953 1.6172-0.40625 2.5781-0.40625 0.875 0 1.6875 0.10938 2.4375 0.32812 0.75 0.21094 1.3945 0.53125 1.9375 0.96875 0.55078 0.42969 0.98438 0.96484 1.2969 1.6094 0.32031 0.64844 0.48438 1.4023 0.48438 2.2656v7.1875c0 0.51172 0.046875 1.0547 0.14062 1.625 0.09375 0.57422 0.22266 1.0742 0.39062 1.5v0.23438zm-4.6562-2.0156c0.50781 0 0.98828-0.0625 1.4375-0.1875 0.44531-0.13281 0.85156-0.3125 1.2188-0.53125 0.36328-0.21875 0.67578-0.46875 0.9375-0.75 0.26953-0.28125 0.48438-0.57031 0.64062-0.875v-3.125h-2.4531c-1.543 0-2.7461 0.23047-3.6094 0.6875-0.85547 0.44922-1.2812 1.1641-1.2812 2.1406 0 0.38672 0.0625 0.74219 0.1875 1.0625 0.13281 0.32422 0.32812 0.60547 0.57812 0.84375 0.25781 0.23047 0.58203 0.41406 0.96875 0.54688 0.39453 0.125 0.85156 0.1875 1.375 0.1875z"/>
-</g>
-<g transform="translate(1137 205.5)">
-<path d="m2.8906-21.922h7.8906v19.641h5.0469v2.2812h-12.938v-2.2812h5.25v-17.328h-5.25z"/>
-</g>
-<g transform="translate(1154.5 205.5)">
-<path d="m8.7344-19.172v3.7344h5.875v2.0469h-5.875v8.3906c0 0.59375 0.070313 1.0898 0.21875 1.4844 0.15625 0.38672 0.36328 0.69922 0.625 0.9375 0.26953 0.23047 0.57812 0.39062 0.92188 0.48438 0.35156 0.09375 0.72266 0.14062 1.1094 0.14062 0.28906 0 0.58594-0.015625 0.89062-0.046875 0.30078-0.03125 0.59766-0.070312 0.89062-0.125 0.28906-0.050781 0.5625-0.10156 0.8125-0.15625 0.25-0.050781 0.45703-0.09375 0.625-0.125l0.35938 1.8594c-0.21875 0.13672-0.48438 0.25781-0.79688 0.35938-0.3125 0.09375-0.65625 0.17969-1.0312 0.25-0.36719 0.070312-0.75781 0.125-1.1719 0.15625-0.40625 0.039062-0.82031 0.0625-1.2344 0.0625-0.67969 0-1.3203-0.09375-1.9219-0.28125-0.59375-0.19531-1.1094-0.50391-1.5469-0.92188-0.4375-0.42578-0.78125-0.97266-1.0312-1.6406-0.25-0.67578-0.375-1.4883-0.375-2.4375v-8.3906h-4.0469v-2.0469h4.0469v-3.7344z"/>
-</g>
-<g transform="translate(1172.1 205.5)">
-<path d="m5.125-13.141c0.55078-0.8125 1.2266-1.4414 2.0312-1.8906 0.8125-0.44531 1.7227-0.67578 2.7344-0.6875 0.80078 0 1.5312 0.12109 2.1875 0.35938 0.66406 0.23047 1.2344 0.58984 1.7031 1.0781 0.46875 0.49219 0.82812 1.1172 1.0781 1.875 0.25 0.76172 0.375 1.6562 0.375 2.6875v9.7188h-2.6406v-9.75c0-1.2578-0.30469-2.1953-0.90625-2.8125-0.60547-0.625-1.4648-0.92969-2.5781-0.92188-0.85547 0-1.625 0.21094-2.3125 0.625-0.6875 0.41797-1.2461 0.96484-1.6719 1.6406v11.219h-2.6406v-21.922h2.6406z"/>
-</g>
-<g transform="translate(1189.6 205.5)">
-<path d="m9.0625-1.8594c0.46875 0 0.92578-0.070313 1.375-0.21875 0.45703-0.15625 0.86328-0.36719 1.2188-0.64062 0.35156-0.26953 0.63281-0.58594 0.84375-0.95312 0.21875-0.36328 0.33203-0.75781 0.34375-1.1875h2.5c-0.011719 0.67969-0.19531 1.3281-0.54688 1.9531-0.34375 0.625-0.80859 1.1719-1.3906 1.6406-0.57422 0.46875-1.2422 0.84375-2 1.125-0.75 0.28125-1.5312 0.42188-2.3438 0.42188-1.168 0-2.1953-0.21094-3.0781-0.625-0.875-0.41406-1.6055-0.97656-2.1875-1.6875-0.58594-0.70703-1.0234-1.5234-1.3125-2.4531-0.29297-0.92578-0.4375-1.9062-0.4375-2.9375v-0.59375c0-1.0195 0.14453-1.9922 0.4375-2.9219 0.28906-0.9375 0.72656-1.7578 1.3125-2.4688 0.58203-0.70703 1.3125-1.2695 2.1875-1.6875 0.88281-0.41406 1.9102-0.625 3.0781-0.625 0.90625 0 1.7383 0.14844 2.5 0.4375 0.76953 0.28125 1.4297 0.67188 1.9844 1.1719 0.5625 0.5 1 1.0938 1.3125 1.7812 0.32031 0.6875 0.48438 1.4219 0.48438 2.2031h-2.5c-0.011719-0.46875-0.11719-0.90625-0.3125-1.3125-0.19922-0.41406-0.46484-0.78125-0.79688-1.0938-0.32422-0.32031-0.71875-0.57031-1.1875-0.75-0.46094-0.17578-0.95312-0.26562-1.4844-0.26562-0.82422 0-1.5156 0.16797-2.0781 0.5-0.55469 0.32422-1 0.75-1.3438 1.2812-0.33594 0.52344-0.57812 1.1094-0.73438 1.7656-0.14844 0.65625-0.21875 1.3203-0.21875 1.9844v0.59375c0 0.67969 0.070312 1.3516 0.21875 2.0156 0.15625 0.65625 0.39844 1.25 0.73438 1.7812 0.34375 0.52344 0.78906 0.94922 1.3438 1.2812 0.55078 0.32422 1.2422 0.48438 2.0781 0.48438z"/>
-</g>
-<g transform="translate(1207.1 205.5)">
-<path d="m12.625 0c-0.10547-0.19531-0.1875-0.44531-0.25-0.75-0.0625-0.30078-0.10938-0.61328-0.14062-0.9375-0.26172 0.27344-0.55859 0.52734-0.89062 0.76562-0.32422 0.23047-0.68359 0.4375-1.0781 0.625-0.39844 0.17969-0.82031 0.31641-1.2656 0.42188-0.44922 0.10156-0.92188 0.15625-1.4219 0.15625-0.82422 0-1.5703-0.11719-2.2344-0.34375-0.65625-0.23828-1.2148-0.5625-1.6719-0.96875-0.46094-0.40625-0.82031-0.88281-1.0781-1.4375-0.25-0.5625-0.375-1.1641-0.375-1.8125 0-0.84375 0.16406-1.582 0.5-2.2188 0.34375-0.64453 0.82031-1.1758 1.4375-1.5938 0.625-0.42578 1.3672-0.74219 2.2344-0.95312 0.875-0.20703 1.8477-0.3125 2.9219-0.3125h2.8906v-1.2188c0-0.45703-0.089844-0.875-0.26562-1.25-0.16797-0.375-0.40625-0.69141-0.71875-0.95312-0.3125-0.25781-0.69922-0.45703-1.1562-0.59375-0.44922-0.14453-0.95312-0.21875-1.5156-0.21875-0.52344 0-0.99219 0.070312-1.4062 0.20312-0.41797 0.125-0.77344 0.29688-1.0625 0.51562-0.28125 0.21875-0.5 0.48047-0.65625 0.78125-0.15625 0.30469-0.23438 0.61719-0.23438 0.9375h-2.6406c0-0.5625 0.14062-1.1133 0.42188-1.6562 0.28125-0.53906 0.6875-1.0234 1.2188-1.4531 0.53125-0.4375 1.1719-0.78516 1.9219-1.0469 0.75781-0.26953 1.6172-0.40625 2.5781-0.40625 0.875 0 1.6875 0.10938 2.4375 0.32812 0.75 0.21094 1.3945 0.53125 1.9375 0.96875 0.55078 0.42969 0.98438 0.96484 1.2969 1.6094 0.32031 0.64844 0.48438 1.4023 0.48438 2.2656v7.1875c0 0.51172 0.046875 1.0547 0.14062 1.625 0.09375 0.57422 0.22266 1.0742 0.39062 1.5v0.23438zm-4.6562-2.0156c0.50781 0 0.98828-0.0625 1.4375-0.1875 0.44531-0.13281 0.85156-0.3125 1.2188-0.53125 0.36328-0.21875 0.67578-0.46875 0.9375-0.75 0.26953-0.28125 0.48438-0.57031 0.64062-0.875v-3.125h-2.4531c-1.543 0-2.7461 0.23047-3.6094 0.6875-0.85547 0.44922-1.2812 1.1641-1.2812 2.1406 0 0.38672 0.0625 0.74219 0.1875 1.0625 0.13281 0.32422 0.32812 0.60547 0.57812 0.84375 0.25781 0.23047 0.58203 0.41406 0.96875 0.54688 0.39453 0.125 0.85156 0.1875 1.375 0.1875z"/>
-</g>
-<g transform="translate(1224.7 205.5)">
-<path d="m12.594-15.719c0.25 0 0.50391 0.011719 0.76562 0.03125 0.26953 0.011719 0.52344 0.03125 0.76562 0.0625 0.25 0.03125 0.47266 0.074219 0.67188 0.125 0.20703 0.042969 0.37891 0.09375 0.51562 0.15625l-0.35938 2.5781c-0.51172-0.11328-1-0.19531-1.4688-0.25-0.46094-0.050781-0.9375-0.078125-1.4375-0.078125-1.2422 0-2.2461 0.28125-3.0156 0.84375-0.76172 0.5625-1.3242 1.3438-1.6875 2.3438v9.9062h-2.6562v-15.438h2.5156l0.125 2.4531c0.63281-0.84375 1.3906-1.5078 2.2656-2 0.88281-0.48828 1.8828-0.73438 3-0.73438z"/>
-</g>
-<g transform="translate(1242.2 205.5)">
-<path d="m9.2969 0.28125c-1.0859 0-2.0781-0.18359-2.9844-0.54688-0.90625-0.375-1.6836-0.89453-2.3281-1.5625-0.64844-0.66406-1.1523-1.4531-1.5156-2.3594-0.36719-0.91406-0.54688-1.9102-0.54688-2.9844v-0.60938c0-1.2383 0.19531-2.3477 0.59375-3.3281 0.40625-0.98828 0.9375-1.8203 1.5938-2.5 0.66406-0.6875 1.4219-1.207 2.2656-1.5625 0.84375-0.36328 1.7031-0.54688 2.5781-0.54688 1.1133 0 2.0859 0.19531 2.9219 0.57812 0.83203 0.38672 1.5234 0.91797 2.0781 1.5938 0.55078 0.67969 0.96094 1.4805 1.2344 2.4062 0.26953 0.91797 0.40625 1.918 0.40625 3v1.1719h-11.031c0.03125 0.71094 0.16406 1.375 0.40625 2 0.23828 0.61719 0.57031 1.1523 1 1.6094 0.42578 0.46094 0.92969 0.82422 1.5156 1.0938 0.59375 0.26172 1.2422 0.39062 1.9531 0.39062 0.94531 0 1.7852-0.1875 2.5156-0.5625 0.72656-0.38281 1.3359-0.89062 1.8281-1.5156l1.6094 1.25c-0.25 0.39844-0.57031 0.77344-0.95312 1.125-0.38672 0.35547-0.83594 0.67188-1.3438 0.95312-0.5 0.27344-1.0742 0.49219-1.7188 0.65625-0.63672 0.16406-1.3281 0.25-2.0781 0.25zm-0.34375-13.828c-0.53125 0-1.0391 0.10156-1.5156 0.29688-0.46875 0.1875-0.89844 0.46875-1.2812 0.84375-0.375 0.375-0.69531 0.83984-0.95312 1.3906-0.26172 0.54297-0.44531 1.1719-0.54688 1.8906h8.2969v-0.20312c-0.03125-0.50781-0.13281-1.0156-0.29688-1.5156-0.16797-0.50781-0.41406-0.96094-0.73438-1.3594-0.32422-0.40625-0.73047-0.72656-1.2188-0.96875-0.49219-0.25-1.0742-0.375-1.75-0.375z"/>
-</g>
-</g>
-<path d="m70.582 265.63h112.28c7.4531 0 13.5 6.0469 13.5 13.5v27c0 7.457-6.0469 13.5-13.5 13.5h-112.28c-7.457 0-13.5-6.043-13.5-13.5v-27c0-7.4531 6.043-13.5 13.5-13.5z" fill="#b8d2ff"/>
-<g fill="#303b54">
-<g transform="translate(69.08 303.13)">
-<path d="m17.344-14.453c0 1.1172-0.26562 2.1641-0.79688 3.1406-0.53125 0.98047-1.3672 1.7734-2.5 2.375-1.125 0.59375-2.5469 0.89062-4.2656 0.89062h-3.5156v8.0469h-4.2031v-20.938h7.7188c1.6133 0 2.9883 0.28125 4.125 0.84375 1.1445 0.55469 2.0039 1.3242 2.5781 2.3125 0.57031 0.98047 0.85938 2.0898 0.85938 3.3281zm-7.75 3.0156c1.1641 0 2.0234-0.25781 2.5781-0.78125 0.5625-0.53125 0.84375-1.2734 0.84375-2.2344 0-2.0391-1.1406-3.0625-3.4219-3.0625h-3.3281v6.0781z"/>
-</g>
-<g transform="translate(87.313 303.13)">
-<path d="m9.4531 0.26562c-1.6055 0-3.0469-0.35156-4.3281-1.0625-1.2812-0.70703-2.2891-1.7109-3.0156-3.0156-0.73047-1.3008-1.0938-2.8008-1.0938-4.5 0-1.6953 0.375-3.1953 1.125-4.5 0.75-1.3008 1.7734-2.3047 3.0781-3.0156 1.3008-0.70703 2.75-1.0625 4.3438-1.0625 1.6016 0 3.0547 0.35547 4.3594 1.0625 1.3008 0.71094 2.3281 1.7148 3.0781 3.0156 0.75 1.3047 1.125 2.8047 1.125 4.5 0 1.6992-0.38672 3.1992-1.1562 4.5-0.77344 1.3047-1.8125 2.3086-3.125 3.0156-1.3125 0.71094-2.7773 1.0625-4.3906 1.0625zm0-3.6562c0.75781 0 1.4727-0.17969 2.1406-0.54688 0.66406-0.375 1.1953-0.92969 1.5938-1.6719 0.40625-0.73828 0.60938-1.6406 0.60938-2.7031 0-1.582-0.41797-2.7969-1.25-3.6406-0.82422-0.85156-1.8359-1.2812-3.0312-1.2812-1.2109 0-2.2188 0.42969-3.0312 1.2812-0.80469 0.84375-1.2031 2.0586-1.2031 3.6406 0 1.5859 0.39453 2.8047 1.1875 3.6562 0.78906 0.84375 1.7852 1.2656 2.9844 1.2656z"/>
-</g>
-<g transform="translate(106.45 303.13)">
-<path d="m6.2656-22.203v22.203h-4.2031v-22.203z"/>
-</g>
-<g transform="translate(114.78 303.13)">
-<path d="m4.2031-18.594c-0.74219 0-1.3555-0.23438-1.8438-0.70312-0.49219-0.47656-0.73438-1.0664-0.73438-1.7656 0-0.69531 0.24219-1.2812 0.73438-1.75 0.48828-0.46875 1.1016-0.70312 1.8438-0.70312 0.73828 0 1.3516 0.23438 1.8438 0.70312 0.48828 0.46875 0.73438 1.0547 0.73438 1.75 0 0.69922-0.24609 1.2891-0.73438 1.7656-0.49219 0.46875-1.1055 0.70312-1.8438 0.70312zm2.0625 1.9688v16.625h-4.2031v-16.625z"/>
-</g>
-<g transform="translate(123.12 303.13)">
-<path d="m0.98438-8.3125c0-1.7188 0.34766-3.2227 1.0469-4.5156 0.70703-1.2891 1.6797-2.2891 2.9219-3 1.2383-0.70703 2.6562-1.0625 4.25-1.0625 2.0625 0 3.7656 0.51562 5.1094 1.5469 1.3516 1.0312 2.2656 2.4766 2.7344 4.3281h-4.5312c-0.24219-0.71875-0.64844-1.2812-1.2188-1.6875-0.57422-0.40625-1.2773-0.60938-2.1094-0.60938-1.2109 0-2.1641 0.4375-2.8594 1.3125-0.69922 0.86719-1.0469 2.0938-1.0469 3.6875 0 1.5859 0.34766 2.8125 1.0469 3.6875 0.69531 0.86719 1.6484 1.2969 2.8594 1.2969 1.6953 0 2.8047-0.75781 3.3281-2.2812h4.5312c-0.46875 1.8047-1.3867 3.2344-2.75 4.2969-1.3555 1.0547-3.0547 1.5781-5.0938 1.5781-1.5938 0-3.0117-0.35156-4.25-1.0625-1.2422-0.70703-2.2148-1.707-2.9219-3-0.69922-1.2891-1.0469-2.7969-1.0469-4.5156z"/>
-</g>
-<g transform="translate(141.17 303.13)">
-<path d="m4.2031-18.594c-0.74219 0-1.3555-0.23438-1.8438-0.70312-0.49219-0.47656-0.73438-1.0664-0.73438-1.7656 0-0.69531 0.24219-1.2812 0.73438-1.75 0.48828-0.46875 1.1016-0.70312 1.8438-0.70312 0.73828 0 1.3516 0.23438 1.8438 0.70312 0.48828 0.46875 0.73438 1.0547 0.73438 1.75 0 0.69922-0.24609 1.2891-0.73438 1.7656-0.49219 0.46875-1.1055 0.70312-1.8438 0.70312zm2.0625 1.9688v16.625h-4.2031v-16.625z"/>
-</g>
-<g transform="translate(149.51 303.13)">
-<path d="m17.516-8.6719c0 0.60547-0.039063 1.1484-0.10938 1.625h-12.156c0.10156 1.1992 0.52344 2.1406 1.2656 2.8281 0.73828 0.67969 1.6445 1.0156 2.7188 1.0156 1.5625 0 2.6719-0.67188 3.3281-2.0156h4.5312c-0.48047 1.6055-1.4023 2.9219-2.7656 3.9531-1.3555 1.0234-3.0234 1.5312-5 1.5312-1.5938 0-3.0273-0.35156-4.2969-1.0625-1.2734-0.70703-2.2656-1.7109-2.9844-3.0156-0.71094-1.3008-1.0625-2.8008-1.0625-4.5 0-1.7188 0.34766-3.2266 1.0469-4.5312 0.70703-1.3008 1.6914-2.3008 2.9531-3 1.2578-0.69531 2.707-1.0469 4.3438-1.0469 1.582 0 3 0.34375 4.25 1.0312 1.25 0.67969 2.2188 1.6406 2.9062 2.8906s1.0312 2.6836 1.0312 4.2969zm-4.3438-1.2031c-0.023437-1.0703-0.41406-1.9297-1.1719-2.5781-0.76172-0.65625-1.6953-0.98438-2.7969-0.98438-1.0312 0-1.9062 0.32031-2.625 0.95312-0.71094 0.625-1.1406 1.4961-1.2969 2.6094z"/>
-</g>
-<g transform="translate(168.01 303.13)">
-<path d="m8.4375 0.26562c-1.3672 0-2.5898-0.24609-3.6719-0.73438-1.0742-0.48828-1.9297-1.1484-2.5625-1.9844-0.625-0.84375-0.96875-1.7734-1.0312-2.7969h4.2344c0.070312 0.63672 0.38281 1.168 0.9375 1.5938 0.55078 0.41797 1.2383 0.625 2.0625 0.625 0.78906 0 1.4102-0.15625 1.8594-0.46875 0.45703-0.32031 0.6875-0.73438 0.6875-1.2344 0-0.53906-0.27734-0.94531-0.82812-1.2188-0.55469-0.26953-1.4297-0.56641-2.625-0.89062-1.2422-0.30078-2.2578-0.60938-3.0469-0.92188-0.79297-0.32031-1.4766-0.8125-2.0469-1.4688-0.5625-0.66406-0.84375-1.5547-0.84375-2.6719 0-0.92578 0.26562-1.7656 0.79688-2.5156 0.53125-0.75781 1.2891-1.3594 2.2812-1.7969 0.98828-0.44531 2.1484-0.67188 3.4844-0.67188 1.9766 0 3.5547 0.49609 4.7344 1.4844 1.1875 0.99219 1.8359 2.3242 1.9531 4h-4.0156c-0.0625-0.65625-0.33984-1.1758-0.82812-1.5625-0.49219-0.39453-1.1406-0.59375-1.9531-0.59375-0.76172 0-1.3516 0.14062-1.7656 0.42188-0.40625 0.28125-0.60938 0.67188-0.60938 1.1719 0 0.5625 0.27344 0.99219 0.82812 1.2812 0.5625 0.28125 1.4375 0.57422 2.625 0.875 1.1953 0.30469 2.1875 0.61719 2.9688 0.9375 0.78125 0.3125 1.4531 0.80859 2.0156 1.4844 0.57031 0.66797 0.86719 1.5547 0.89062 2.6562 0 0.96094-0.26562 1.8203-0.79688 2.5781-0.53125 0.76172-1.293 1.3555-2.2812 1.7812-0.99219 0.42578-2.1406 0.64062-3.4531 0.64062z"/>
-</g>
-<g transform="translate(72.906 1034)">
-<path d="m1.0469-10.5c0-2.0625 0.46094-3.9062 1.3906-5.5312 0.9375-1.6328 2.207-2.9062 3.8125-3.8125 1.6133-0.90625 3.4219-1.3594 5.4219-1.3594 2.3438 0 4.3906 0.60156 6.1406 1.7969 1.7578 1.1992 2.9922 2.8555 3.7031 4.9688h-4.8281c-0.49219-1-1.1719-1.75-2.0469-2.25-0.86719-0.5-1.8672-0.75-3-0.75-1.2188 0-2.3086 0.28906-3.2656 0.85938-0.94922 0.57422-1.6875 1.3828-2.2188 2.4219-0.52344 1.043-0.78125 2.2617-0.78125 3.6562 0 1.375 0.25781 2.5898 0.78125 3.6406 0.53125 1.0547 1.2695 1.8672 2.2188 2.4375 0.95703 0.57422 2.0469 0.85938 3.2656 0.85938 1.1328 0 2.1328-0.25391 3-0.76562 0.875-0.50781 1.5547-1.2656 2.0469-2.2656h4.8281c-0.71094 2.1367-1.9375 3.8047-3.6875 5-1.75 1.1875-3.8047 1.7812-6.1562 1.7812-2 0-3.8086-0.45312-5.4219-1.3594-1.6055-0.91406-2.875-2.1797-3.8125-3.7969-0.92969-1.625-1.3906-3.4688-1.3906-5.5312z"/>
-</g>
-<g transform="translate(95.937 1034)">
-<path d="m9.4531 0.26562c-1.6055 0-3.0469-0.35156-4.3281-1.0625-1.2812-0.70703-2.2891-1.7109-3.0156-3.0156-0.73047-1.3008-1.0938-2.8008-1.0938-4.5 0-1.6953 0.375-3.1953 1.125-4.5 0.75-1.3008 1.7734-2.3047 3.0781-3.0156 1.3008-0.70703 2.75-1.0625 4.3438-1.0625 1.6016 0 3.0547 0.35547 4.3594 1.0625 1.3008 0.71094 2.3281 1.7148 3.0781 3.0156 0.75 1.3047 1.125 2.8047 1.125 4.5 0 1.6992-0.38672 3.1992-1.1562 4.5-0.77344 1.3047-1.8125 2.3086-3.125 3.0156-1.3125 0.71094-2.7773 1.0625-4.3906 1.0625zm0-3.6562c0.75781 0 1.4727-0.17969 2.1406-0.54688 0.66406-0.375 1.1953-0.92969 1.5938-1.6719 0.40625-0.73828 0.60938-1.6406 0.60938-2.7031 0-1.582-0.41797-2.7969-1.25-3.6406-0.82422-0.85156-1.8359-1.2812-3.0312-1.2812-1.2109 0-2.2188 0.42969-3.0312 1.2812-0.80469 0.84375-1.2031 2.0586-1.2031 3.6406 0 1.5859 0.39453 2.8047 1.1875 3.6562 0.78906 0.84375 1.7852 1.2656 2.9844 1.2656z"/>
-</g>
-<g transform="translate(115.07 1034)">
-<path d="m22.703-16.859c2.0391 0 3.6875 0.625 4.9375 1.875s1.875 2.9961 1.875 5.2344v9.75h-4.2031v-9.1875c0-1.2891-0.32812-2.2812-0.98438-2.9688-0.65625-0.69531-1.5586-1.0469-2.7031-1.0469-1.1367 0-2.043 0.35156-2.7188 1.0469-0.66797 0.6875-1 1.6797-1 2.9688v9.1875h-4.2031v-9.1875c0-1.2891-0.32812-2.2812-0.98438-2.9688-0.65625-0.69531-1.5586-1.0469-2.7031-1.0469-1.1562 0-2.0742 0.35156-2.75 1.0469-0.66797 0.6875-1 1.6797-1 2.9688v9.1875h-4.2031v-16.625h4.2031v2.0156c0.53906-0.69531 1.2344-1.2422 2.0781-1.6406 0.85156-0.40625 1.7891-0.60938 2.8125-0.60938 1.3008 0 2.4609 0.27734 3.4844 0.82812 1.0195 0.55469 1.8125 1.3359 2.375 2.3438 0.53125-0.95703 1.3125-1.7227 2.3438-2.2969 1.0312-0.58203 2.1445-0.875 3.3438-0.875z"/>
-</g>
-<g transform="translate(146.5 1034)">
-<path d="m6.2656-14.219c0.53906-0.75781 1.2852-1.3945 2.2344-1.9062 0.95703-0.50781 2.0469-0.76562 3.2656-0.76562 1.4141 0 2.6953 0.35156 3.8438 1.0469 1.1562 0.69922 2.0664 1.6953 2.7344 2.9844 0.66406 1.293 1 2.7891 1 4.4844 0 1.7109-0.33594 3.2188-1 4.5312-0.66797 1.3047-1.5781 2.3125-2.7344 3.0312-1.1484 0.71875-2.4297 1.0781-3.8438 1.0781-1.2188 0-2.2969-0.25-3.2344-0.75-0.92969-0.5-1.6836-1.1289-2.2656-1.8906v10.297h-4.2031v-24.547h4.2031zm8.7969 5.8438c0-1-0.21094-1.8633-0.625-2.5938-0.40625-0.72656-0.94922-1.2812-1.625-1.6562-0.66797-0.38281-1.3867-0.57812-2.1562-0.57812-0.76172 0-1.4805 0.19922-2.1562 0.59375-0.66797 0.38672-1.2109 0.94922-1.625 1.6875-0.40625 0.74219-0.60938 1.6094-0.60938 2.6094s0.20312 1.8711 0.60938 2.6094c0.41406 0.74219 0.95703 1.3086 1.625 1.7031 0.67578 0.38672 1.3945 0.57812 2.1562 0.57812 0.76953 0 1.4883-0.19531 2.1562-0.59375 0.67578-0.40625 1.2188-0.97656 1.625-1.7188 0.41406-0.73828 0.625-1.6172 0.625-2.6406z"/>
-</g>
-<g transform="translate(166.83 1034)">
-<path d="m6.2656-22.203v22.203h-4.2031v-22.203z"/>
-</g>
-<g transform="translate(175.17 1034)">
-<path d="m4.2031-18.594c-0.74219 0-1.3555-0.23438-1.8438-0.70312-0.49219-0.47656-0.73438-1.0664-0.73438-1.7656 0-0.69531 0.24219-1.2812 0.73438-1.75 0.48828-0.46875 1.1016-0.70312 1.8438-0.70312 0.73828 0 1.3516 0.23438 1.8438 0.70312 0.48828 0.46875 0.73438 1.0547 0.73438 1.75 0 0.69922-0.24609 1.2891-0.73438 1.7656-0.49219 0.46875-1.1055 0.70312-1.8438 0.70312zm2.0625 1.9688v16.625h-4.2031v-16.625z"/>
-</g>
-<g transform="translate(183.5 1034)">
-<path d="m0.98438-8.375c0-1.6758 0.33203-3.1641 1-4.4688 0.67578-1.3008 1.5859-2.3008 2.7344-3 1.1562-0.69531 2.4414-1.0469 3.8594-1.0469 1.2383 0 2.3203 0.25 3.25 0.75 0.9375 0.5 1.6797 1.1328 2.2344 1.8906v-2.375h4.2344v16.625h-4.2344v-2.4375c-0.53125 0.78125-1.2773 1.4297-2.2344 1.9375-0.94922 0.50781-2.043 0.76562-3.2812 0.76562-1.3984 0-2.6719-0.35938-3.8281-1.0781-1.1484-0.71875-2.0586-1.7266-2.7344-3.0312-0.66797-1.3125-1-2.8203-1-4.5312zm13.078 0.0625c0-1.0195-0.19922-1.8945-0.59375-2.625-0.39844-0.72656-0.9375-1.2852-1.625-1.6719-0.67969-0.39453-1.4062-0.59375-2.1875-0.59375s-1.5 0.19531-2.1562 0.57812c-0.65625 0.375-1.1953 0.92969-1.6094 1.6562-0.40625 0.73047-0.60938 1.5938-0.60938 2.5938s0.20312 1.875 0.60938 2.625c0.41406 0.75 0.95703 1.3281 1.625 1.7344 0.66406 0.39844 1.3789 0.59375 2.1406 0.59375 0.78125 0 1.5078-0.19141 2.1875-0.57812 0.6875-0.39453 1.2266-0.95703 1.625-1.6875 0.39453-0.72656 0.59375-1.6016 0.59375-2.625z"/>
-</g>
-<g transform="translate(203.84 1034)">
-<path d="m11.281-16.859c1.9766 0 3.5781 0.625 4.7969 1.875s1.8281 2.9961 1.8281 5.2344v9.75h-4.2031v-9.1875c0-1.3125-0.32812-2.3203-0.98438-3.0312-0.65625-0.71875-1.5586-1.0781-2.7031-1.0781-1.1562 0-2.0742 0.35938-2.75 1.0781-0.66797 0.71094-1 1.7188-1 3.0312v9.1875h-4.2031v-16.625h4.2031v2.0781c0.5625-0.71875 1.2734-1.2812 2.1406-1.6875 0.875-0.41406 1.832-0.625 2.875-0.625z"/>
-</g>
-<g transform="translate(223.66 1034)">
-<path d="m6.9531-13.172v8.0469c0 0.55469 0.13281 0.95312 0.40625 1.2031 0.26953 0.25 0.72656 0.375 1.375 0.375h1.9531v3.5469h-2.6406c-3.543 0-5.3125-1.7188-5.3125-5.1562v-8.0156h-1.9844v-3.4531h1.9844v-4.1094h4.2188v4.1094h3.7344v3.4531z"/>
-</g>
-<g transform="translate(235.29 1034)"/>
-<g transform="translate(242.43 1034)">
-<path d="m13.891 0-7.625-9.3281v9.3281h-4.2031v-20.938h4.2031v9.3906l7.625-9.3906h5.0625l-8.6406 10.375 8.8906 10.562z"/>
-</g>
-<g transform="translate(262.31 1034)">
-<path d="m17.766-16.625v16.625h-4.2344v-2.0938c-0.54297 0.71875-1.25 1.2812-2.125 1.6875-0.86719 0.40625-1.8086 0.60938-2.8281 0.60938-1.3047 0-2.4531-0.26953-3.4531-0.8125-1-0.55078-1.7891-1.3633-2.3594-2.4375-0.5625-1.0703-0.84375-2.3477-0.84375-3.8281v-9.75h4.2031v9.1562c0 1.3242 0.32812 2.3398 0.98438 3.0469 0.65625 0.71094 1.5547 1.0625 2.7031 1.0625 1.1562 0 2.0625-0.35156 2.7188-1.0625 0.66406-0.70703 1-1.7227 1-3.0469v-9.1562z"/>
-</g>
-<g transform="translate(282.14 1034)">
-<path d="m6.2656-14.188c0.53906-0.80078 1.2852-1.4531 2.2344-1.9531 0.95703-0.5 2.0469-0.75 3.2656-0.75 1.4141 0 2.6953 0.35156 3.8438 1.0469 1.1562 0.69922 2.0664 1.6953 2.7344 2.9844 0.66406 1.293 1 2.7891 1 4.4844 0 1.7109-0.33594 3.2188-1 4.5312-0.66797 1.3047-1.5781 2.3125-2.7344 3.0312-1.1484 0.71875-2.4297 1.0781-3.8438 1.0781-1.2422 0-2.3281-0.24609-3.2656-0.73438-0.92969-0.48828-1.6719-1.125-2.2344-1.9062v2.375h-4.2031v-22.203h4.2031zm8.7969 5.8125c0-1-0.21094-1.8633-0.625-2.5938-0.40625-0.72656-0.94922-1.2812-1.625-1.6562-0.66797-0.38281-1.3867-0.57812-2.1562-0.57812-0.76172 0-1.4805 0.19922-2.1562 0.59375-0.66797 0.38672-1.2109 0.94922-1.625 1.6875-0.40625 0.74219-0.60938 1.6094-0.60938 2.6094s0.20312 1.8711 0.60938 2.6094c0.41406 0.74219 0.95703 1.3086 1.625 1.7031 0.67578 0.38672 1.3945 0.57812 2.1562 0.57812 0.76953 0 1.4883-0.19531 2.1562-0.59375 0.67578-0.40625 1.2188-0.97656 1.625-1.7188 0.41406-0.73828 0.625-1.6172 0.625-2.6406z"/>
-</g>
-<g transform="translate(302.47 1034)">
-<path d="m17.516-8.6719c0 0.60547-0.039063 1.1484-0.10938 1.625h-12.156c0.10156 1.1992 0.52344 2.1406 1.2656 2.8281 0.73828 0.67969 1.6445 1.0156 2.7188 1.0156 1.5625 0 2.6719-0.67188 3.3281-2.0156h4.5312c-0.48047 1.6055-1.4023 2.9219-2.7656 3.9531-1.3555 1.0234-3.0234 1.5312-5 1.5312-1.5938 0-3.0273-0.35156-4.2969-1.0625-1.2734-0.70703-2.2656-1.7109-2.9844-3.0156-0.71094-1.3008-1.0625-2.8008-1.0625-4.5 0-1.7188 0.34766-3.2266 1.0469-4.5312 0.70703-1.3008 1.6914-2.3008 2.9531-3 1.2578-0.69531 2.707-1.0469 4.3438-1.0469 1.582 0 3 0.34375 4.25 1.0312 1.25 0.67969 2.2188 1.6406 2.9062 2.8906s1.0312 2.6836 1.0312 4.2969zm-4.3438-1.2031c-0.023437-1.0703-0.41406-1.9297-1.1719-2.5781-0.76172-0.65625-1.6953-0.98438-2.7969-0.98438-1.0312 0-1.9062 0.32031-2.625 0.95312-0.71094 0.625-1.1406 1.4961-1.2969 2.6094z"/>
-</g>
-<g transform="translate(320.97 1034)">
-<path d="m6.2656-14.047c0.53906-0.875 1.2422-1.5625 2.1094-2.0625 0.875-0.5 1.875-0.75 3-0.75v4.4062h-1.1094c-1.3242 0-2.3242 0.3125-3 0.9375-0.66797 0.61719-1 1.6953-1 3.2344v8.2812h-4.2031v-16.625h4.2031z"/>
-</g>
-<g transform="translate(333.09 1034)">
-<path d="m11.281-16.859c1.9766 0 3.5781 0.625 4.7969 1.875s1.8281 2.9961 1.8281 5.2344v9.75h-4.2031v-9.1875c0-1.3125-0.32812-2.3203-0.98438-3.0312-0.65625-0.71875-1.5586-1.0781-2.7031-1.0781-1.1562 0-2.0742 0.35938-2.75 1.0781-0.66797 0.71094-1 1.7188-1 3.0312v9.1875h-4.2031v-16.625h4.2031v2.0781c0.5625-0.71875 1.2734-1.2812 2.1406-1.6875 0.875-0.41406 1.832-0.625 2.875-0.625z"/>
-</g>
-<g transform="translate(352.91 1034)">
-<path d="m17.516-8.6719c0 0.60547-0.039063 1.1484-0.10938 1.625h-12.156c0.10156 1.1992 0.52344 2.1406 1.2656 2.8281 0.73828 0.67969 1.6445 1.0156 2.7188 1.0156 1.5625 0 2.6719-0.67188 3.3281-2.0156h4.5312c-0.48047 1.6055-1.4023 2.9219-2.7656 3.9531-1.3555 1.0234-3.0234 1.5312-5 1.5312-1.5938 0-3.0273-0.35156-4.2969-1.0625-1.2734-0.70703-2.2656-1.7109-2.9844-3.0156-0.71094-1.3008-1.0625-2.8008-1.0625-4.5 0-1.7188 0.34766-3.2266 1.0469-4.5312 0.70703-1.3008 1.6914-2.3008 2.9531-3 1.2578-0.69531 2.707-1.0469 4.3438-1.0469 1.582 0 3 0.34375 4.25 1.0312 1.25 0.67969 2.2188 1.6406 2.9062 2.8906s1.0312 2.6836 1.0312 4.2969zm-4.3438-1.2031c-0.023437-1.0703-0.41406-1.9297-1.1719-2.5781-0.76172-0.65625-1.6953-0.98438-2.7969-0.98438-1.0312 0-1.9062 0.32031-2.625 0.95312-0.71094 0.625-1.1406 1.4961-1.2969 2.6094z"/>
-</g>
-<g transform="translate(371.41 1034)">
-<path d="m6.9531-13.172v8.0469c0 0.55469 0.13281 0.95312 0.40625 1.2031 0.26953 0.25 0.72656 0.375 1.375 0.375h1.9531v3.5469h-2.6406c-3.543 0-5.3125-1.7188-5.3125-5.1562v-8.0156h-1.9844v-3.4531h1.9844v-4.1094h4.2188v4.1094h3.7344v3.4531z"/>
-</g>
-<g transform="translate(383.05 1034)">
-<path d="m17.516-8.6719c0 0.60547-0.039063 1.1484-0.10938 1.625h-12.156c0.10156 1.1992 0.52344 2.1406 1.2656 2.8281 0.73828 0.67969 1.6445 1.0156 2.7188 1.0156 1.5625 0 2.6719-0.67188 3.3281-2.0156h4.5312c-0.48047 1.6055-1.4023 2.9219-2.7656 3.9531-1.3555 1.0234-3.0234 1.5312-5 1.5312-1.5938 0-3.0273-0.35156-4.2969-1.0625-1.2734-0.70703-2.2656-1.7109-2.9844-3.0156-0.71094-1.3008-1.0625-2.8008-1.0625-4.5 0-1.7188 0.34766-3.2266 1.0469-4.5312 0.70703-1.3008 1.6914-2.3008 2.9531-3 1.2578-0.69531 2.707-1.0469 4.3438-1.0469 1.582 0 3 0.34375 4.25 1.0312 1.25 0.67969 2.2188 1.6406 2.9062 2.8906s1.0312 2.6836 1.0312 4.2969zm-4.3438-1.2031c-0.023437-1.0703-0.41406-1.9297-1.1719-2.5781-0.76172-0.65625-1.6953-0.98438-2.7969-0.98438-1.0312 0-1.9062 0.32031-2.625 0.95312-0.71094 0.625-1.1406 1.4961-1.2969 2.6094z"/>
-</g>
-<g transform="translate(401.55 1034)">
-<path d="m8.4375 0.26562c-1.3672 0-2.5898-0.24609-3.6719-0.73438-1.0742-0.48828-1.9297-1.1484-2.5625-1.9844-0.625-0.84375-0.96875-1.7734-1.0312-2.7969h4.2344c0.070312 0.63672 0.38281 1.168 0.9375 1.5938 0.55078 0.41797 1.2383 0.625 2.0625 0.625 0.78906 0 1.4102-0.15625 1.8594-0.46875 0.45703-0.32031 0.6875-0.73438 0.6875-1.2344 0-0.53906-0.27734-0.94531-0.82812-1.2188-0.55469-0.26953-1.4297-0.56641-2.625-0.89062-1.2422-0.30078-2.2578-0.60938-3.0469-0.92188-0.79297-0.32031-1.4766-0.8125-2.0469-1.4688-0.5625-0.66406-0.84375-1.5547-0.84375-2.6719 0-0.92578 0.26562-1.7656 0.79688-2.5156 0.53125-0.75781 1.2891-1.3594 2.2812-1.7969 0.98828-0.44531 2.1484-0.67188 3.4844-0.67188 1.9766 0 3.5547 0.49609 4.7344 1.4844 1.1875 0.99219 1.8359 2.3242 1.9531 4h-4.0156c-0.0625-0.65625-0.33984-1.1758-0.82812-1.5625-0.49219-0.39453-1.1406-0.59375-1.9531-0.59375-0.76172 0-1.3516 0.14062-1.7656 0.42188-0.40625 0.28125-0.60938 0.67188-0.60938 1.1719 0 0.5625 0.27344 0.99219 0.82812 1.2812 0.5625 0.28125 1.4375 0.57422 2.625 0.875 1.1953 0.30469 2.1875 0.61719 2.9688 0.9375 0.78125 0.3125 1.4531 0.80859 2.0156 1.4844 0.57031 0.66797 0.86719 1.5547 0.89062 2.6562 0 0.96094-0.26562 1.8203-0.79688 2.5781-0.53125 0.76172-1.293 1.3555-2.2812 1.7812-0.99219 0.42578-2.1406 0.64062-3.4531 0.64062z"/>
-</g>
-<g transform="translate(417.89 1034)"/>
-<g transform="translate(425.03 1034)">
-<path d="m20.875-20.938-7.6719 20.938h-5.1094l-7.6719-20.938h4.5l5.7656 16.641 5.7188-16.641z"/>
-</g>
-<g transform="translate(446.35 1034)">
-<path d="m4.2031-18.594c-0.74219 0-1.3555-0.23438-1.8438-0.70312-0.49219-0.47656-0.73438-1.0664-0.73438-1.7656 0-0.69531 0.24219-1.2812 0.73438-1.75 0.48828-0.46875 1.1016-0.70312 1.8438-0.70312 0.73828 0 1.3516 0.23438 1.8438 0.70312 0.48828 0.46875 0.73438 1.0547 0.73438 1.75 0 0.69922-0.24609 1.2891-0.73438 1.7656-0.49219 0.46875-1.1055 0.70312-1.8438 0.70312zm2.0625 1.9688v16.625h-4.2031v-16.625z"/>
-</g>
-<g transform="translate(454.69 1034)">
-<path d="m8.4375 0.26562c-1.3672 0-2.5898-0.24609-3.6719-0.73438-1.0742-0.48828-1.9297-1.1484-2.5625-1.9844-0.625-0.84375-0.96875-1.7734-1.0312-2.7969h4.2344c0.070312 0.63672 0.38281 1.168 0.9375 1.5938 0.55078 0.41797 1.2383 0.625 2.0625 0.625 0.78906 0 1.4102-0.15625 1.8594-0.46875 0.45703-0.32031 0.6875-0.73438 0.6875-1.2344 0-0.53906-0.27734-0.94531-0.82812-1.2188-0.55469-0.26953-1.4297-0.56641-2.625-0.89062-1.2422-0.30078-2.2578-0.60938-3.0469-0.92188-0.79297-0.32031-1.4766-0.8125-2.0469-1.4688-0.5625-0.66406-0.84375-1.5547-0.84375-2.6719 0-0.92578 0.26562-1.7656 0.79688-2.5156 0.53125-0.75781 1.2891-1.3594 2.2812-1.7969 0.98828-0.44531 2.1484-0.67188 3.4844-0.67188 1.9766 0 3.5547 0.49609 4.7344 1.4844 1.1875 0.99219 1.8359 2.3242 1.9531 4h-4.0156c-0.0625-0.65625-0.33984-1.1758-0.82812-1.5625-0.49219-0.39453-1.1406-0.59375-1.9531-0.59375-0.76172 0-1.3516 0.14062-1.7656 0.42188-0.40625 0.28125-0.60938 0.67188-0.60938 1.1719 0 0.5625 0.27344 0.99219 0.82812 1.2812 0.5625 0.28125 1.4375 0.57422 2.625 0.875 1.1953 0.30469 2.1875 0.61719 2.9688 0.9375 0.78125 0.3125 1.4531 0.80859 2.0156 1.4844 0.57031 0.66797 0.86719 1.5547 0.89062 2.6562 0 0.96094-0.26562 1.8203-0.79688 2.5781-0.53125 0.76172-1.293 1.3555-2.2812 1.7812-0.99219 0.42578-2.1406 0.64062-3.4531 0.64062z"/>
-</g>
-<g transform="translate(471.03 1034)">
-<path d="m4.2031-18.594c-0.74219 0-1.3555-0.23438-1.8438-0.70312-0.49219-0.47656-0.73438-1.0664-0.73438-1.7656 0-0.69531 0.24219-1.2812 0.73438-1.75 0.48828-0.46875 1.1016-0.70312 1.8438-0.70312 0.73828 0 1.3516 0.23438 1.8438 0.70312 0.48828 0.46875 0.73438 1.0547 0.73438 1.75 0 0.69922-0.24609 1.2891-0.73438 1.7656-0.49219 0.46875-1.1055 0.70312-1.8438 0.70312zm2.0625 1.9688v16.625h-4.2031v-16.625z"/>
-</g>
-<g transform="translate(479.37 1034)">
-<path d="m6.2656-14.188c0.53906-0.80078 1.2852-1.4531 2.2344-1.9531 0.95703-0.5 2.0469-0.75 3.2656-0.75 1.4141 0 2.6953 0.35156 3.8438 1.0469 1.1562 0.69922 2.0664 1.6953 2.7344 2.9844 0.66406 1.293 1 2.7891 1 4.4844 0 1.7109-0.33594 3.2188-1 4.5312-0.66797 1.3047-1.5781 2.3125-2.7344 3.0312-1.1484 0.71875-2.4297 1.0781-3.8438 1.0781-1.2422 0-2.3281-0.24609-3.2656-0.73438-0.92969-0.48828-1.6719-1.125-2.2344-1.9062v2.375h-4.2031v-22.203h4.2031zm8.7969 5.8125c0-1-0.21094-1.8633-0.625-2.5938-0.40625-0.72656-0.94922-1.2812-1.625-1.6562-0.66797-0.38281-1.3867-0.57812-2.1562-0.57812-0.76172 0-1.4805 0.19922-2.1562 0.59375-0.66797 0.38672-1.2109 0.94922-1.625 1.6875-0.40625 0.74219-0.60938 1.6094-0.60938 2.6094s0.20312 1.8711 0.60938 2.6094c0.41406 0.74219 0.95703 1.3086 1.625 1.7031 0.67578 0.38672 1.3945 0.57812 2.1562 0.57812 0.76953 0 1.4883-0.19531 2.1562-0.59375 0.67578-0.40625 1.2188-0.97656 1.625-1.7188 0.41406-0.73828 0.625-1.6172 0.625-2.6406z"/>
-</g>
-<g transform="translate(499.7 1034)">
-<path d="m4.2031-18.594c-0.74219 0-1.3555-0.23438-1.8438-0.70312-0.49219-0.47656-0.73438-1.0664-0.73438-1.7656 0-0.69531 0.24219-1.2812 0.73438-1.75 0.48828-0.46875 1.1016-0.70312 1.8438-0.70312 0.73828 0 1.3516 0.23438 1.8438 0.70312 0.48828 0.46875 0.73438 1.0547 0.73438 1.75 0 0.69922-0.24609 1.2891-0.73438 1.7656-0.49219 0.46875-1.1055 0.70312-1.8438 0.70312zm2.0625 1.9688v16.625h-4.2031v-16.625z"/>
-</g>
-<g transform="translate(508.04 1034)">
-<path d="m6.2656-22.203v22.203h-4.2031v-22.203z"/>
-</g>
-<g transform="translate(516.37 1034)">
-<path d="m4.2031-18.594c-0.74219 0-1.3555-0.23438-1.8438-0.70312-0.49219-0.47656-0.73438-1.0664-0.73438-1.7656 0-0.69531 0.24219-1.2812 0.73438-1.75 0.48828-0.46875 1.1016-0.70312 1.8438-0.70312 0.73828 0 1.3516 0.23438 1.8438 0.70312 0.48828 0.46875 0.73438 1.0547 0.73438 1.75 0 0.69922-0.24609 1.2891-0.73438 1.7656-0.49219 0.46875-1.1055 0.70312-1.8438 0.70312zm2.0625 1.9688v16.625h-4.2031v-16.625z"/>
-</g>
-<g transform="translate(524.71 1034)">
-<path d="m6.9531-13.172v8.0469c0 0.55469 0.13281 0.95312 0.40625 1.2031 0.26953 0.25 0.72656 0.375 1.375 0.375h1.9531v3.5469h-2.6406c-3.543 0-5.3125-1.7188-5.3125-5.1562v-8.0156h-1.9844v-3.4531h1.9844v-4.1094h4.2188v4.1094h3.7344v3.4531z"/>
-</g>
-<g transform="translate(536.35 1034)">
-<path d="m17.969-16.625-10.281 24.484h-4.4844l3.6094-8.2812-6.6562-16.203h4.7031l4.2969 11.609 4.3438-11.609z"/>
-</g>
-<g transform="translate(554.49 1034)"/>
-<g transform="translate(561.63 1034)">
-<path d="m0.98438-8.375c0-1.6758 0.33203-3.1641 1-4.4688 0.67578-1.3008 1.5859-2.3008 2.7344-3 1.1562-0.69531 2.4414-1.0469 3.8594-1.0469 1.2383 0 2.3203 0.25 3.25 0.75 0.9375 0.5 1.6797 1.1328 2.2344 1.8906v-2.375h4.2344v16.625h-4.2344v-2.4375c-0.53125 0.78125-1.2773 1.4297-2.2344 1.9375-0.94922 0.50781-2.043 0.76562-3.2812 0.76562-1.3984 0-2.6719-0.35938-3.8281-1.0781-1.1484-0.71875-2.0586-1.7266-2.7344-3.0312-0.66797-1.3125-1-2.8203-1-4.5312zm13.078 0.0625c0-1.0195-0.19922-1.8945-0.59375-2.625-0.39844-0.72656-0.9375-1.2852-1.625-1.6719-0.67969-0.39453-1.4062-0.59375-2.1875-0.59375s-1.5 0.19531-2.1562 0.57812c-0.65625 0.375-1.1953 0.92969-1.6094 1.6562-0.40625 0.73047-0.60938 1.5938-0.60938 2.5938s0.20312 1.875 0.60938 2.625c0.41406 0.75 0.95703 1.3281 1.625 1.7344 0.66406 0.39844 1.3789 0.59375 2.1406 0.59375 0.78125 0 1.5078-0.19141 2.1875-0.57812 0.6875-0.39453 1.2266-0.95703 1.625-1.6875 0.39453-0.72656 0.59375-1.6016 0.59375-2.625z"/>
-</g>
-<g transform="translate(581.96 1034)">
-<path d="m11.281-16.859c1.9766 0 3.5781 0.625 4.7969 1.875s1.8281 2.9961 1.8281 5.2344v9.75h-4.2031v-9.1875c0-1.3125-0.32812-2.3203-0.98438-3.0312-0.65625-0.71875-1.5586-1.0781-2.7031-1.0781-1.1562 0-2.0742 0.35938-2.75 1.0781-0.66797 0.71094-1 1.7188-1 3.0312v9.1875h-4.2031v-16.625h4.2031v2.0781c0.5625-0.71875 1.2734-1.2812 2.1406-1.6875 0.875-0.41406 1.832-0.625 2.875-0.625z"/>
-</g>
-<g transform="translate(601.78 1034)">
-<path d="m0.98438-8.375c0-1.6758 0.33203-3.1641 1-4.4688 0.67578-1.3008 1.5938-2.3008 2.75-3 1.1641-0.69531 2.457-1.0469 3.875-1.0469 1.082 0 2.1133 0.23438 3.0938 0.70312 0.97656 0.46875 1.7578 1.0938 2.3438 1.875v-7.8906h4.25v22.203h-4.25v-2.4531c-0.52344 0.8125-1.2578 1.4688-2.2031 1.9688-0.9375 0.5-2.0273 0.75-3.2656 0.75-1.3984 0-2.6797-0.35938-3.8438-1.0781-1.1562-0.71875-2.0742-1.7266-2.75-3.0312-0.66797-1.3125-1-2.8203-1-4.5312zm13.078 0.0625c0-1.0195-0.19922-1.8945-0.59375-2.625-0.39844-0.72656-0.9375-1.2852-1.625-1.6719-0.67969-0.39453-1.4062-0.59375-2.1875-0.59375s-1.5 0.19531-2.1562 0.57812c-0.65625 0.375-1.1953 0.92969-1.6094 1.6562-0.40625 0.73047-0.60938 1.5938-0.60938 2.5938s0.20312 1.875 0.60938 2.625c0.41406 0.75 0.95703 1.3281 1.625 1.7344 0.66406 0.39844 1.3789 0.59375 2.1406 0.59375 0.78125 0 1.5078-0.19141 2.1875-0.57812 0.6875-0.39453 1.2266-0.95703 1.625-1.6875 0.39453-0.72656 0.59375-1.6016 0.59375-2.625z"/>
-</g>
-<g transform="translate(622.11 1034)"/>
-<g transform="translate(629.25 1034)">
-<path d="m14.906-3.9844h-8.3438l-1.375 3.9844h-4.4062l7.5312-20.969h4.8906l7.5312 20.969h-4.4375zm-1.1406-3.3594-3.0312-8.7656-3.0312 8.7656z"/>
-</g>
-<g transform="translate(650.72 1034)">
-<path d="m17.766-16.625v16.625h-4.2344v-2.0938c-0.54297 0.71875-1.25 1.2812-2.125 1.6875-0.86719 0.40625-1.8086 0.60938-2.8281 0.60938-1.3047 0-2.4531-0.26953-3.4531-0.8125-1-0.55078-1.7891-1.3633-2.3594-2.4375-0.5625-1.0703-0.84375-2.3477-0.84375-3.8281v-9.75h4.2031v9.1562c0 1.3242 0.32812 2.3398 0.98438 3.0469 0.65625 0.71094 1.5547 1.0625 2.7031 1.0625 1.1562 0 2.0625-0.35156 2.7188-1.0625 0.66406-0.70703 1-1.7227 1-3.0469v-9.1562z"/>
-</g>
-<g transform="translate(670.54 1034)">
-<path d="m0.98438-8.375c0-1.6758 0.33203-3.1641 1-4.4688 0.67578-1.3008 1.5938-2.3008 2.75-3 1.1641-0.69531 2.457-1.0469 3.875-1.0469 1.082 0 2.1133 0.23438 3.0938 0.70312 0.97656 0.46875 1.7578 1.0938 2.3438 1.875v-7.8906h4.25v22.203h-4.25v-2.4531c-0.52344 0.8125-1.2578 1.4688-2.2031 1.9688-0.9375 0.5-2.0273 0.75-3.2656 0.75-1.3984 0-2.6797-0.35938-3.8438-1.0781-1.1562-0.71875-2.0742-1.7266-2.75-3.0312-0.66797-1.3125-1-2.8203-1-4.5312zm13.078 0.0625c0-1.0195-0.19922-1.8945-0.59375-2.625-0.39844-0.72656-0.9375-1.2852-1.625-1.6719-0.67969-0.39453-1.4062-0.59375-2.1875-0.59375s-1.5 0.19531-2.1562 0.57812c-0.65625 0.375-1.1953 0.92969-1.6094 1.6562-0.40625 0.73047-0.60938 1.5938-0.60938 2.5938s0.20312 1.875 0.60938 2.625c0.41406 0.75 0.95703 1.3281 1.625 1.7344 0.66406 0.39844 1.3789 0.59375 2.1406 0.59375 0.78125 0 1.5078-0.19141 2.1875-0.57812 0.6875-0.39453 1.2266-0.95703 1.625-1.6875 0.39453-0.72656 0.59375-1.6016 0.59375-2.625z"/>
-</g>
-<g transform="translate(690.88 1034)">
-<path d="m4.2031-18.594c-0.74219 0-1.3555-0.23438-1.8438-0.70312-0.49219-0.47656-0.73438-1.0664-0.73438-1.7656 0-0.69531 0.24219-1.2812 0.73438-1.75 0.48828-0.46875 1.1016-0.70312 1.8438-0.70312 0.73828 0 1.3516 0.23438 1.8438 0.70312 0.48828 0.46875 0.73438 1.0547 0.73438 1.75 0 0.69922-0.24609 1.2891-0.73438 1.7656-0.49219 0.46875-1.1055 0.70312-1.8438 0.70312zm2.0625 1.9688v16.625h-4.2031v-16.625z"/>
-</g>
-<g transform="translate(699.21 1034)">
-<path d="m6.9531-13.172v8.0469c0 0.55469 0.13281 0.95312 0.40625 1.2031 0.26953 0.25 0.72656 0.375 1.375 0.375h1.9531v3.5469h-2.6406c-3.543 0-5.3125-1.7188-5.3125-5.1562v-8.0156h-1.9844v-3.4531h1.9844v-4.1094h4.2188v4.1094h3.7344v3.4531z"/>
-</g>
-<g transform="translate(710.85 1034)"/>
-<g transform="translate(717.99 1034)">
-<path d="m9.3906-20.938c2.1953 0 4.1289 0.43359 5.7969 1.2969 1.6758 0.85547 2.9688 2.0781 3.875 3.6719 0.91406 1.5859 1.375 3.4297 1.375 5.5312 0 2.0938-0.46094 3.9297-1.375 5.5-0.90625 1.5742-2.1992 2.793-3.875 3.6562-1.668 0.85547-3.6016 1.2812-5.7969 1.2812h-7.3281v-20.938zm-0.15625 17.375c2.207 0 3.9102-0.59766 5.1094-1.7969 1.1953-1.207 1.7969-2.8984 1.7969-5.0781 0-2.1758-0.60156-3.8789-1.7969-5.1094-1.1992-1.2383-2.9023-1.8594-5.1094-1.8594h-2.9688v13.844z"/>
-</g>
-<g transform="translate(739.49 1034)">
-<path d="m0.98438-8.375c0-1.6758 0.33203-3.1641 1-4.4688 0.67578-1.3008 1.5859-2.3008 2.7344-3 1.1562-0.69531 2.4414-1.0469 3.8594-1.0469 1.2383 0 2.3203 0.25 3.25 0.75 0.9375 0.5 1.6797 1.1328 2.2344 1.8906v-2.375h4.2344v16.625h-4.2344v-2.4375c-0.53125 0.78125-1.2773 1.4297-2.2344 1.9375-0.94922 0.50781-2.043 0.76562-3.2812 0.76562-1.3984 0-2.6719-0.35938-3.8281-1.0781-1.1484-0.71875-2.0586-1.7266-2.7344-3.0312-0.66797-1.3125-1-2.8203-1-4.5312zm13.078 0.0625c0-1.0195-0.19922-1.8945-0.59375-2.625-0.39844-0.72656-0.9375-1.2852-1.625-1.6719-0.67969-0.39453-1.4062-0.59375-2.1875-0.59375s-1.5 0.19531-2.1562 0.57812c-0.65625 0.375-1.1953 0.92969-1.6094 1.6562-0.40625 0.73047-0.60938 1.5938-0.60938 2.5938s0.20312 1.875 0.60938 2.625c0.41406 0.75 0.95703 1.3281 1.625 1.7344 0.66406 0.39844 1.3789 0.59375 2.1406 0.59375 0.78125 0 1.5078-0.19141 2.1875-0.57812 0.6875-0.39453 1.2266-0.95703 1.625-1.6875 0.39453-0.72656 0.59375-1.6016 0.59375-2.625z"/>
-</g>
-<g transform="translate(759.82 1034)">
-<path d="m8.4375 0.26562c-1.3672 0-2.5898-0.24609-3.6719-0.73438-1.0742-0.48828-1.9297-1.1484-2.5625-1.9844-0.625-0.84375-0.96875-1.7734-1.0312-2.7969h4.2344c0.070312 0.63672 0.38281 1.168 0.9375 1.5938 0.55078 0.41797 1.2383 0.625 2.0625 0.625 0.78906 0 1.4102-0.15625 1.8594-0.46875 0.45703-0.32031 0.6875-0.73438 0.6875-1.2344 0-0.53906-0.27734-0.94531-0.82812-1.2188-0.55469-0.26953-1.4297-0.56641-2.625-0.89062-1.2422-0.30078-2.2578-0.60938-3.0469-0.92188-0.79297-0.32031-1.4766-0.8125-2.0469-1.4688-0.5625-0.66406-0.84375-1.5547-0.84375-2.6719 0-0.92578 0.26562-1.7656 0.79688-2.5156 0.53125-0.75781 1.2891-1.3594 2.2812-1.7969 0.98828-0.44531 2.1484-0.67188 3.4844-0.67188 1.9766 0 3.5547 0.49609 4.7344 1.4844 1.1875 0.99219 1.8359 2.3242 1.9531 4h-4.0156c-0.0625-0.65625-0.33984-1.1758-0.82812-1.5625-0.49219-0.39453-1.1406-0.59375-1.9531-0.59375-0.76172 0-1.3516 0.14062-1.7656 0.42188-0.40625 0.28125-0.60938 0.67188-0.60938 1.1719 0 0.5625 0.27344 0.99219 0.82812 1.2812 0.5625 0.28125 1.4375 0.57422 2.625 0.875 1.1953 0.30469 2.1875 0.61719 2.9688 0.9375 0.78125 0.3125 1.4531 0.80859 2.0156 1.4844 0.57031 0.66797 0.86719 1.5547 0.89062 2.6562 0 0.96094-0.26562 1.8203-0.79688 2.5781-0.53125 0.76172-1.293 1.3555-2.2812 1.7812-0.99219 0.42578-2.1406 0.64062-3.4531 0.64062z"/>
-</g>
-<g transform="translate(776.16 1034)">
-<path d="m11.438-16.859c1.25 0 2.3633 0.27734 3.3438 0.82812 0.98828 0.55469 1.7539 1.3672 2.2969 2.4375 0.55078 1.0625 0.82812 2.3438 0.82812 3.8438v9.75h-4.2031v-9.1875c0-1.3125-0.32812-2.3203-0.98438-3.0312-0.65625-0.71875-1.5586-1.0781-2.7031-1.0781-1.1562 0-2.0742 0.35938-2.75 1.0781-0.66797 0.71094-1 1.7188-1 3.0312v9.1875h-4.2031v-22.203h4.2031v7.6562c0.53906-0.71875 1.2578-1.2812 2.1562-1.6875 0.90625-0.41406 1.9102-0.625 3.0156-0.625z"/>
-</g>
-<g transform="translate(795.99 1034)">
-<path d="m6.2656-14.188c0.53906-0.80078 1.2852-1.4531 2.2344-1.9531 0.95703-0.5 2.0469-0.75 3.2656-0.75 1.4141 0 2.6953 0.35156 3.8438 1.0469 1.1562 0.69922 2.0664 1.6953 2.7344 2.9844 0.66406 1.293 1 2.7891 1 4.4844 0 1.7109-0.33594 3.2188-1 4.5312-0.66797 1.3047-1.5781 2.3125-2.7344 3.0312-1.1484 0.71875-2.4297 1.0781-3.8438 1.0781-1.2422 0-2.3281-0.24609-3.2656-0.73438-0.92969-0.48828-1.6719-1.125-2.2344-1.9062v2.375h-4.2031v-22.203h4.2031zm8.7969 5.8125c0-1-0.21094-1.8633-0.625-2.5938-0.40625-0.72656-0.94922-1.2812-1.625-1.6562-0.66797-0.38281-1.3867-0.57812-2.1562-0.57812-0.76172 0-1.4805 0.19922-2.1562 0.59375-0.66797 0.38672-1.2109 0.94922-1.625 1.6875-0.40625 0.74219-0.60938 1.6094-0.60938 2.6094s0.20312 1.8711 0.60938 2.6094c0.41406 0.74219 0.95703 1.3086 1.625 1.7031 0.67578 0.38672 1.3945 0.57812 2.1562 0.57812 0.76953 0 1.4883-0.19531 2.1562-0.59375 0.67578-0.40625 1.2188-0.97656 1.625-1.7188 0.41406-0.73828 0.625-1.6172 0.625-2.6406z"/>
-</g>
-<g transform="translate(816.32 1034)">
-<path d="m9.4531 0.26562c-1.6055 0-3.0469-0.35156-4.3281-1.0625-1.2812-0.70703-2.2891-1.7109-3.0156-3.0156-0.73047-1.3008-1.0938-2.8008-1.0938-4.5 0-1.6953 0.375-3.1953 1.125-4.5 0.75-1.3008 1.7734-2.3047 3.0781-3.0156 1.3008-0.70703 2.75-1.0625 4.3438-1.0625 1.6016 0 3.0547 0.35547 4.3594 1.0625 1.3008 0.71094 2.3281 1.7148 3.0781 3.0156 0.75 1.3047 1.125 2.8047 1.125 4.5 0 1.6992-0.38672 3.1992-1.1562 4.5-0.77344 1.3047-1.8125 2.3086-3.125 3.0156-1.3125 0.71094-2.7773 1.0625-4.3906 1.0625zm0-3.6562c0.75781 0 1.4727-0.17969 2.1406-0.54688 0.66406-0.375 1.1953-0.92969 1.5938-1.6719 0.40625-0.73828 0.60938-1.6406 0.60938-2.7031 0-1.582-0.41797-2.7969-1.25-3.6406-0.82422-0.85156-1.8359-1.2812-3.0312-1.2812-1.2109 0-2.2188 0.42969-3.0312 1.2812-0.80469 0.84375-1.2031 2.0586-1.2031 3.6406 0 1.5859 0.39453 2.8047 1.1875 3.6562 0.78906 0.84375 1.7852 1.2656 2.9844 1.2656z"/>
-</g>
-<g transform="translate(835.45 1034)">
-<path d="m0.98438-8.375c0-1.6758 0.33203-3.1641 1-4.4688 0.67578-1.3008 1.5859-2.3008 2.7344-3 1.1562-0.69531 2.4414-1.0469 3.8594-1.0469 1.2383 0 2.3203 0.25 3.25 0.75 0.9375 0.5 1.6797 1.1328 2.2344 1.8906v-2.375h4.2344v16.625h-4.2344v-2.4375c-0.53125 0.78125-1.2773 1.4297-2.2344 1.9375-0.94922 0.50781-2.043 0.76562-3.2812 0.76562-1.3984 0-2.6719-0.35938-3.8281-1.0781-1.1484-0.71875-2.0586-1.7266-2.7344-3.0312-0.66797-1.3125-1-2.8203-1-4.5312zm13.078 0.0625c0-1.0195-0.19922-1.8945-0.59375-2.625-0.39844-0.72656-0.9375-1.2852-1.625-1.6719-0.67969-0.39453-1.4062-0.59375-2.1875-0.59375s-1.5 0.19531-2.1562 0.57812c-0.65625 0.375-1.1953 0.92969-1.6094 1.6562-0.40625 0.73047-0.60938 1.5938-0.60938 2.5938s0.20312 1.875 0.60938 2.625c0.41406 0.75 0.95703 1.3281 1.625 1.7344 0.66406 0.39844 1.3789 0.59375 2.1406 0.59375 0.78125 0 1.5078-0.19141 2.1875-0.57812 0.6875-0.39453 1.2266-0.95703 1.625-1.6875 0.39453-0.72656 0.59375-1.6016 0.59375-2.625z"/>
-</g>
-<g transform="translate(855.78 1034)">
-<path d="m6.2656-14.047c0.53906-0.875 1.2422-1.5625 2.1094-2.0625 0.875-0.5 1.875-0.75 3-0.75v4.4062h-1.1094c-1.3242 0-2.3242 0.3125-3 0.9375-0.66797 0.61719-1 1.6953-1 3.2344v8.2812h-4.2031v-16.625h4.2031z"/>
-</g>
-<g transform="translate(867.9 1034)">
-<path d="m0.98438-8.375c0-1.6758 0.33203-3.1641 1-4.4688 0.67578-1.3008 1.5938-2.3008 2.75-3 1.1641-0.69531 2.457-1.0469 3.875-1.0469 1.082 0 2.1133 0.23438 3.0938 0.70312 0.97656 0.46875 1.7578 1.0938 2.3438 1.875v-7.8906h4.25v22.203h-4.25v-2.4531c-0.52344 0.8125-1.2578 1.4688-2.2031 1.9688-0.9375 0.5-2.0273 0.75-3.2656 0.75-1.3984 0-2.6797-0.35938-3.8438-1.0781-1.1562-0.71875-2.0742-1.7266-2.75-3.0312-0.66797-1.3125-1-2.8203-1-4.5312zm13.078 0.0625c0-1.0195-0.19922-1.8945-0.59375-2.625-0.39844-0.72656-0.9375-1.2852-1.625-1.6719-0.67969-0.39453-1.4062-0.59375-2.1875-0.59375s-1.5 0.19531-2.1562 0.57812c-0.65625 0.375-1.1953 0.92969-1.6094 1.6562-0.40625 0.73047-0.60938 1.5938-0.60938 2.5938s0.20312 1.875 0.60938 2.625c0.41406 0.75 0.95703 1.3281 1.625 1.7344 0.66406 0.39844 1.3789 0.59375 2.1406 0.59375 0.78125 0 1.5078-0.19141 2.1875-0.57812 0.6875-0.39453 1.2266-0.95703 1.625-1.6875 0.39453-0.72656 0.59375-1.6016 0.59375-2.625z"/>
-</g>
-</g>
-<g>
-<g transform="translate(118.34 932.56)">
-<path d="m5.2969-12.547c1.3633 0 2.5469 0.25781 3.5469 0.76562 1 0.51172 1.7656 1.2422 2.2969 2.1875 0.53906 0.94922 0.8125 2.0625 0.8125 3.3438 0 1.293-0.27344 2.4062-0.8125 3.3438-0.53125 0.9375-1.2969 1.6562-2.2969 2.1562s-2.1836 0.75-3.5469 0.75h-3.9062v-12.547zm0 11.203c1.6133 0 2.8477-0.42578 3.7031-1.2812 0.85156-0.86328 1.2812-2.0703 1.2812-3.625 0-1.5625-0.43359-2.7812-1.2969-3.6562-0.85547-0.875-2.0859-1.3125-3.6875-1.3125h-2.2656v9.875z"/>
-</g>
-<g transform="translate(131.07 932.56)">
-<path d="m10.391-5.3125c0 0.3125-0.023437 0.64844-0.0625 1h-7.875c0.050781 0.96875 0.37891 1.7305 0.98438 2.2812 0.61328 0.54297 1.3516 0.8125 2.2188 0.8125 0.70703 0 1.2969-0.16406 1.7656-0.5 0.47656-0.33203 0.8125-0.77344 1-1.3281h1.7656c-0.26172 0.94922-0.78906 1.7188-1.5781 2.3125-0.79297 0.59375-1.7773 0.89062-2.9531 0.89062-0.9375 0-1.7773-0.20703-2.5156-0.625-0.74219-0.41406-1.3203-1.0078-1.7344-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.76953 0.97656-1.3633 1.7188-1.7812 0.73828-0.41406 1.5859-0.625 2.5469-0.625 0.9375 0 1.7656 0.21094 2.4844 0.625 0.71875 0.40625 1.2695 0.96875 1.6562 1.6875 0.39453 0.71094 0.59375 1.5117 0.59375 2.4062zm-1.7031-0.34375c0-0.625-0.14062-1.1602-0.42188-1.6094-0.27344-0.44531-0.64844-0.78516-1.125-1.0156-0.46875-0.23828-0.99219-0.35938-1.5625-0.35938-0.82422 0-1.5273 0.26562-2.1094 0.79688-0.58594 0.52344-0.91797 1.25-1 2.1875z"/>
-</g>
-<g transform="translate(142.23 932.56)">
-<path d="m6.5312 0-2.3438-3.6719-2.25 3.6719h-1.7031l3.1875-4.8906-3.1875-4.9688h1.8594l2.3281 3.6562 2.2344-3.6562h1.7188l-3.1719 4.875 3.1875 4.9844z"/>
-</g>
-<g transform="translate(213.86 932.56)">
-<path d="m7.0781 0.125c-1.168 0-2.2305-0.26953-3.1875-0.8125-0.96094-0.55078-1.7188-1.3164-2.2812-2.2969-0.55469-0.97656-0.82812-2.0781-0.82812-3.2969 0-1.2266 0.27344-2.3281 0.82812-3.2969 0.5625-0.97656 1.3203-1.7383 2.2812-2.2812 0.95703-0.55078 2.0195-0.82812 3.1875-0.82812 1.1758 0 2.2422 0.27734 3.2031 0.82812 0.95703 0.54297 1.7109 1.2969 2.2656 2.2656 0.55078 0.96875 0.82812 2.0742 0.82812 3.3125 0 1.2422-0.27734 2.3438-0.82812 3.3125-0.55469 0.96875-1.3086 1.7305-2.2656 2.2812-0.96094 0.54297-2.0273 0.8125-3.2031 0.8125zm0-1.4219c0.875 0 1.6602-0.20312 2.3594-0.60938 0.70703-0.40625 1.2578-0.98438 1.6562-1.7344 0.40625-0.75781 0.60938-1.6406 0.60938-2.6406 0-1.0078-0.20312-1.8906-0.60938-2.6406-0.39844-0.75-0.94531-1.3281-1.6406-1.7344-0.69922-0.40625-1.4922-0.60938-2.375-0.60938-0.89844 0-1.6953 0.20312-2.3906 0.60938-0.6875 0.40625-1.2344 0.98438-1.6406 1.7344-0.39844 0.75-0.59375 1.6328-0.59375 2.6406 0 1 0.19531 1.8828 0.59375 2.6406 0.40625 0.75 0.95703 1.3281 1.6562 1.7344 0.70703 0.40625 1.5 0.60938 2.375 0.60938z"/>
-</g>
-<g transform="translate(228 932.56)">
-<path d="m3.0312-8.0469c0.32031-0.5625 0.80078-1.0312 1.4375-1.4062 0.64453-0.38281 1.3945-0.57812 2.25-0.57812 0.875 0 1.6641 0.21484 2.375 0.64062 0.71875 0.41797 1.2812 1.0078 1.6875 1.7656 0.40625 0.76172 0.60938 1.6484 0.60938 2.6562 0 1-0.20312 1.8906-0.60938 2.6719-0.40625 0.77344-0.96875 1.375-1.6875 1.8125-0.71094 0.42969-1.5 0.64062-2.375 0.64062-0.84375 0-1.5898-0.1875-2.2344-0.5625-0.63672-0.375-1.1211-0.84375-1.4531-1.4062v6.5h-1.6406v-14.547h1.6406zm6.6875 3.0781c0-0.73828-0.15234-1.3828-0.45312-1.9375-0.30469-0.55078-0.71094-0.97266-1.2188-1.2656-0.5-0.28906-1.0586-0.4375-1.6719-0.4375-0.60547 0-1.1641 0.15234-1.6719 0.45312-0.51172 0.29297-0.91797 0.71875-1.2188 1.2812-0.30469 0.55469-0.45312 1.1953-0.45312 1.9219 0 0.75 0.14844 1.4062 0.45312 1.9688 0.30078 0.55469 0.70703 0.97656 1.2188 1.2656 0.50781 0.29297 1.0664 0.4375 1.6719 0.4375 0.61328 0 1.1719-0.14453 1.6719-0.4375 0.50781-0.28906 0.91406-0.71094 1.2188-1.2656 0.30078-0.5625 0.45312-1.2227 0.45312-1.9844z"/>
-</g>
-<g transform="translate(240.17 932.56)">
-<path d="m10.391-5.3125c0 0.3125-0.023437 0.64844-0.0625 1h-7.875c0.050781 0.96875 0.37891 1.7305 0.98438 2.2812 0.61328 0.54297 1.3516 0.8125 2.2188 0.8125 0.70703 0 1.2969-0.16406 1.7656-0.5 0.47656-0.33203 0.8125-0.77344 1-1.3281h1.7656c-0.26172 0.94922-0.78906 1.7188-1.5781 2.3125-0.79297 0.59375-1.7773 0.89062-2.9531 0.89062-0.9375 0-1.7773-0.20703-2.5156-0.625-0.74219-0.41406-1.3203-1.0078-1.7344-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.76953 0.97656-1.3633 1.7188-1.7812 0.73828-0.41406 1.5859-0.625 2.5469-0.625 0.9375 0 1.7656 0.21094 2.4844 0.625 0.71875 0.40625 1.2695 0.96875 1.6562 1.6875 0.39453 0.71094 0.59375 1.5117 0.59375 2.4062zm-1.7031-0.34375c0-0.625-0.14062-1.1602-0.42188-1.6094-0.27344-0.44531-0.64844-0.78516-1.125-1.0156-0.46875-0.23828-0.99219-0.35938-1.5625-0.35938-0.82422 0-1.5273 0.26562-2.1094 0.79688-0.58594 0.52344-0.91797 1.25-1 2.1875z"/>
-</g>
-<g transform="translate(251.33 932.56)">
-<path d="m6.1875-10.047c1.1953 0 2.1641 0.36719 2.9062 1.0938 0.75 0.73047 1.125 1.7773 1.125 3.1406v5.8125h-1.6094v-5.5781c0-0.98828-0.25-1.7422-0.75-2.2656-0.49219-0.51953-1.1641-0.78125-2.0156-0.78125-0.86719 0-1.5547 0.27344-2.0625 0.8125-0.5 0.54297-0.75 1.3281-0.75 2.3594v5.4531h-1.6406v-9.8594h1.6406v1.4062c0.32031-0.50781 0.75781-0.89844 1.3125-1.1719 0.5625-0.28125 1.1758-0.42188 1.8438-0.42188z"/>
-</g>
-<g transform="translate(262.85 932.56)">
-<path d="m5.3594 0.125c-0.82422 0-1.5625-0.14453-2.2188-0.4375-0.65625-0.28906-1.1719-0.69531-1.5469-1.2188-0.36719-0.53125-0.55469-1.1328-0.5625-1.8125h1.7344c0.0625 0.58594 0.30469 1.0781 0.73438 1.4844 0.42578 0.39844 1.0469 0.59375 1.8594 0.59375 0.78125 0 1.3945-0.19141 1.8438-0.57812 0.45703-0.39453 0.6875-0.89453 0.6875-1.5 0-0.47656-0.13672-0.86719-0.40625-1.1719-0.26172-0.30078-0.58984-0.53125-0.98438-0.6875-0.39844-0.15625-0.93359-0.32031-1.6094-0.5-0.82422-0.21875-1.4844-0.42969-1.9844-0.64062-0.5-0.21875-0.92969-0.55469-1.2812-1.0156-0.35547-0.46875-0.53125-1.0938-0.53125-1.875 0-0.6875 0.17188-1.2891 0.51562-1.8125 0.35156-0.53125 0.84375-0.9375 1.4688-1.2188 0.63281-0.28906 1.3594-0.4375 2.1719-0.4375 1.1758 0 2.1406 0.29688 2.8906 0.89062 0.75 0.58594 1.1719 1.3594 1.2656 2.3281h-1.7969c-0.054687-0.47656-0.30469-0.89844-0.75-1.2656-0.44922-0.36328-1.0391-0.54688-1.7656-0.54688-0.6875 0-1.25 0.17969-1.6875 0.53125-0.42969 0.35547-0.64062 0.85156-0.64062 1.4844 0 0.44922 0.12891 0.82031 0.39062 1.1094 0.25781 0.29297 0.57812 0.51172 0.95312 0.65625 0.38281 0.14844 0.91406 0.32031 1.5938 0.51562 0.83203 0.23047 1.5 0.45312 2 0.67188s0.92969 0.5625 1.2969 1.0312c0.36328 0.46094 0.54688 1.0859 0.54688 1.875 0 0.61719-0.16797 1.1953-0.5 1.7344-0.32422 0.54297-0.80469 0.98047-1.4375 1.3125-0.63672 0.33594-1.3867 0.5-2.25 0.5z"/>
-</g>
-<g transform="translate(273.42 932.56)">
-<path d="m10.391-5.3125c0 0.3125-0.023437 0.64844-0.0625 1h-7.875c0.050781 0.96875 0.37891 1.7305 0.98438 2.2812 0.61328 0.54297 1.3516 0.8125 2.2188 0.8125 0.70703 0 1.2969-0.16406 1.7656-0.5 0.47656-0.33203 0.8125-0.77344 1-1.3281h1.7656c-0.26172 0.94922-0.78906 1.7188-1.5781 2.3125-0.79297 0.59375-1.7773 0.89062-2.9531 0.89062-0.9375 0-1.7773-0.20703-2.5156-0.625-0.74219-0.41406-1.3203-1.0078-1.7344-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.76953 0.97656-1.3633 1.7188-1.7812 0.73828-0.41406 1.5859-0.625 2.5469-0.625 0.9375 0 1.7656 0.21094 2.4844 0.625 0.71875 0.40625 1.2695 0.96875 1.6562 1.6875 0.39453 0.71094 0.59375 1.5117 0.59375 2.4062zm-1.7031-0.34375c0-0.625-0.14062-1.1602-0.42188-1.6094-0.27344-0.44531-0.64844-0.78516-1.125-1.0156-0.46875-0.23828-0.99219-0.35938-1.5625-0.35938-0.82422 0-1.5273 0.26562-2.1094 0.79688-0.58594 0.52344-0.91797 1.25-1 2.1875z"/>
-</g>
-<g transform="translate(284.58 932.56)">
-<path d="m0.78125-4.9688c0-1.0078 0.20312-1.8945 0.60938-2.6562 0.40625-0.75781 0.96094-1.3477 1.6719-1.7656 0.71875-0.42578 1.5156-0.64062 2.3906-0.64062 0.86328 0 1.6133 0.1875 2.25 0.5625 0.63281 0.375 1.1094 0.84375 1.4219 1.4062v-1.7969h1.6562v9.8594h-1.6562v-1.8438c-0.32422 0.58594-0.80859 1.0625-1.4531 1.4375-0.63672 0.375-1.3828 0.5625-2.2344 0.5625-0.875 0-1.668-0.21094-2.375-0.64062-0.71094-0.4375-1.2656-1.0391-1.6719-1.8125-0.40625-0.78125-0.60938-1.6719-0.60938-2.6719zm8.3438 0.015625c0-0.73828-0.15234-1.3828-0.45312-1.9375-0.30469-0.55078-0.71094-0.97266-1.2188-1.2656-0.5-0.30078-1.0586-0.45312-1.6719-0.45312-0.61719 0-1.1797 0.14844-1.6875 0.4375-0.5 0.29297-0.90234 0.71484-1.2031 1.2656-0.29297 0.55469-0.4375 1.1992-0.4375 1.9375 0 0.76172 0.14453 1.4219 0.4375 1.9844 0.30078 0.55469 0.70312 0.97656 1.2031 1.2656 0.50781 0.29297 1.0703 0.4375 1.6875 0.4375 0.61328 0 1.1719-0.14453 1.6719-0.4375 0.50781-0.28906 0.91406-0.71094 1.2188-1.2656 0.30078-0.5625 0.45312-1.2188 0.45312-1.9688z"/>
-</g>
-<g transform="translate(296.74 932.56)">
-<path d="m3.0312-8.2656c0.28125-0.5625 0.6875-1 1.2188-1.3125 0.53906-0.3125 1.1914-0.46875 1.9531-0.46875v1.6875h-0.42188c-1.8359 0-2.75 1-2.75 3v5.3594h-1.6406v-9.8594h1.6406z"/>
-</g>
-<g transform="translate(303.46 932.56)">
-<path d="m0.78125-4.9531c0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.75781 0.96875-1.3477 1.6875-1.7656 0.72656-0.42578 1.5625-0.64062 2.5-0.64062 1.207 0 2.2031 0.29688 2.9844 0.89062 0.78906 0.58594 1.3164 1.3984 1.5781 2.4375h-1.7656c-0.16797-0.59375-0.49609-1.0625-0.98438-1.4062-0.49219-0.35156-1.0938-0.53125-1.8125-0.53125-0.9375 0-1.6953 0.32422-2.2656 0.96875-0.57422 0.63672-0.85938 1.543-0.85938 2.7188 0 1.1875 0.28516 2.1094 0.85938 2.7656 0.57031 0.64844 1.3281 0.96875 2.2656 0.96875 0.71875 0 1.3164-0.16406 1.7969-0.5 0.47656-0.34375 0.8125-0.82812 1-1.4531h1.7656c-0.27344 1.0117-0.80469 1.8203-1.5938 2.4219-0.79297 0.60547-1.7812 0.90625-2.9688 0.90625-0.9375 0-1.7734-0.20703-2.5-0.625-0.71875-0.41406-1.2812-1.0078-1.6875-1.7812-0.40625-0.76953-0.60938-1.6719-0.60938-2.7031z"/>
-</g>
-<g transform="translate(314.38 932.56)">
-<path d="m6.2812-10.047c0.73828 0 1.4102 0.16406 2.0156 0.48438 0.60156 0.3125 1.0703 0.78906 1.4062 1.4219 0.34375 0.63672 0.51562 1.4141 0.51562 2.3281v5.8125h-1.6094v-5.5781c0-0.98828-0.25-1.7422-0.75-2.2656-0.49219-0.51953-1.1641-0.78125-2.0156-0.78125-0.86719 0-1.5547 0.27344-2.0625 0.8125-0.5 0.54297-0.75 1.3281-0.75 2.3594v5.4531h-1.6406v-13.312h1.6406v4.8594c0.32031-0.50781 0.76562-0.89844 1.3281-1.1719 0.57031-0.28125 1.2109-0.42188 1.9219-0.42188z"/>
-</g>
-<g transform="translate(325.9 932.56)">
-<path d="m4.5938-12.703c0.69531 0 1.3203 0.16406 1.875 0.48438 0.55078 0.3125 0.97656 0.75 1.2812 1.3125 0.3125 0.55469 0.46875 1.1797 0.46875 1.875 0 0.69922-0.15625 1.3281-0.46875 1.8906-0.30469 0.5625-0.73047 1.0078-1.2812 1.3281-0.55469 0.3125-1.1797 0.46875-1.875 0.46875-0.71094 0-1.3398-0.15625-1.8906-0.46875-0.55469-0.32031-0.98438-0.76562-1.2969-1.3281s-0.46875-1.1914-0.46875-1.8906c0-0.69531 0.15625-1.3203 0.46875-1.875 0.3125-0.5625 0.74219-1 1.2969-1.3125 0.55078-0.32031 1.1797-0.48438 1.8906-0.48438zm0 6.6406c0.86328 0 1.5625-0.27344 2.0938-0.82812 0.53125-0.55078 0.79688-1.2656 0.79688-2.1406s-0.26562-1.5859-0.79688-2.1406c-0.53125-0.55078-1.2305-0.82812-2.0938-0.82812-0.875 0-1.5781 0.27734-2.1094 0.82812-0.52344 0.55469-0.78125 1.2656-0.78125 2.1406s0.25781 1.5898 0.78125 2.1406c0.53125 0.55469 1.2344 0.82812 2.1094 0.82812zm1.6094-3.7344c0 0.29297-0.074219 0.53906-0.21875 0.73438-0.14844 0.19922-0.35547 0.33984-0.625 0.42188l1.0156 1.5-1.1406 0.015625-0.85938-1.4375h-0.3125v1.4375h-0.9375v-3.875h1.7344c0.40625 0 0.72656 0.10938 0.96875 0.32812 0.25 0.21875 0.375 0.51172 0.375 0.875zm-2.1406 0.45312h0.75c0.125 0 0.23438-0.035156 0.32812-0.10938 0.09375-0.070313 0.14062-0.17188 0.14062-0.29688 0-0.13281-0.046875-0.23438-0.14062-0.29688-0.09375-0.070313-0.20312-0.10938-0.32812-0.10938h-0.75z"/>
-</g>
-<g transform="translate(402.81 932.56)">
-<path d="m11.75-12.547-4.7344 12.547h-1.8906l-4.7344-12.547h1.75l3.9375 10.812 3.9531-10.812z"/>
-</g>
-<g transform="translate(414.98 932.56)">
-<path d="m10.391-5.3125c0 0.3125-0.023437 0.64844-0.0625 1h-7.875c0.050781 0.96875 0.37891 1.7305 0.98438 2.2812 0.61328 0.54297 1.3516 0.8125 2.2188 0.8125 0.70703 0 1.2969-0.16406 1.7656-0.5 0.47656-0.33203 0.8125-0.77344 1-1.3281h1.7656c-0.26172 0.94922-0.78906 1.7188-1.5781 2.3125-0.79297 0.59375-1.7773 0.89062-2.9531 0.89062-0.9375 0-1.7773-0.20703-2.5156-0.625-0.74219-0.41406-1.3203-1.0078-1.7344-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.76953 0.97656-1.3633 1.7188-1.7812 0.73828-0.41406 1.5859-0.625 2.5469-0.625 0.9375 0 1.7656 0.21094 2.4844 0.625 0.71875 0.40625 1.2695 0.96875 1.6562 1.6875 0.39453 0.71094 0.59375 1.5117 0.59375 2.4062zm-1.7031-0.34375c0-0.625-0.14062-1.1602-0.42188-1.6094-0.27344-0.44531-0.64844-0.78516-1.125-1.0156-0.46875-0.23828-0.99219-0.35938-1.5625-0.35938-0.82422 0-1.5273 0.26562-2.1094 0.79688-0.58594 0.52344-0.91797 1.25-1 2.1875z"/>
-</g>
-<g transform="translate(426.14 932.56)">
-<path d="m3.0312-13.312v13.312h-1.6406v-13.312z"/>
-</g>
-<g transform="translate(430.57 932.56)">
-<path d="m10.391-5.3125c0 0.3125-0.023437 0.64844-0.0625 1h-7.875c0.050781 0.96875 0.37891 1.7305 0.98438 2.2812 0.61328 0.54297 1.3516 0.8125 2.2188 0.8125 0.70703 0 1.2969-0.16406 1.7656-0.5 0.47656-0.33203 0.8125-0.77344 1-1.3281h1.7656c-0.26172 0.94922-0.78906 1.7188-1.5781 2.3125-0.79297 0.59375-1.7773 0.89062-2.9531 0.89062-0.9375 0-1.7773-0.20703-2.5156-0.625-0.74219-0.41406-1.3203-1.0078-1.7344-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.76953 0.97656-1.3633 1.7188-1.7812 0.73828-0.41406 1.5859-0.625 2.5469-0.625 0.9375 0 1.7656 0.21094 2.4844 0.625 0.71875 0.40625 1.2695 0.96875 1.6562 1.6875 0.39453 0.71094 0.59375 1.5117 0.59375 2.4062zm-1.7031-0.34375c0-0.625-0.14062-1.1602-0.42188-1.6094-0.27344-0.44531-0.64844-0.78516-1.125-1.0156-0.46875-0.23828-0.99219-0.35938-1.5625-0.35938-0.82422 0-1.5273 0.26562-2.1094 0.79688-0.58594 0.52344-0.91797 1.25-1 2.1875z"/>
-</g>
-<g transform="translate(441.73 932.56)">
-<path d="m3.0312-8.2656c0.28125-0.5625 0.6875-1 1.2188-1.3125 0.53906-0.3125 1.1914-0.46875 1.9531-0.46875v1.6875h-0.42188c-1.8359 0-2.75 1-2.75 3v5.3594h-1.6406v-9.8594h1.6406z"/>
-</g>
-<g transform="translate(448.44 932.56)">
-<path d="m5.6875 0.15625c-0.92969 0-1.7656-0.20703-2.5156-0.625-0.75-0.41406-1.3398-1.0078-1.7656-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0078 0.21875-1.8984 0.65625-2.6719 0.4375-0.76953 1.0312-1.3633 1.7812-1.7812 0.75781-0.41406 1.6094-0.625 2.5469-0.625 0.92578 0 1.7695 0.21094 2.5312 0.625 0.75781 0.41797 1.3594 1.0117 1.7969 1.7812 0.4375 0.76172 0.65625 1.6523 0.65625 2.6719 0 1.0234-0.23047 1.9219-0.6875 2.7031-0.44922 0.77344-1.0586 1.3672-1.8281 1.7812-0.76172 0.41797-1.6094 0.625-2.5469 0.625zm0-1.4375c0.58203 0 1.1328-0.13281 1.6562-0.40625 0.51953-0.28125 0.9375-0.69531 1.25-1.25 0.32031-0.55078 0.48438-1.2227 0.48438-2.0156 0-0.78906-0.15625-1.4609-0.46875-2.0156-0.3125-0.55078-0.72656-0.96094-1.2344-1.2344-0.5-0.26953-1.0469-0.40625-1.6406-0.40625s-1.1406 0.13672-1.6406 0.40625c-0.5 0.27344-0.90234 0.68359-1.2031 1.2344-0.29297 0.55469-0.4375 1.2266-0.4375 2.0156 0 0.80469 0.14453 1.4805 0.4375 2.0312 0.28906 0.55469 0.67969 0.96484 1.1719 1.2344 0.5 0.27344 1.0391 0.40625 1.625 0.40625z"/>
-</g>
-<g transform="translate(531.31 932.56)">
-<path d="m10.891-8.9062c-0.34375-0.73828-0.85156-1.3047-1.5156-1.7031-0.65625-0.40625-1.4219-0.60938-2.2969-0.60938s-1.668 0.20312-2.375 0.60938c-0.69922 0.39844-1.25 0.96875-1.6562 1.7188-0.39844 0.75-0.59375 1.6211-0.59375 2.6094 0 0.98047 0.19531 1.8438 0.59375 2.5938 0.40625 0.74219 0.95703 1.3125 1.6562 1.7188 0.70703 0.39844 1.5 0.59375 2.375 0.59375 1.2188 0 2.2227-0.36328 3.0156-1.0938 0.78906-0.72656 1.2539-1.7188 1.3906-2.9688h-5v-1.3281h6.75v1.25c-0.10547 1.043-0.43359 1.9922-0.98438 2.8438-0.54297 0.85547-1.2656 1.5312-2.1719 2.0312-0.89844 0.5-1.8984 0.75-3 0.75-1.168 0-2.2305-0.26953-3.1875-0.8125-0.96094-0.55078-1.7188-1.3125-2.2812-2.2812-0.55469-0.97656-0.82812-2.0781-0.82812-3.2969 0-1.2266 0.27344-2.3281 0.82812-3.2969 0.5625-0.97656 1.3203-1.7383 2.2812-2.2812 0.95703-0.55078 2.0195-0.82812 3.1875-0.82812 1.332 0 2.5078 0.33594 3.5312 1 1.0312 0.65625 1.7812 1.5859 2.25 2.7812z"/>
-</g>
-<g transform="translate(545.31 932.56)">
-<path d="m0.78125-4.9688c0-1.0078 0.20312-1.8945 0.60938-2.6562 0.40625-0.75781 0.96094-1.3477 1.6719-1.7656 0.71875-0.42578 1.5156-0.64062 2.3906-0.64062 0.86328 0 1.6133 0.1875 2.25 0.5625 0.63281 0.375 1.1094 0.84375 1.4219 1.4062v-1.7969h1.6562v9.8594h-1.6562v-1.8438c-0.32422 0.58594-0.80859 1.0625-1.4531 1.4375-0.63672 0.375-1.3828 0.5625-2.2344 0.5625-0.875 0-1.668-0.21094-2.375-0.64062-0.71094-0.4375-1.2656-1.0391-1.6719-1.8125-0.40625-0.78125-0.60938-1.6719-0.60938-2.6719zm8.3438 0.015625c0-0.73828-0.15234-1.3828-0.45312-1.9375-0.30469-0.55078-0.71094-0.97266-1.2188-1.2656-0.5-0.30078-1.0586-0.45312-1.6719-0.45312-0.61719 0-1.1797 0.14844-1.6875 0.4375-0.5 0.29297-0.90234 0.71484-1.2031 1.2656-0.29297 0.55469-0.4375 1.1992-0.4375 1.9375 0 0.76172 0.14453 1.4219 0.4375 1.9844 0.30078 0.55469 0.70312 0.97656 1.2031 1.2656 0.50781 0.29297 1.0703 0.4375 1.6875 0.4375 0.61328 0 1.1719-0.14453 1.6719-0.4375 0.50781-0.28906 0.91406-0.71094 1.2188-1.2656 0.30078-0.5625 0.45312-1.2188 0.45312-1.9688z"/>
-</g>
-<g transform="translate(557.48 932.56)">
-<path d="m3.3906-8.5156v5.8125c0 0.48047 0.097656 0.82031 0.29688 1.0156 0.20703 0.19922 0.5625 0.29688 1.0625 0.29688h1.2031v1.3906h-1.4688c-0.91797 0-1.6055-0.20703-2.0625-0.625-0.44922-0.42578-0.67188-1.1172-0.67188-2.0781v-5.8125h-1.2812v-1.3438h1.2812v-2.4844h1.6406v2.4844h2.5625v1.3438z"/>
-</g>
-<g transform="translate(564.03 932.56)">
-<path d="m10.391-5.3125c0 0.3125-0.023437 0.64844-0.0625 1h-7.875c0.050781 0.96875 0.37891 1.7305 0.98438 2.2812 0.61328 0.54297 1.3516 0.8125 2.2188 0.8125 0.70703 0 1.2969-0.16406 1.7656-0.5 0.47656-0.33203 0.8125-0.77344 1-1.3281h1.7656c-0.26172 0.94922-0.78906 1.7188-1.5781 2.3125-0.79297 0.59375-1.7773 0.89062-2.9531 0.89062-0.9375 0-1.7773-0.20703-2.5156-0.625-0.74219-0.41406-1.3203-1.0078-1.7344-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.76953 0.97656-1.3633 1.7188-1.7812 0.73828-0.41406 1.5859-0.625 2.5469-0.625 0.9375 0 1.7656 0.21094 2.4844 0.625 0.71875 0.40625 1.2695 0.96875 1.6562 1.6875 0.39453 0.71094 0.59375 1.5117 0.59375 2.4062zm-1.7031-0.34375c0-0.625-0.14062-1.1602-0.42188-1.6094-0.27344-0.44531-0.64844-0.78516-1.125-1.0156-0.46875-0.23828-0.99219-0.35938-1.5625-0.35938-0.82422 0-1.5273 0.26562-2.1094 0.79688-0.58594 0.52344-0.91797 1.25-1 2.1875z"/>
-</g>
-<g transform="translate(575.19 932.56)">
-<path d="m6.8906 0-3.8594-4.3594v4.3594h-1.6406v-13.312h1.6406v7.8281l3.7969-4.375h2.2812l-4.6406 4.9062 4.6562 4.9531z"/>
-</g>
-<g transform="translate(584.46 932.56)">
-<path d="m10.391-5.3125c0 0.3125-0.023437 0.64844-0.0625 1h-7.875c0.050781 0.96875 0.37891 1.7305 0.98438 2.2812 0.61328 0.54297 1.3516 0.8125 2.2188 0.8125 0.70703 0 1.2969-0.16406 1.7656-0.5 0.47656-0.33203 0.8125-0.77344 1-1.3281h1.7656c-0.26172 0.94922-0.78906 1.7188-1.5781 2.3125-0.79297 0.59375-1.7773 0.89062-2.9531 0.89062-0.9375 0-1.7773-0.20703-2.5156-0.625-0.74219-0.41406-1.3203-1.0078-1.7344-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.76953 0.97656-1.3633 1.7188-1.7812 0.73828-0.41406 1.5859-0.625 2.5469-0.625 0.9375 0 1.7656 0.21094 2.4844 0.625 0.71875 0.40625 1.2695 0.96875 1.6562 1.6875 0.39453 0.71094 0.59375 1.5117 0.59375 2.4062zm-1.7031-0.34375c0-0.625-0.14062-1.1602-0.42188-1.6094-0.27344-0.44531-0.64844-0.78516-1.125-1.0156-0.46875-0.23828-0.99219-0.35938-1.5625-0.35938-0.82422 0-1.5273 0.26562-2.1094 0.79688-0.58594 0.52344-0.91797 1.25-1 2.1875z"/>
-</g>
-<g transform="translate(595.62 932.56)">
-<path d="m10.391-5.3125c0 0.3125-0.023437 0.64844-0.0625 1h-7.875c0.050781 0.96875 0.37891 1.7305 0.98438 2.2812 0.61328 0.54297 1.3516 0.8125 2.2188 0.8125 0.70703 0 1.2969-0.16406 1.7656-0.5 0.47656-0.33203 0.8125-0.77344 1-1.3281h1.7656c-0.26172 0.94922-0.78906 1.7188-1.5781 2.3125-0.79297 0.59375-1.7773 0.89062-2.9531 0.89062-0.9375 0-1.7773-0.20703-2.5156-0.625-0.74219-0.41406-1.3203-1.0078-1.7344-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.76953 0.97656-1.3633 1.7188-1.7812 0.73828-0.41406 1.5859-0.625 2.5469-0.625 0.9375 0 1.7656 0.21094 2.4844 0.625 0.71875 0.40625 1.2695 0.96875 1.6562 1.6875 0.39453 0.71094 0.59375 1.5117 0.59375 2.4062zm-1.7031-0.34375c0-0.625-0.14062-1.1602-0.42188-1.6094-0.27344-0.44531-0.64844-0.78516-1.125-1.0156-0.46875-0.23828-0.99219-0.35938-1.5625-0.35938-0.82422 0-1.5273 0.26562-2.1094 0.79688-0.58594 0.52344-0.91797 1.25-1 2.1875z"/>
-</g>
-<g transform="translate(606.78 932.56)">
-<path d="m3.0312-8.0469c0.32031-0.5625 0.80078-1.0312 1.4375-1.4062 0.64453-0.38281 1.3945-0.57812 2.25-0.57812 0.875 0 1.6641 0.21484 2.375 0.64062 0.71875 0.41797 1.2812 1.0078 1.6875 1.7656 0.40625 0.76172 0.60938 1.6484 0.60938 2.6562 0 1-0.20312 1.8906-0.60938 2.6719-0.40625 0.77344-0.96875 1.375-1.6875 1.8125-0.71094 0.42969-1.5 0.64062-2.375 0.64062-0.84375 0-1.5898-0.1875-2.2344-0.5625-0.63672-0.375-1.1211-0.84375-1.4531-1.4062v6.5h-1.6406v-14.547h1.6406zm6.6875 3.0781c0-0.73828-0.15234-1.3828-0.45312-1.9375-0.30469-0.55078-0.71094-0.97266-1.2188-1.2656-0.5-0.28906-1.0586-0.4375-1.6719-0.4375-0.60547 0-1.1641 0.15234-1.6719 0.45312-0.51172 0.29297-0.91797 0.71875-1.2188 1.2812-0.30469 0.55469-0.45312 1.1953-0.45312 1.9219 0 0.75 0.14844 1.4062 0.45312 1.9688 0.30078 0.55469 0.70703 0.97656 1.2188 1.2656 0.50781 0.29297 1.0664 0.4375 1.6719 0.4375 0.61328 0 1.1719-0.14453 1.6719-0.4375 0.50781-0.28906 0.91406-0.71094 1.2188-1.2656 0.30078-0.5625 0.45312-1.2227 0.45312-1.9844z"/>
-</g>
-<g transform="translate(618.95 932.56)">
-<path d="m10.391-5.3125c0 0.3125-0.023437 0.64844-0.0625 1h-7.875c0.050781 0.96875 0.37891 1.7305 0.98438 2.2812 0.61328 0.54297 1.3516 0.8125 2.2188 0.8125 0.70703 0 1.2969-0.16406 1.7656-0.5 0.47656-0.33203 0.8125-0.77344 1-1.3281h1.7656c-0.26172 0.94922-0.78906 1.7188-1.5781 2.3125-0.79297 0.59375-1.7773 0.89062-2.9531 0.89062-0.9375 0-1.7773-0.20703-2.5156-0.625-0.74219-0.41406-1.3203-1.0078-1.7344-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.76953 0.97656-1.3633 1.7188-1.7812 0.73828-0.41406 1.5859-0.625 2.5469-0.625 0.9375 0 1.7656 0.21094 2.4844 0.625 0.71875 0.40625 1.2695 0.96875 1.6562 1.6875 0.39453 0.71094 0.59375 1.5117 0.59375 2.4062zm-1.7031-0.34375c0-0.625-0.14062-1.1602-0.42188-1.6094-0.27344-0.44531-0.64844-0.78516-1.125-1.0156-0.46875-0.23828-0.99219-0.35938-1.5625-0.35938-0.82422 0-1.5273 0.26562-2.1094 0.79688-0.58594 0.52344-0.91797 1.25-1 2.1875z"/>
-</g>
-<g transform="translate(630.11 932.56)">
-<path d="m3.0312-8.2656c0.28125-0.5625 0.6875-1 1.2188-1.3125 0.53906-0.3125 1.1914-0.46875 1.9531-0.46875v1.6875h-0.42188c-1.8359 0-2.75 1-2.75 3v5.3594h-1.6406v-9.8594h1.6406z"/>
-</g>
-<g transform="translate(636.82 932.56)">
-<path d="m0.45312-12.672h4.3594v1.0156h-1.5312v5.3125h-1.2969l0.015625-5.3125h-1.5469zm12.594 0v6.3281h-1.2031l-0.015625-4.5781-1.9688 4.5781h-0.90625l-1.9531-4.6562v4.6562h-1.1875v-6.3281h1.6719l1.9688 4.8125 2.0156-4.8125z"/>
-</g>
-<g transform="translate(730.94 932.56)">
-<path d="m9.1094-12.547v1.3281h-3.4219v11.219h-1.6406v-11.219h-3.4375v-1.3281z"/>
-</g>
-<g transform="translate(740.68 932.56)">
-<path d="m3.0312-8.2656c0.28125-0.5625 0.6875-1 1.2188-1.3125 0.53906-0.3125 1.1914-0.46875 1.9531-0.46875v1.6875h-0.42188c-1.8359 0-2.75 1-2.75 3v5.3594h-1.6406v-9.8594h1.6406z"/>
-</g>
-<g transform="translate(747.39 932.56)">
-<path d="m2.2344-11.469c-0.3125 0-0.57812-0.10156-0.79688-0.3125-0.21875-0.21875-0.32812-0.48438-0.32812-0.79688s0.10938-0.57812 0.32812-0.79688 0.48438-0.32812 0.79688-0.32812c0.30078 0 0.55469 0.10938 0.76562 0.32812 0.20703 0.21875 0.3125 0.48438 0.3125 0.79688s-0.10547 0.57812-0.3125 0.79688c-0.21094 0.21094-0.46484 0.3125-0.76562 0.3125zm0.79688 1.6094v9.8594h-1.6406v-9.8594z"/>
-</g>
-<g transform="translate(751.82 932.56)">
-<path d="m5.0625-1.5156 3.0625-8.3438h1.7344l-3.8594 9.8594h-1.9062l-3.875-9.8594h1.7656z"/>
-</g>
-<g transform="translate(761.92 932.56)">
-<path d="m9.875-9.8594-5.9375 14.5h-1.6875l1.9375-4.75-3.9688-9.75h1.8125l3.0938 7.9844 3.0625-7.9844z"/>
-</g>
-<g transform="translate(872.3 932.56)">
-<path d="m8.4844-12.547v1.3281h-5.4531v4.2344h4.4219v1.3281h-4.4219v5.6562h-1.6406v-12.547z"/>
-</g>
-<g transform="translate(881.38 932.56)">
-<path d="m0.78125-4.9688c0-1.0078 0.20312-1.8945 0.60938-2.6562 0.40625-0.75781 0.96094-1.3477 1.6719-1.7656 0.71875-0.42578 1.5156-0.64062 2.3906-0.64062 0.86328 0 1.6133 0.1875 2.25 0.5625 0.63281 0.375 1.1094 0.84375 1.4219 1.4062v-1.7969h1.6562v9.8594h-1.6562v-1.8438c-0.32422 0.58594-0.80859 1.0625-1.4531 1.4375-0.63672 0.375-1.3828 0.5625-2.2344 0.5625-0.875 0-1.668-0.21094-2.375-0.64062-0.71094-0.4375-1.2656-1.0391-1.6719-1.8125-0.40625-0.78125-0.60938-1.6719-0.60938-2.6719zm8.3438 0.015625c0-0.73828-0.15234-1.3828-0.45312-1.9375-0.30469-0.55078-0.71094-0.97266-1.2188-1.2656-0.5-0.30078-1.0586-0.45312-1.6719-0.45312-0.61719 0-1.1797 0.14844-1.6875 0.4375-0.5 0.29297-0.90234 0.71484-1.2031 1.2656-0.29297 0.55469-0.4375 1.1992-0.4375 1.9375 0 0.76172 0.14453 1.4219 0.4375 1.9844 0.30078 0.55469 0.70312 0.97656 1.2031 1.2656 0.50781 0.29297 1.0703 0.4375 1.6875 0.4375 0.61328 0 1.1719-0.14453 1.6719-0.4375 0.50781-0.28906 0.91406-0.71094 1.2188-1.2656 0.30078-0.5625 0.45312-1.2188 0.45312-1.9688z"/>
-</g>
-<g transform="translate(893.54 932.56)">
-<path d="m3.0312-13.312v13.312h-1.6406v-13.312z"/>
-</g>
-<g transform="translate(897.97 932.56)">
-<path d="m0.78125-4.9531c0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.75781 0.96875-1.3477 1.6875-1.7656 0.72656-0.42578 1.5625-0.64062 2.5-0.64062 1.207 0 2.2031 0.29688 2.9844 0.89062 0.78906 0.58594 1.3164 1.3984 1.5781 2.4375h-1.7656c-0.16797-0.59375-0.49609-1.0625-0.98438-1.4062-0.49219-0.35156-1.0938-0.53125-1.8125-0.53125-0.9375 0-1.6953 0.32422-2.2656 0.96875-0.57422 0.63672-0.85938 1.543-0.85938 2.7188 0 1.1875 0.28516 2.1094 0.85938 2.7656 0.57031 0.64844 1.3281 0.96875 2.2656 0.96875 0.71875 0 1.3164-0.16406 1.7969-0.5 0.47656-0.34375 0.8125-0.82812 1-1.4531h1.7656c-0.27344 1.0117-0.80469 1.8203-1.5938 2.4219-0.79297 0.60547-1.7812 0.90625-2.9688 0.90625-0.9375 0-1.7734-0.20703-2.5-0.625-0.71875-0.41406-1.2812-1.0078-1.6875-1.7812-0.40625-0.76953-0.60938-1.6719-0.60938-2.7031z"/>
-</g>
-<g transform="translate(908.9 932.56)">
-<path d="m5.6875 0.15625c-0.92969 0-1.7656-0.20703-2.5156-0.625-0.75-0.41406-1.3398-1.0078-1.7656-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0078 0.21875-1.8984 0.65625-2.6719 0.4375-0.76953 1.0312-1.3633 1.7812-1.7812 0.75781-0.41406 1.6094-0.625 2.5469-0.625 0.92578 0 1.7695 0.21094 2.5312 0.625 0.75781 0.41797 1.3594 1.0117 1.7969 1.7812 0.4375 0.76172 0.65625 1.6523 0.65625 2.6719 0 1.0234-0.23047 1.9219-0.6875 2.7031-0.44922 0.77344-1.0586 1.3672-1.8281 1.7812-0.76172 0.41797-1.6094 0.625-2.5469 0.625zm0-1.4375c0.58203 0 1.1328-0.13281 1.6562-0.40625 0.51953-0.28125 0.9375-0.69531 1.25-1.25 0.32031-0.55078 0.48438-1.2227 0.48438-2.0156 0-0.78906-0.15625-1.4609-0.46875-2.0156-0.3125-0.55078-0.72656-0.96094-1.2344-1.2344-0.5-0.26953-1.0469-0.40625-1.6406-0.40625s-1.1406 0.13672-1.6406 0.40625c-0.5 0.27344-0.90234 0.68359-1.2031 1.2344-0.29297 0.55469-0.4375 1.2266-0.4375 2.0156 0 0.80469 0.14453 1.4805 0.4375 2.0312 0.28906 0.55469 0.67969 0.96484 1.1719 1.2344 0.5 0.27344 1.0391 0.40625 1.625 0.40625z"/>
-</g>
-<g transform="translate(920.42 932.56)">
-<path d="m0.45312-12.672h4.3594v1.0156h-1.5312v5.3125h-1.2969l0.015625-5.3125h-1.5469zm12.594 0v6.3281h-1.2031l-0.015625-4.5781-1.9688 4.5781h-0.90625l-1.9531-4.6562v4.6562h-1.1875v-6.3281h1.6719l1.9688 4.8125 2.0156-4.8125z"/>
-</g>
-<g transform="translate(1024.7 932.56)">
-<path d="m0.78125-6.2812c0-1.2266 0.27344-2.3281 0.82812-3.2969 0.55078-0.97656 1.3008-1.7422 2.25-2.2969 0.95703-0.55078 2.0156-0.82812 3.1719-0.82812 1.375 0 2.5703 0.32812 3.5938 0.98438 1.0195 0.65625 1.7656 1.5938 2.2344 2.8125h-1.9688c-0.34375-0.75781-0.84375-1.3438-1.5-1.75s-1.4453-0.60938-2.3594-0.60938c-0.875 0-1.6641 0.20312-2.3594 0.60938-0.6875 0.40625-1.2305 0.98438-1.625 1.7344-0.39844 0.75-0.59375 1.6328-0.59375 2.6406 0 1 0.19531 1.875 0.59375 2.625 0.39453 0.75 0.9375 1.3281 1.625 1.7344 0.69531 0.40625 1.4844 0.60938 2.3594 0.60938 0.91406 0 1.7031-0.19531 2.3594-0.59375 0.65625-0.40625 1.1562-0.98828 1.5-1.75h1.9688c-0.46875 1.1992-1.2148 2.125-2.2344 2.7812-1.0234 0.65625-2.2188 0.98438-3.5938 0.98438-1.1562 0-2.2148-0.26953-3.1719-0.8125-0.94922-0.55078-1.6992-1.3125-2.25-2.2812-0.55469-0.97656-0.82812-2.0781-0.82812-3.2969z"/>
-</g>
-<g transform="translate(1038.6 932.56)">
-<path d="m0.78125-4.9688c0-1.0078 0.20312-1.8945 0.60938-2.6562 0.40625-0.75781 0.96094-1.3477 1.6719-1.7656 0.71875-0.42578 1.5156-0.64062 2.3906-0.64062 0.86328 0 1.6133 0.1875 2.25 0.5625 0.63281 0.375 1.1094 0.84375 1.4219 1.4062v-1.7969h1.6562v9.8594h-1.6562v-1.8438c-0.32422 0.58594-0.80859 1.0625-1.4531 1.4375-0.63672 0.375-1.3828 0.5625-2.2344 0.5625-0.875 0-1.668-0.21094-2.375-0.64062-0.71094-0.4375-1.2656-1.0391-1.6719-1.8125-0.40625-0.78125-0.60938-1.6719-0.60938-2.6719zm8.3438 0.015625c0-0.73828-0.15234-1.3828-0.45312-1.9375-0.30469-0.55078-0.71094-0.97266-1.2188-1.2656-0.5-0.30078-1.0586-0.45312-1.6719-0.45312-0.61719 0-1.1797 0.14844-1.6875 0.4375-0.5 0.29297-0.90234 0.71484-1.2031 1.2656-0.29297 0.55469-0.4375 1.1992-0.4375 1.9375 0 0.76172 0.14453 1.4219 0.4375 1.9844 0.30078 0.55469 0.70312 0.97656 1.2031 1.2656 0.50781 0.29297 1.0703 0.4375 1.6875 0.4375 0.61328 0 1.1719-0.14453 1.6719-0.4375 0.50781-0.28906 0.91406-0.71094 1.2188-1.2656 0.30078-0.5625 0.45312-1.2188 0.45312-1.9688z"/>
-</g>
-<g transform="translate(1050.7 932.56)">
-<path d="m3.0312-13.312v13.312h-1.6406v-13.312z"/>
-</g>
-<g transform="translate(1055.2 932.56)">
-<path d="m2.2344-11.469c-0.3125 0-0.57812-0.10156-0.79688-0.3125-0.21875-0.21875-0.32812-0.48438-0.32812-0.79688s0.10938-0.57812 0.32812-0.79688 0.48438-0.32812 0.79688-0.32812c0.30078 0 0.55469 0.10938 0.76562 0.32812 0.20703 0.21875 0.3125 0.48438 0.3125 0.79688s-0.10547 0.57812-0.3125 0.79688c-0.21094 0.21094-0.46484 0.3125-0.76562 0.3125zm0.79688 1.6094v9.8594h-1.6406v-9.8594z"/>
-</g>
-<g transform="translate(1059.6 932.56)">
-<path d="m0.78125-4.9531c0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.75781 0.96875-1.3477 1.6875-1.7656 0.72656-0.42578 1.5625-0.64062 2.5-0.64062 1.207 0 2.2031 0.29688 2.9844 0.89062 0.78906 0.58594 1.3164 1.3984 1.5781 2.4375h-1.7656c-0.16797-0.59375-0.49609-1.0625-0.98438-1.4062-0.49219-0.35156-1.0938-0.53125-1.8125-0.53125-0.9375 0-1.6953 0.32422-2.2656 0.96875-0.57422 0.63672-0.85938 1.543-0.85938 2.7188 0 1.1875 0.28516 2.1094 0.85938 2.7656 0.57031 0.64844 1.3281 0.96875 2.2656 0.96875 0.71875 0 1.3164-0.16406 1.7969-0.5 0.47656-0.34375 0.8125-0.82812 1-1.4531h1.7656c-0.27344 1.0117-0.80469 1.8203-1.5938 2.4219-0.79297 0.60547-1.7812 0.90625-2.9688 0.90625-0.9375 0-1.7734-0.20703-2.5-0.625-0.71875-0.41406-1.2812-1.0078-1.6875-1.7812-0.40625-0.76953-0.60938-1.6719-0.60938-2.7031z"/>
-</g>
-<g transform="translate(1070.5 932.56)">
-<path d="m5.6875 0.15625c-0.92969 0-1.7656-0.20703-2.5156-0.625-0.75-0.41406-1.3398-1.0078-1.7656-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0078 0.21875-1.8984 0.65625-2.6719 0.4375-0.76953 1.0312-1.3633 1.7812-1.7812 0.75781-0.41406 1.6094-0.625 2.5469-0.625 0.92578 0 1.7695 0.21094 2.5312 0.625 0.75781 0.41797 1.3594 1.0117 1.7969 1.7812 0.4375 0.76172 0.65625 1.6523 0.65625 2.6719 0 1.0234-0.23047 1.9219-0.6875 2.7031-0.44922 0.77344-1.0586 1.3672-1.8281 1.7812-0.76172 0.41797-1.6094 0.625-2.5469 0.625zm0-1.4375c0.58203 0 1.1328-0.13281 1.6562-0.40625 0.51953-0.28125 0.9375-0.69531 1.25-1.25 0.32031-0.55078 0.48438-1.2227 0.48438-2.0156 0-0.78906-0.15625-1.4609-0.46875-2.0156-0.3125-0.55078-0.72656-0.96094-1.2344-1.2344-0.5-0.26953-1.0469-0.40625-1.6406-0.40625s-1.1406 0.13672-1.6406 0.40625c-0.5 0.27344-0.90234 0.68359-1.2031 1.2344-0.29297 0.55469-0.4375 1.2266-0.4375 2.0156 0 0.80469 0.14453 1.4805 0.4375 2.0312 0.28906 0.55469 0.67969 0.96484 1.1719 1.2344 0.5 0.27344 1.0391 0.40625 1.625 0.40625z"/>
-</g>
-<g transform="translate(1129 932.56)">
-<path d="m0.78125-6.2812c0-1.2266 0.27344-2.3281 0.82812-3.2969 0.55078-0.97656 1.3008-1.7422 2.25-2.2969 0.95703-0.55078 2.0156-0.82812 3.1719-0.82812 1.375 0 2.5703 0.32812 3.5938 0.98438 1.0195 0.65625 1.7656 1.5938 2.2344 2.8125h-1.9688c-0.34375-0.75781-0.84375-1.3438-1.5-1.75s-1.4453-0.60938-2.3594-0.60938c-0.875 0-1.6641 0.20312-2.3594 0.60938-0.6875 0.40625-1.2305 0.98438-1.625 1.7344-0.39844 0.75-0.59375 1.6328-0.59375 2.6406 0 1 0.19531 1.875 0.59375 2.625 0.39453 0.75 0.9375 1.3281 1.625 1.7344 0.69531 0.40625 1.4844 0.60938 2.3594 0.60938 0.91406 0 1.7031-0.19531 2.3594-0.59375 0.65625-0.40625 1.1562-0.98828 1.5-1.75h1.9688c-0.46875 1.1992-1.2148 2.125-2.2344 2.7812-1.0234 0.65625-2.2188 0.98438-3.5938 0.98438-1.1562 0-2.2148-0.26953-3.1719-0.8125-0.94922-0.55078-1.6992-1.3125-2.25-2.2812-0.55469-0.97656-0.82812-2.0781-0.82812-3.2969z"/>
-</g>
-<g transform="translate(1142.9 932.56)">
-<path d="m10.391-5.3125c0 0.3125-0.023437 0.64844-0.0625 1h-7.875c0.050781 0.96875 0.37891 1.7305 0.98438 2.2812 0.61328 0.54297 1.3516 0.8125 2.2188 0.8125 0.70703 0 1.2969-0.16406 1.7656-0.5 0.47656-0.33203 0.8125-0.77344 1-1.3281h1.7656c-0.26172 0.94922-0.78906 1.7188-1.5781 2.3125-0.79297 0.59375-1.7773 0.89062-2.9531 0.89062-0.9375 0-1.7773-0.20703-2.5156-0.625-0.74219-0.41406-1.3203-1.0078-1.7344-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.76953 0.97656-1.3633 1.7188-1.7812 0.73828-0.41406 1.5859-0.625 2.5469-0.625 0.9375 0 1.7656 0.21094 2.4844 0.625 0.71875 0.40625 1.2695 0.96875 1.6562 1.6875 0.39453 0.71094 0.59375 1.5117 0.59375 2.4062zm-1.7031-0.34375c0-0.625-0.14062-1.1602-0.42188-1.6094-0.27344-0.44531-0.64844-0.78516-1.125-1.0156-0.46875-0.23828-0.99219-0.35938-1.5625-0.35938-0.82422 0-1.5273 0.26562-2.1094 0.79688-0.58594 0.52344-0.91797 1.25-1 2.1875z"/>
-</g>
-<g transform="translate(1154 932.56)">
-<path d="m3.0312-8.2656c0.28125-0.5625 0.6875-1 1.2188-1.3125 0.53906-0.3125 1.1914-0.46875 1.9531-0.46875v1.6875h-0.42188c-1.8359 0-2.75 1-2.75 3v5.3594h-1.6406v-9.8594h1.6406z"/>
-</g>
-<g transform="translate(1160.8 932.56)">
-<path d="m3.3906-8.5156v5.8125c0 0.48047 0.097656 0.82031 0.29688 1.0156 0.20703 0.19922 0.5625 0.29688 1.0625 0.29688h1.2031v1.3906h-1.4688c-0.91797 0-1.6055-0.20703-2.0625-0.625-0.44922-0.42578-0.67188-1.1172-0.67188-2.0781v-5.8125h-1.2812v-1.3438h1.2812v-2.4844h1.6406v2.4844h2.5625v1.3438z"/>
-</g>
-<g transform="translate(1167.3 932.56)">
-<path d="m8.2188-7.2969v1.3906h-7.1719v-1.3906z"/>
-</g>
-<g transform="translate(1177.2 932.56)">
-<path d="m14.109-12.453v12.453h-1.6406v-9.2812l-4.1406 9.2812h-1.1406l-4.1562-9.3125v9.3125h-1.6406v-12.453h1.7656l4.6094 10.297 4.5938-10.297z"/>
-</g>
-<g transform="translate(1192.7 932.56)">
-<path d="m0.78125-4.9688c0-1.0078 0.20312-1.8945 0.60938-2.6562 0.40625-0.75781 0.96094-1.3477 1.6719-1.7656 0.71875-0.42578 1.5156-0.64062 2.3906-0.64062 0.86328 0 1.6133 0.1875 2.25 0.5625 0.63281 0.375 1.1094 0.84375 1.4219 1.4062v-1.7969h1.6562v9.8594h-1.6562v-1.8438c-0.32422 0.58594-0.80859 1.0625-1.4531 1.4375-0.63672 0.375-1.3828 0.5625-2.2344 0.5625-0.875 0-1.668-0.21094-2.375-0.64062-0.71094-0.4375-1.2656-1.0391-1.6719-1.8125-0.40625-0.78125-0.60938-1.6719-0.60938-2.6719zm8.3438 0.015625c0-0.73828-0.15234-1.3828-0.45312-1.9375-0.30469-0.55078-0.71094-0.97266-1.2188-1.2656-0.5-0.30078-1.0586-0.45312-1.6719-0.45312-0.61719 0-1.1797 0.14844-1.6875 0.4375-0.5 0.29297-0.90234 0.71484-1.2031 1.2656-0.29297 0.55469-0.4375 1.1992-0.4375 1.9375 0 0.76172 0.14453 1.4219 0.4375 1.9844 0.30078 0.55469 0.70312 0.97656 1.2031 1.2656 0.50781 0.29297 1.0703 0.4375 1.6875 0.4375 0.61328 0 1.1719-0.14453 1.6719-0.4375 0.50781-0.28906 0.91406-0.71094 1.2188-1.2656 0.30078-0.5625 0.45312-1.2188 0.45312-1.9688z"/>
-</g>
-<g transform="translate(1204.9 932.56)">
-<path d="m6.1875-10.047c1.1953 0 2.1641 0.36719 2.9062 1.0938 0.75 0.73047 1.125 1.7773 1.125 3.1406v5.8125h-1.6094v-5.5781c0-0.98828-0.25-1.7422-0.75-2.2656-0.49219-0.51953-1.1641-0.78125-2.0156-0.78125-0.86719 0-1.5547 0.27344-2.0625 0.8125-0.5 0.54297-0.75 1.3281-0.75 2.3594v5.4531h-1.6406v-9.8594h1.6406v1.4062c0.32031-0.50781 0.75781-0.89844 1.3125-1.1719 0.5625-0.28125 1.1758-0.42188 1.8438-0.42188z"/>
-</g>
-<g transform="translate(1216.4 932.56)">
-<path d="m0.78125-4.9688c0-1.0078 0.20312-1.8945 0.60938-2.6562 0.40625-0.75781 0.96094-1.3477 1.6719-1.7656 0.71875-0.42578 1.5156-0.64062 2.3906-0.64062 0.86328 0 1.6133 0.1875 2.25 0.5625 0.63281 0.375 1.1094 0.84375 1.4219 1.4062v-1.7969h1.6562v9.8594h-1.6562v-1.8438c-0.32422 0.58594-0.80859 1.0625-1.4531 1.4375-0.63672 0.375-1.3828 0.5625-2.2344 0.5625-0.875 0-1.668-0.21094-2.375-0.64062-0.71094-0.4375-1.2656-1.0391-1.6719-1.8125-0.40625-0.78125-0.60938-1.6719-0.60938-2.6719zm8.3438 0.015625c0-0.73828-0.15234-1.3828-0.45312-1.9375-0.30469-0.55078-0.71094-0.97266-1.2188-1.2656-0.5-0.30078-1.0586-0.45312-1.6719-0.45312-0.61719 0-1.1797 0.14844-1.6875 0.4375-0.5 0.29297-0.90234 0.71484-1.2031 1.2656-0.29297 0.55469-0.4375 1.1992-0.4375 1.9375 0 0.76172 0.14453 1.4219 0.4375 1.9844 0.30078 0.55469 0.70312 0.97656 1.2031 1.2656 0.50781 0.29297 1.0703 0.4375 1.6875 0.4375 0.61328 0 1.1719-0.14453 1.6719-0.4375 0.50781-0.28906 0.91406-0.71094 1.2188-1.2656 0.30078-0.5625 0.45312-1.2188 0.45312-1.9688z"/>
-</g>
-<g transform="translate(1228.6 932.56)">
-<path d="m5.4531-10.031c0.85156 0 1.5977 0.1875 2.2344 0.5625 0.64453 0.375 1.125 0.84375 1.4375 1.4062v-1.7969h1.6562v10.078c0 0.89453-0.19531 1.6914-0.57812 2.3906-0.38672 0.70703-0.9375 1.2578-1.6562 1.6562-0.71094 0.39453-1.5391 0.59375-2.4844 0.59375-1.293 0-2.3711-0.30859-3.2344-0.92188-0.86719-0.60547-1.375-1.4375-1.5312-2.5h1.625c0.17578 0.60156 0.54688 1.0859 1.1094 1.4531 0.5625 0.36328 1.2383 0.54688 2.0312 0.54688 0.90625 0 1.6406-0.28125 2.2031-0.84375 0.57031-0.5625 0.85938-1.3555 0.85938-2.375v-2.0781c-0.32422 0.58594-0.80469 1.0703-1.4375 1.4531-0.63672 0.375-1.3828 0.5625-2.2344 0.5625-0.875 0-1.6719-0.21094-2.3906-0.64062-0.71094-0.4375-1.2656-1.0391-1.6719-1.8125-0.40625-0.78125-0.60938-1.6719-0.60938-2.6719 0-1.0078 0.20312-1.8945 0.60938-2.6562 0.40625-0.75781 0.96094-1.3477 1.6719-1.7656 0.71875-0.42578 1.5156-0.64062 2.3906-0.64062zm3.6719 5.0781c0-0.73828-0.15234-1.3828-0.45312-1.9375-0.30469-0.55078-0.71094-0.97266-1.2188-1.2656-0.5-0.30078-1.0586-0.45312-1.6719-0.45312-0.61719 0-1.1797 0.14844-1.6875 0.4375-0.5 0.29297-0.90234 0.71484-1.2031 1.2656-0.29297 0.55469-0.4375 1.1992-0.4375 1.9375 0 0.76172 0.14453 1.4219 0.4375 1.9844 0.30078 0.55469 0.70312 0.97656 1.2031 1.2656 0.50781 0.29297 1.0703 0.4375 1.6875 0.4375 0.61328 0 1.1719-0.14453 1.6719-0.4375 0.50781-0.28906 0.91406-0.71094 1.2188-1.2656 0.30078-0.5625 0.45312-1.2188 0.45312-1.9688z"/>
-</g>
-<g transform="translate(1240.8 932.56)">
-<path d="m10.391-5.3125c0 0.3125-0.023437 0.64844-0.0625 1h-7.875c0.050781 0.96875 0.37891 1.7305 0.98438 2.2812 0.61328 0.54297 1.3516 0.8125 2.2188 0.8125 0.70703 0 1.2969-0.16406 1.7656-0.5 0.47656-0.33203 0.8125-0.77344 1-1.3281h1.7656c-0.26172 0.94922-0.78906 1.7188-1.5781 2.3125-0.79297 0.59375-1.7773 0.89062-2.9531 0.89062-0.9375 0-1.7773-0.20703-2.5156-0.625-0.74219-0.41406-1.3203-1.0078-1.7344-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.76953 0.97656-1.3633 1.7188-1.7812 0.73828-0.41406 1.5859-0.625 2.5469-0.625 0.9375 0 1.7656 0.21094 2.4844 0.625 0.71875 0.40625 1.2695 0.96875 1.6562 1.6875 0.39453 0.71094 0.59375 1.5117 0.59375 2.4062zm-1.7031-0.34375c0-0.625-0.14062-1.1602-0.42188-1.6094-0.27344-0.44531-0.64844-0.78516-1.125-1.0156-0.46875-0.23828-0.99219-0.35938-1.5625-0.35938-0.82422 0-1.5273 0.26562-2.1094 0.79688-0.58594 0.52344-0.91797 1.25-1 2.1875z"/>
-</g>
-<g transform="translate(1251.9 932.56)">
-<path d="m3.0312-8.2656c0.28125-0.5625 0.6875-1 1.2188-1.3125 0.53906-0.3125 1.1914-0.46875 1.9531-0.46875v1.6875h-0.42188c-1.8359 0-2.75 1-2.75 3v5.3594h-1.6406v-9.8594h1.6406z"/>
-</g>
-<g transform="translate(1258.6 932.56)">
-<path d="m0.45312-12.672h4.3594v1.0156h-1.5312v5.3125h-1.2969l0.015625-5.3125h-1.5469zm12.594 0v6.3281h-1.2031l-0.015625-4.5781-1.9688 4.5781h-0.90625l-1.9531-4.6562v4.6562h-1.1875v-6.3281h1.6719l1.9688 4.8125 2.0156-4.8125z"/>
-</g>
-<g transform="translate(1303.4 932.56)">
-<path d="m8.1875 0-5.1562-5.7188v5.7188h-1.6406v-12.547h1.6406v5.8125l5.1719-5.8125h2.0781l-5.6875 6.2812 5.7344 6.2656z"/>
-</g>
-<g transform="translate(1314.1 932.56)">
-<path d="m10.141-9.8594v9.8594h-1.6406v-1.4531c-0.3125 0.5-0.75 0.89062-1.3125 1.1719-0.55469 0.28125-1.168 0.42188-1.8438 0.42188-0.77344 0-1.4648-0.15625-2.0781-0.46875-0.60547-0.32031-1.0859-0.80078-1.4375-1.4375-0.35547-0.63281-0.53125-1.4102-0.53125-2.3281v-5.7656h1.625v5.5625c0 0.96875 0.24219 1.7148 0.73438 2.2344 0.48828 0.52344 1.1602 0.78125 2.0156 0.78125 0.875 0 1.5625-0.26562 2.0625-0.79688 0.50781-0.53906 0.76562-1.332 0.76562-2.375v-5.4062z"/>
-</g>
-<g transform="translate(1325.7 932.56)">
-<path d="m3.0312-8.0312c0.33203-0.58203 0.82031-1.0625 1.4688-1.4375 0.64453-0.375 1.3828-0.5625 2.2188-0.5625 0.88281 0 1.6797 0.21484 2.3906 0.64062 0.70703 0.41797 1.2656 1.0078 1.6719 1.7656 0.40625 0.76172 0.60938 1.6484 0.60938 2.6562 0 1-0.20312 1.8906-0.60938 2.6719-0.40625 0.77344-0.96875 1.375-1.6875 1.8125-0.71094 0.42969-1.5 0.64062-2.375 0.64062-0.85547 0-1.6055-0.17969-2.25-0.54688-0.63672-0.375-1.1172-0.84766-1.4375-1.4219v1.8125h-1.6406v-13.312h1.6406zm6.6875 3.0625c0-0.73828-0.15234-1.3828-0.45312-1.9375-0.30469-0.55078-0.71094-0.97266-1.2188-1.2656-0.5-0.28906-1.0586-0.4375-1.6719-0.4375-0.60547 0-1.1641 0.15234-1.6719 0.45312-0.51172 0.29297-0.91797 0.71875-1.2188 1.2812-0.30469 0.55469-0.45312 1.1953-0.45312 1.9219 0 0.75 0.14844 1.4062 0.45312 1.9688 0.30078 0.55469 0.70703 0.97656 1.2188 1.2656 0.50781 0.29297 1.0664 0.4375 1.6719 0.4375 0.61328 0 1.1719-0.14453 1.6719-0.4375 0.50781-0.28906 0.91406-0.71094 1.2188-1.2656 0.30078-0.5625 0.45312-1.2227 0.45312-1.9844z"/>
-</g>
-<g transform="translate(1337.8 932.56)">
-<path d="m10.391-5.3125c0 0.3125-0.023437 0.64844-0.0625 1h-7.875c0.050781 0.96875 0.37891 1.7305 0.98438 2.2812 0.61328 0.54297 1.3516 0.8125 2.2188 0.8125 0.70703 0 1.2969-0.16406 1.7656-0.5 0.47656-0.33203 0.8125-0.77344 1-1.3281h1.7656c-0.26172 0.94922-0.78906 1.7188-1.5781 2.3125-0.79297 0.59375-1.7773 0.89062-2.9531 0.89062-0.9375 0-1.7773-0.20703-2.5156-0.625-0.74219-0.41406-1.3203-1.0078-1.7344-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.76953 0.97656-1.3633 1.7188-1.7812 0.73828-0.41406 1.5859-0.625 2.5469-0.625 0.9375 0 1.7656 0.21094 2.4844 0.625 0.71875 0.40625 1.2695 0.96875 1.6562 1.6875 0.39453 0.71094 0.59375 1.5117 0.59375 2.4062zm-1.7031-0.34375c0-0.625-0.14062-1.1602-0.42188-1.6094-0.27344-0.44531-0.64844-0.78516-1.125-1.0156-0.46875-0.23828-0.99219-0.35938-1.5625-0.35938-0.82422 0-1.5273 0.26562-2.1094 0.79688-0.58594 0.52344-0.91797 1.25-1 2.1875z"/>
-</g>
-<g transform="translate(1349 932.56)">
-<path d="m3.0312-8.2656c0.28125-0.5625 0.6875-1 1.2188-1.3125 0.53906-0.3125 1.1914-0.46875 1.9531-0.46875v1.6875h-0.42188c-1.8359 0-2.75 1-2.75 3v5.3594h-1.6406v-9.8594h1.6406z"/>
-</g>
-<g transform="translate(1355.7 932.56)">
-<path d="m6.1875-10.047c1.1953 0 2.1641 0.36719 2.9062 1.0938 0.75 0.73047 1.125 1.7773 1.125 3.1406v5.8125h-1.6094v-5.5781c0-0.98828-0.25-1.7422-0.75-2.2656-0.49219-0.51953-1.1641-0.78125-2.0156-0.78125-0.86719 0-1.5547 0.27344-2.0625 0.8125-0.5 0.54297-0.75 1.3281-0.75 2.3594v5.4531h-1.6406v-9.8594h1.6406v1.4062c0.32031-0.50781 0.75781-0.89844 1.3125-1.1719 0.5625-0.28125 1.1758-0.42188 1.8438-0.42188z"/>
-</g>
-<g transform="translate(1367.2 932.56)">
-<path d="m10.391-5.3125c0 0.3125-0.023437 0.64844-0.0625 1h-7.875c0.050781 0.96875 0.37891 1.7305 0.98438 2.2812 0.61328 0.54297 1.3516 0.8125 2.2188 0.8125 0.70703 0 1.2969-0.16406 1.7656-0.5 0.47656-0.33203 0.8125-0.77344 1-1.3281h1.7656c-0.26172 0.94922-0.78906 1.7188-1.5781 2.3125-0.79297 0.59375-1.7773 0.89062-2.9531 0.89062-0.9375 0-1.7773-0.20703-2.5156-0.625-0.74219-0.41406-1.3203-1.0078-1.7344-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.76953 0.97656-1.3633 1.7188-1.7812 0.73828-0.41406 1.5859-0.625 2.5469-0.625 0.9375 0 1.7656 0.21094 2.4844 0.625 0.71875 0.40625 1.2695 0.96875 1.6562 1.6875 0.39453 0.71094 0.59375 1.5117 0.59375 2.4062zm-1.7031-0.34375c0-0.625-0.14062-1.1602-0.42188-1.6094-0.27344-0.44531-0.64844-0.78516-1.125-1.0156-0.46875-0.23828-0.99219-0.35938-1.5625-0.35938-0.82422 0-1.5273 0.26562-2.1094 0.79688-0.58594 0.52344-0.91797 1.25-1 2.1875z"/>
-</g>
-<g transform="translate(1378.4 932.56)">
-<path d="m3.3906-8.5156v5.8125c0 0.48047 0.097656 0.82031 0.29688 1.0156 0.20703 0.19922 0.5625 0.29688 1.0625 0.29688h1.2031v1.3906h-1.4688c-0.91797 0-1.6055-0.20703-2.0625-0.625-0.44922-0.42578-0.67188-1.1172-0.67188-2.0781v-5.8125h-1.2812v-1.3438h1.2812v-2.4844h1.6406v2.4844h2.5625v1.3438z"/>
-</g>
-<g transform="translate(1384.9 932.56)">
-<path d="m10.391-5.3125c0 0.3125-0.023437 0.64844-0.0625 1h-7.875c0.050781 0.96875 0.37891 1.7305 0.98438 2.2812 0.61328 0.54297 1.3516 0.8125 2.2188 0.8125 0.70703 0 1.2969-0.16406 1.7656-0.5 0.47656-0.33203 0.8125-0.77344 1-1.3281h1.7656c-0.26172 0.94922-0.78906 1.7188-1.5781 2.3125-0.79297 0.59375-1.7773 0.89062-2.9531 0.89062-0.9375 0-1.7773-0.20703-2.5156-0.625-0.74219-0.41406-1.3203-1.0078-1.7344-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.76953 0.97656-1.3633 1.7188-1.7812 0.73828-0.41406 1.5859-0.625 2.5469-0.625 0.9375 0 1.7656 0.21094 2.4844 0.625 0.71875 0.40625 1.2695 0.96875 1.6562 1.6875 0.39453 0.71094 0.59375 1.5117 0.59375 2.4062zm-1.7031-0.34375c0-0.625-0.14062-1.1602-0.42188-1.6094-0.27344-0.44531-0.64844-0.78516-1.125-1.0156-0.46875-0.23828-0.99219-0.35938-1.5625-0.35938-0.82422 0-1.5273 0.26562-2.1094 0.79688-0.58594 0.52344-0.91797 1.25-1 2.1875z"/>
-</g>
-<g transform="translate(1396.1 932.56)">
-<path d="m4.875 0.15625c-0.75 0-1.4297-0.125-2.0312-0.375-0.60547-0.25781-1.0781-0.61719-1.4219-1.0781-0.34375-0.46875-0.53906-1-0.57812-1.5938h1.6875c0.050781 0.49219 0.28516 0.89062 0.70312 1.2031 0.41406 0.3125 0.95703 0.46875 1.625 0.46875 0.625 0 1.1133-0.13281 1.4688-0.40625 0.36328-0.28125 0.54688-0.63281 0.54688-1.0625 0-0.42578-0.19531-0.74219-0.57812-0.95312-0.38672-0.20703-0.98047-0.41406-1.7812-0.625-0.73047-0.1875-1.3281-0.37891-1.7969-0.57812-0.46094-0.19531-0.85547-0.48828-1.1875-0.875-0.32422-0.39453-0.48438-0.91016-0.48438-1.5469 0-0.50781 0.14453-0.97266 0.4375-1.3906 0.30078-0.41406 0.72656-0.75 1.2812-1 0.55078-0.25 1.1797-0.375 1.8906-0.375 1.0938 0 1.9727 0.27734 2.6406 0.82812 0.67578 0.55469 1.0391 1.3086 1.0938 2.2656h-1.6406c-0.03125-0.50781-0.24219-0.92188-0.625-1.2344-0.375-0.3125-0.88281-0.46875-1.5156-0.46875-0.59375 0-1.0625 0.125-1.4062 0.375s-0.51562 0.58594-0.51562 1c0 0.32422 0.10156 0.58984 0.3125 0.79688 0.20703 0.21094 0.46875 0.375 0.78125 0.5 0.32031 0.125 0.76562 0.26562 1.3281 0.42188 0.70703 0.19922 1.2812 0.39062 1.7188 0.57812 0.44531 0.17969 0.82812 0.45312 1.1406 0.82812 0.32031 0.375 0.49219 0.85938 0.51562 1.4531 0 0.54297-0.15234 1.0312-0.45312 1.4688-0.30469 0.42969-0.73047 0.76562-1.2812 1.0156-0.54297 0.23828-1.168 0.35938-1.875 0.35938z"/>
-</g>
-<g transform="translate(1405.5 932.56)">
-<path d="m4.5938-12.703c0.69531 0 1.3203 0.16406 1.875 0.48438 0.55078 0.3125 0.97656 0.75 1.2812 1.3125 0.3125 0.55469 0.46875 1.1797 0.46875 1.875 0 0.69922-0.15625 1.3281-0.46875 1.8906-0.30469 0.5625-0.73047 1.0078-1.2812 1.3281-0.55469 0.3125-1.1797 0.46875-1.875 0.46875-0.71094 0-1.3398-0.15625-1.8906-0.46875-0.55469-0.32031-0.98438-0.76562-1.2969-1.3281s-0.46875-1.1914-0.46875-1.8906c0-0.69531 0.15625-1.3203 0.46875-1.875 0.3125-0.5625 0.74219-1 1.2969-1.3125 0.55078-0.32031 1.1797-0.48438 1.8906-0.48438zm0 6.6406c0.86328 0 1.5625-0.27344 2.0938-0.82812 0.53125-0.55078 0.79688-1.2656 0.79688-2.1406s-0.26562-1.5859-0.79688-2.1406c-0.53125-0.55078-1.2305-0.82812-2.0938-0.82812-0.875 0-1.5781 0.27734-2.1094 0.82812-0.52344 0.55469-0.78125 1.2656-0.78125 2.1406s0.25781 1.5898 0.78125 2.1406c0.53125 0.55469 1.2344 0.82812 2.1094 0.82812zm1.6094-3.7344c0 0.29297-0.074219 0.53906-0.21875 0.73438-0.14844 0.19922-0.35547 0.33984-0.625 0.42188l1.0156 1.5-1.1406 0.015625-0.85938-1.4375h-0.3125v1.4375h-0.9375v-3.875h1.7344c0.40625 0 0.72656 0.10938 0.96875 0.32812 0.25 0.21875 0.375 0.51172 0.375 0.875zm-2.1406 0.45312h0.75c0.125 0 0.23438-0.035156 0.32812-0.10938 0.09375-0.070313 0.14062-0.17188 0.14062-0.29688 0-0.13281-0.046875-0.23438-0.14062-0.29688-0.09375-0.070313-0.20312-0.10938-0.32812-0.10938h-0.75z"/>
-</g>
-<g transform="translate(78.752 1152.7)">
-<path d="m9.7812-8.875c0 1.043-0.35938 1.9141-1.0781 2.6094-0.71875 0.6875-1.8086 1.0312-3.2656 1.0312h-2.4062v5.2344h-1.6406v-12.547h4.0469c1.4141 0 2.4922 0.34375 3.2344 1.0312 0.73828 0.67969 1.1094 1.5586 1.1094 2.6406zm-4.3438 2.2812c0.90625 0 1.5703-0.19531 2-0.59375 0.4375-0.39453 0.65625-0.95703 0.65625-1.6875 0-1.5508-0.88672-2.3281-2.6562-2.3281h-2.4062v4.6094z"/>
-</g>
-<g transform="translate(89.174 1152.7)">
-<path d="m3.0312-8.2656c0.28125-0.5625 0.6875-1 1.2188-1.3125 0.53906-0.3125 1.1914-0.46875 1.9531-0.46875v1.6875h-0.42188c-1.8359 0-2.75 1-2.75 3v5.3594h-1.6406v-9.8594h1.6406z"/>
-</g>
-<g transform="translate(95.888 1152.7)">
-<path d="m5.6875 0.15625c-0.92969 0-1.7656-0.20703-2.5156-0.625-0.75-0.41406-1.3398-1.0078-1.7656-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0078 0.21875-1.8984 0.65625-2.6719 0.4375-0.76953 1.0312-1.3633 1.7812-1.7812 0.75781-0.41406 1.6094-0.625 2.5469-0.625 0.92578 0 1.7695 0.21094 2.5312 0.625 0.75781 0.41797 1.3594 1.0117 1.7969 1.7812 0.4375 0.76172 0.65625 1.6523 0.65625 2.6719 0 1.0234-0.23047 1.9219-0.6875 2.7031-0.44922 0.77344-1.0586 1.3672-1.8281 1.7812-0.76172 0.41797-1.6094 0.625-2.5469 0.625zm0-1.4375c0.58203 0 1.1328-0.13281 1.6562-0.40625 0.51953-0.28125 0.9375-0.69531 1.25-1.25 0.32031-0.55078 0.48438-1.2227 0.48438-2.0156 0-0.78906-0.15625-1.4609-0.46875-2.0156-0.3125-0.55078-0.72656-0.96094-1.2344-1.2344-0.5-0.26953-1.0469-0.40625-1.6406-0.40625s-1.1406 0.13672-1.6406 0.40625c-0.5 0.27344-0.90234 0.68359-1.2031 1.2344-0.29297 0.55469-0.4375 1.2266-0.4375 2.0156 0 0.80469 0.14453 1.4805 0.4375 2.0312 0.28906 0.55469 0.67969 0.96484 1.1719 1.2344 0.5 0.27344 1.0391 0.40625 1.625 0.40625z"/>
-</g>
-<g transform="translate(107.41 1152.7)">
-<path d="m13.25-10.047c0.76953 0 1.4531 0.16406 2.0469 0.48438 0.60156 0.3125 1.0781 0.78906 1.4219 1.4219 0.35156 0.63672 0.53125 1.4141 0.53125 2.3281v5.8125h-1.625v-5.5781c0-0.98828-0.24609-1.7422-0.73438-2.2656-0.48047-0.51953-1.1367-0.78125-1.9688-0.78125-0.85547 0-1.5312 0.27734-2.0312 0.82812-0.5 0.54297-0.75 1.3281-0.75 2.3594v5.4375h-1.625v-5.5781c0-0.98828-0.24609-1.7422-0.73438-2.2656-0.48047-0.51953-1.1367-0.78125-1.9688-0.78125-0.85547 0-1.5312 0.27734-2.0312 0.82812-0.5 0.54297-0.75 1.3281-0.75 2.3594v5.4375h-1.6406v-9.8594h1.6406v1.4219c0.32031-0.51953 0.75391-0.91406 1.2969-1.1875 0.53906-0.28125 1.1445-0.42188 1.8125-0.42188 0.82031 0 1.5508 0.1875 2.1875 0.5625 0.63281 0.375 1.1094 0.92188 1.4219 1.6406 0.28125-0.69531 0.73828-1.2383 1.375-1.625 0.63281-0.38281 1.3438-0.57812 2.125-0.57812z"/>
-</g>
-<g transform="translate(125.95 1152.7)">
-<path d="m10.391-5.3125c0 0.3125-0.023437 0.64844-0.0625 1h-7.875c0.050781 0.96875 0.37891 1.7305 0.98438 2.2812 0.61328 0.54297 1.3516 0.8125 2.2188 0.8125 0.70703 0 1.2969-0.16406 1.7656-0.5 0.47656-0.33203 0.8125-0.77344 1-1.3281h1.7656c-0.26172 0.94922-0.78906 1.7188-1.5781 2.3125-0.79297 0.59375-1.7773 0.89062-2.9531 0.89062-0.9375 0-1.7773-0.20703-2.5156-0.625-0.74219-0.41406-1.3203-1.0078-1.7344-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.76953 0.97656-1.3633 1.7188-1.7812 0.73828-0.41406 1.5859-0.625 2.5469-0.625 0.9375 0 1.7656 0.21094 2.4844 0.625 0.71875 0.40625 1.2695 0.96875 1.6562 1.6875 0.39453 0.71094 0.59375 1.5117 0.59375 2.4062zm-1.7031-0.34375c0-0.625-0.14062-1.1602-0.42188-1.6094-0.27344-0.44531-0.64844-0.78516-1.125-1.0156-0.46875-0.23828-0.99219-0.35938-1.5625-0.35938-0.82422 0-1.5273 0.26562-2.1094 0.79688-0.58594 0.52344-0.91797 1.25-1 2.1875z"/>
-</g>
-<g transform="translate(137.11 1152.7)">
-<path d="m3.3906-8.5156v5.8125c0 0.48047 0.097656 0.82031 0.29688 1.0156 0.20703 0.19922 0.5625 0.29688 1.0625 0.29688h1.2031v1.3906h-1.4688c-0.91797 0-1.6055-0.20703-2.0625-0.625-0.44922-0.42578-0.67188-1.1172-0.67188-2.0781v-5.8125h-1.2812v-1.3438h1.2812v-2.4844h1.6406v2.4844h2.5625v1.3438z"/>
-</g>
-<g transform="translate(143.66 1152.7)">
-<path d="m6.2812-10.047c0.73828 0 1.4102 0.16406 2.0156 0.48438 0.60156 0.3125 1.0703 0.78906 1.4062 1.4219 0.34375 0.63672 0.51562 1.4141 0.51562 2.3281v5.8125h-1.6094v-5.5781c0-0.98828-0.25-1.7422-0.75-2.2656-0.49219-0.51953-1.1641-0.78125-2.0156-0.78125-0.86719 0-1.5547 0.27344-2.0625 0.8125-0.5 0.54297-0.75 1.3281-0.75 2.3594v5.4531h-1.6406v-13.312h1.6406v4.8594c0.32031-0.50781 0.76562-0.89844 1.3281-1.1719 0.57031-0.28125 1.2109-0.42188 1.9219-0.42188z"/>
-</g>
-<g transform="translate(155.18 1152.7)">
-<path d="m10.391-5.3125c0 0.3125-0.023437 0.64844-0.0625 1h-7.875c0.050781 0.96875 0.37891 1.7305 0.98438 2.2812 0.61328 0.54297 1.3516 0.8125 2.2188 0.8125 0.70703 0 1.2969-0.16406 1.7656-0.5 0.47656-0.33203 0.8125-0.77344 1-1.3281h1.7656c-0.26172 0.94922-0.78906 1.7188-1.5781 2.3125-0.79297 0.59375-1.7773 0.89062-2.9531 0.89062-0.9375 0-1.7773-0.20703-2.5156-0.625-0.74219-0.41406-1.3203-1.0078-1.7344-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.76953 0.97656-1.3633 1.7188-1.7812 0.73828-0.41406 1.5859-0.625 2.5469-0.625 0.9375 0 1.7656 0.21094 2.4844 0.625 0.71875 0.40625 1.2695 0.96875 1.6562 1.6875 0.39453 0.71094 0.59375 1.5117 0.59375 2.4062zm-1.7031-0.34375c0-0.625-0.14062-1.1602-0.42188-1.6094-0.27344-0.44531-0.64844-0.78516-1.125-1.0156-0.46875-0.23828-0.99219-0.35938-1.5625-0.35938-0.82422 0-1.5273 0.26562-2.1094 0.79688-0.58594 0.52344-0.91797 1.25-1 2.1875z"/>
-</g>
-<g transform="translate(166.34 1152.7)">
-<path d="m10.141-9.8594v9.8594h-1.6406v-1.4531c-0.3125 0.5-0.75 0.89062-1.3125 1.1719-0.55469 0.28125-1.168 0.42188-1.8438 0.42188-0.77344 0-1.4648-0.15625-2.0781-0.46875-0.60547-0.32031-1.0859-0.80078-1.4375-1.4375-0.35547-0.63281-0.53125-1.4102-0.53125-2.3281v-5.7656h1.625v5.5625c0 0.96875 0.24219 1.7148 0.73438 2.2344 0.48828 0.52344 1.1602 0.78125 2.0156 0.78125 0.875 0 1.5625-0.26562 2.0625-0.79688 0.50781-0.53906 0.76562-1.332 0.76562-2.375v-5.4062z"/>
-</g>
-<g transform="translate(177.86 1152.7)">
-<path d="m4.875 0.15625c-0.75 0-1.4297-0.125-2.0312-0.375-0.60547-0.25781-1.0781-0.61719-1.4219-1.0781-0.34375-0.46875-0.53906-1-0.57812-1.5938h1.6875c0.050781 0.49219 0.28516 0.89062 0.70312 1.2031 0.41406 0.3125 0.95703 0.46875 1.625 0.46875 0.625 0 1.1133-0.13281 1.4688-0.40625 0.36328-0.28125 0.54688-0.63281 0.54688-1.0625 0-0.42578-0.19531-0.74219-0.57812-0.95312-0.38672-0.20703-0.98047-0.41406-1.7812-0.625-0.73047-0.1875-1.3281-0.37891-1.7969-0.57812-0.46094-0.19531-0.85547-0.48828-1.1875-0.875-0.32422-0.39453-0.48438-0.91016-0.48438-1.5469 0-0.50781 0.14453-0.97266 0.4375-1.3906 0.30078-0.41406 0.72656-0.75 1.2812-1 0.55078-0.25 1.1797-0.375 1.8906-0.375 1.0938 0 1.9727 0.27734 2.6406 0.82812 0.67578 0.55469 1.0391 1.3086 1.0938 2.2656h-1.6406c-0.03125-0.50781-0.24219-0.92188-0.625-1.2344-0.375-0.3125-0.88281-0.46875-1.5156-0.46875-0.59375 0-1.0625 0.125-1.4062 0.375s-0.51562 0.58594-0.51562 1c0 0.32422 0.10156 0.58984 0.3125 0.79688 0.20703 0.21094 0.46875 0.375 0.78125 0.5 0.32031 0.125 0.76562 0.26562 1.3281 0.42188 0.70703 0.19922 1.2812 0.39062 1.7188 0.57812 0.44531 0.17969 0.82812 0.45312 1.1406 0.82812 0.32031 0.375 0.49219 0.85938 0.51562 1.4531 0 0.54297-0.15234 1.0312-0.45312 1.4688-0.30469 0.42969-0.73047 0.76562-1.2812 1.0156-0.54297 0.23828-1.168 0.35938-1.875 0.35938z"/>
-</g>
-<g transform="translate(187.26 1152.7)">
-<path d="m4.5938-12.703c0.69531 0 1.3203 0.16406 1.875 0.48438 0.55078 0.3125 0.97656 0.75 1.2812 1.3125 0.3125 0.55469 0.46875 1.1797 0.46875 1.875 0 0.69922-0.15625 1.3281-0.46875 1.8906-0.30469 0.5625-0.73047 1.0078-1.2812 1.3281-0.55469 0.3125-1.1797 0.46875-1.875 0.46875-0.71094 0-1.3398-0.15625-1.8906-0.46875-0.55469-0.32031-0.98438-0.76562-1.2969-1.3281s-0.46875-1.1914-0.46875-1.8906c0-0.69531 0.15625-1.3203 0.46875-1.875 0.3125-0.5625 0.74219-1 1.2969-1.3125 0.55078-0.32031 1.1797-0.48438 1.8906-0.48438zm0 6.6406c0.86328 0 1.5625-0.27344 2.0938-0.82812 0.53125-0.55078 0.79688-1.2656 0.79688-2.1406s-0.26562-1.5859-0.79688-2.1406c-0.53125-0.55078-1.2305-0.82812-2.0938-0.82812-0.875 0-1.5781 0.27734-2.1094 0.82812-0.52344 0.55469-0.78125 1.2656-0.78125 2.1406s0.25781 1.5898 0.78125 2.1406c0.53125 0.55469 1.2344 0.82812 2.1094 0.82812zm1.6094-3.7344c0 0.29297-0.074219 0.53906-0.21875 0.73438-0.14844 0.19922-0.35547 0.33984-0.625 0.42188l1.0156 1.5-1.1406 0.015625-0.85938-1.4375h-0.3125v1.4375h-0.9375v-3.875h1.7344c0.40625 0 0.72656 0.10938 0.96875 0.32812 0.25 0.21875 0.375 0.51172 0.375 0.875zm-2.1406 0.45312h0.75c0.125 0 0.23438-0.035156 0.32812-0.10938 0.09375-0.070313 0.14062-0.17188 0.14062-0.29688 0-0.13281-0.046875-0.23438-0.14062-0.29688-0.09375-0.070313-0.20312-0.10938-0.32812-0.10938h-0.75z"/>
-</g>
-<g transform="translate(238.42 1152.7)">
-<path d="m10.891-8.9062c-0.34375-0.73828-0.85156-1.3047-1.5156-1.7031-0.65625-0.40625-1.4219-0.60938-2.2969-0.60938s-1.668 0.20312-2.375 0.60938c-0.69922 0.39844-1.25 0.96875-1.6562 1.7188-0.39844 0.75-0.59375 1.6211-0.59375 2.6094 0 0.98047 0.19531 1.8438 0.59375 2.5938 0.40625 0.74219 0.95703 1.3125 1.6562 1.7188 0.70703 0.39844 1.5 0.59375 2.375 0.59375 1.2188 0 2.2227-0.36328 3.0156-1.0938 0.78906-0.72656 1.2539-1.7188 1.3906-2.9688h-5v-1.3281h6.75v1.25c-0.10547 1.043-0.43359 1.9922-0.98438 2.8438-0.54297 0.85547-1.2656 1.5312-2.1719 2.0312-0.89844 0.5-1.8984 0.75-3 0.75-1.168 0-2.2305-0.26953-3.1875-0.8125-0.96094-0.55078-1.7188-1.3125-2.2812-2.2812-0.55469-0.97656-0.82812-2.0781-0.82812-3.2969 0-1.2266 0.27344-2.3281 0.82812-3.2969 0.5625-0.97656 1.3203-1.7383 2.2812-2.2812 0.95703-0.55078 2.0195-0.82812 3.1875-0.82812 1.332 0 2.5078 0.33594 3.5312 1 1.0312 0.65625 1.7812 1.5859 2.25 2.7812z"/>
-</g>
-<g transform="translate(252.42 1152.7)">
-<path d="m3.0312-8.2656c0.28125-0.5625 0.6875-1 1.2188-1.3125 0.53906-0.3125 1.1914-0.46875 1.9531-0.46875v1.6875h-0.42188c-1.8359 0-2.75 1-2.75 3v5.3594h-1.6406v-9.8594h1.6406z"/>
-</g>
-<g transform="translate(259.14 1152.7)">
-<path d="m0.78125-4.9688c0-1.0078 0.20312-1.8945 0.60938-2.6562 0.40625-0.75781 0.96094-1.3477 1.6719-1.7656 0.71875-0.42578 1.5156-0.64062 2.3906-0.64062 0.86328 0 1.6133 0.1875 2.25 0.5625 0.63281 0.375 1.1094 0.84375 1.4219 1.4062v-1.7969h1.6562v9.8594h-1.6562v-1.8438c-0.32422 0.58594-0.80859 1.0625-1.4531 1.4375-0.63672 0.375-1.3828 0.5625-2.2344 0.5625-0.875 0-1.668-0.21094-2.375-0.64062-0.71094-0.4375-1.2656-1.0391-1.6719-1.8125-0.40625-0.78125-0.60938-1.6719-0.60938-2.6719zm8.3438 0.015625c0-0.73828-0.15234-1.3828-0.45312-1.9375-0.30469-0.55078-0.71094-0.97266-1.2188-1.2656-0.5-0.30078-1.0586-0.45312-1.6719-0.45312-0.61719 0-1.1797 0.14844-1.6875 0.4375-0.5 0.29297-0.90234 0.71484-1.2031 1.2656-0.29297 0.55469-0.4375 1.1992-0.4375 1.9375 0 0.76172 0.14453 1.4219 0.4375 1.9844 0.30078 0.55469 0.70312 0.97656 1.2031 1.2656 0.50781 0.29297 1.0703 0.4375 1.6875 0.4375 0.61328 0 1.1719-0.14453 1.6719-0.4375 0.50781-0.28906 0.91406-0.71094 1.2188-1.2656 0.30078-0.5625 0.45312-1.2188 0.45312-1.9688z"/>
-</g>
-<g transform="translate(271.31 1152.7)">
-<path d="m5.4062-8.5156h-2.0781v8.5156h-1.6406v-8.5156h-1.2812v-1.3438h1.2812v-0.70312c0-1.1016 0.28516-1.9102 0.85938-2.4219 0.57031-0.50781 1.4883-0.76562 2.75-0.76562v1.3594c-0.71875 0-1.2305 0.14844-1.5312 0.4375-0.29297 0.28125-0.4375 0.74609-0.4375 1.3906v0.70312h2.0781z"/>
-</g>
-<g transform="translate(277.23 1152.7)">
-<path d="m0.78125-4.9688c0-1.0078 0.20312-1.8945 0.60938-2.6562 0.40625-0.75781 0.96094-1.3477 1.6719-1.7656 0.71875-0.42578 1.5156-0.64062 2.3906-0.64062 0.86328 0 1.6133 0.1875 2.25 0.5625 0.63281 0.375 1.1094 0.84375 1.4219 1.4062v-1.7969h1.6562v9.8594h-1.6562v-1.8438c-0.32422 0.58594-0.80859 1.0625-1.4531 1.4375-0.63672 0.375-1.3828 0.5625-2.2344 0.5625-0.875 0-1.668-0.21094-2.375-0.64062-0.71094-0.4375-1.2656-1.0391-1.6719-1.8125-0.40625-0.78125-0.60938-1.6719-0.60938-2.6719zm8.3438 0.015625c0-0.73828-0.15234-1.3828-0.45312-1.9375-0.30469-0.55078-0.71094-0.97266-1.2188-1.2656-0.5-0.30078-1.0586-0.45312-1.6719-0.45312-0.61719 0-1.1797 0.14844-1.6875 0.4375-0.5 0.29297-0.90234 0.71484-1.2031 1.2656-0.29297 0.55469-0.4375 1.1992-0.4375 1.9375 0 0.76172 0.14453 1.4219 0.4375 1.9844 0.30078 0.55469 0.70312 0.97656 1.2031 1.2656 0.50781 0.29297 1.0703 0.4375 1.6875 0.4375 0.61328 0 1.1719-0.14453 1.6719-0.4375 0.50781-0.28906 0.91406-0.71094 1.2188-1.2656 0.30078-0.5625 0.45312-1.2188 0.45312-1.9688z"/>
-</g>
-<g transform="translate(289.4 1152.7)">
-<path d="m6.1875-10.047c1.1953 0 2.1641 0.36719 2.9062 1.0938 0.75 0.73047 1.125 1.7773 1.125 3.1406v5.8125h-1.6094v-5.5781c0-0.98828-0.25-1.7422-0.75-2.2656-0.49219-0.51953-1.1641-0.78125-2.0156-0.78125-0.86719 0-1.5547 0.27344-2.0625 0.8125-0.5 0.54297-0.75 1.3281-0.75 2.3594v5.4531h-1.6406v-9.8594h1.6406v1.4062c0.32031-0.50781 0.75781-0.89844 1.3125-1.1719 0.5625-0.28125 1.1758-0.42188 1.8438-0.42188z"/>
-</g>
-<g transform="translate(300.92 1152.7)">
-<path d="m0.78125-4.9688c0-1.0078 0.20312-1.8945 0.60938-2.6562 0.40625-0.75781 0.96094-1.3477 1.6719-1.7656 0.71875-0.42578 1.5156-0.64062 2.3906-0.64062 0.86328 0 1.6133 0.1875 2.25 0.5625 0.63281 0.375 1.1094 0.84375 1.4219 1.4062v-1.7969h1.6562v9.8594h-1.6562v-1.8438c-0.32422 0.58594-0.80859 1.0625-1.4531 1.4375-0.63672 0.375-1.3828 0.5625-2.2344 0.5625-0.875 0-1.668-0.21094-2.375-0.64062-0.71094-0.4375-1.2656-1.0391-1.6719-1.8125-0.40625-0.78125-0.60938-1.6719-0.60938-2.6719zm8.3438 0.015625c0-0.73828-0.15234-1.3828-0.45312-1.9375-0.30469-0.55078-0.71094-0.97266-1.2188-1.2656-0.5-0.30078-1.0586-0.45312-1.6719-0.45312-0.61719 0-1.1797 0.14844-1.6875 0.4375-0.5 0.29297-0.90234 0.71484-1.2031 1.2656-0.29297 0.55469-0.4375 1.1992-0.4375 1.9375 0 0.76172 0.14453 1.4219 0.4375 1.9844 0.30078 0.55469 0.70312 0.97656 1.2031 1.2656 0.50781 0.29297 1.0703 0.4375 1.6875 0.4375 0.61328 0 1.1719-0.14453 1.6719-0.4375 0.50781-0.28906 0.91406-0.71094 1.2188-1.2656 0.30078-0.5625 0.45312-1.2188 0.45312-1.9688z"/>
-</g>
-<g transform="translate(313.08 1152.7)">
-<path d="m4.5938-12.703c0.69531 0 1.3203 0.16406 1.875 0.48438 0.55078 0.3125 0.97656 0.75 1.2812 1.3125 0.3125 0.55469 0.46875 1.1797 0.46875 1.875 0 0.69922-0.15625 1.3281-0.46875 1.8906-0.30469 0.5625-0.73047 1.0078-1.2812 1.3281-0.55469 0.3125-1.1797 0.46875-1.875 0.46875-0.71094 0-1.3398-0.15625-1.8906-0.46875-0.55469-0.32031-0.98438-0.76562-1.2969-1.3281s-0.46875-1.1914-0.46875-1.8906c0-0.69531 0.15625-1.3203 0.46875-1.875 0.3125-0.5625 0.74219-1 1.2969-1.3125 0.55078-0.32031 1.1797-0.48438 1.8906-0.48438zm0 6.6406c0.86328 0 1.5625-0.27344 2.0938-0.82812 0.53125-0.55078 0.79688-1.2656 0.79688-2.1406s-0.26562-1.5859-0.79688-2.1406c-0.53125-0.55078-1.2305-0.82812-2.0938-0.82812-0.875 0-1.5781 0.27734-2.1094 0.82812-0.52344 0.55469-0.78125 1.2656-0.78125 2.1406s0.25781 1.5898 0.78125 2.1406c0.53125 0.55469 1.2344 0.82812 2.1094 0.82812zm1.6094-3.7344c0 0.29297-0.074219 0.53906-0.21875 0.73438-0.14844 0.19922-0.35547 0.33984-0.625 0.42188l1.0156 1.5-1.1406 0.015625-0.85938-1.4375h-0.3125v1.4375h-0.9375v-3.875h1.7344c0.40625 0 0.72656 0.10938 0.96875 0.32812 0.25 0.21875 0.375 0.51172 0.375 0.875zm-2.1406 0.45312h0.75c0.125 0 0.23438-0.035156 0.32812-0.10938 0.09375-0.070313 0.14062-0.17188 0.14062-0.29688 0-0.13281-0.046875-0.23438-0.14062-0.29688-0.09375-0.070313-0.20312-0.10938-0.32812-0.10938h-0.75z"/>
-</g>
-</g>
-<g fill="#fffbf9">
-<g transform="translate(412.81 1119.6)">
-<path d="m12-34.078-0.76562 23.188h-5.6719l-0.8125-23.188zm-3.4531 34.422c-1.2188 0-2.2188-0.375-3-1.125-0.78125-0.75781-1.1719-1.6953-1.1719-2.8125 0-1.125 0.39062-2.0625 1.1719-2.8125s1.7812-1.125 3-1.125c1.1758 0 2.1484 0.375 2.9219 1.125 0.76953 0.75 1.1562 1.6875 1.1562 2.8125 0 1.1172-0.38672 2.0547-1.1562 2.8125-0.77344 0.75-1.7461 1.125-2.9219 1.125z"/>
-</g>
-</g>
-<g>
-<g transform="translate(360.12 1152.7)">
-<path d="m8.7969-2.7969h-5.4688l-1 2.7969h-1.7344l4.5312-12.469h1.8906l4.5156 12.469h-1.7188zm-0.46875-1.3281-2.2656-6.3281-2.2656 6.3281z"/>
-</g>
-<g transform="translate(372.25 1152.7)">
-<path d="m3.0312-13.312v13.312h-1.6406v-13.312z"/>
-</g>
-<g transform="translate(376.68 1152.7)">
-<path d="m10.391-5.3125c0 0.3125-0.023437 0.64844-0.0625 1h-7.875c0.050781 0.96875 0.37891 1.7305 0.98438 2.2812 0.61328 0.54297 1.3516 0.8125 2.2188 0.8125 0.70703 0 1.2969-0.16406 1.7656-0.5 0.47656-0.33203 0.8125-0.77344 1-1.3281h1.7656c-0.26172 0.94922-0.78906 1.7188-1.5781 2.3125-0.79297 0.59375-1.7773 0.89062-2.9531 0.89062-0.9375 0-1.7773-0.20703-2.5156-0.625-0.74219-0.41406-1.3203-1.0078-1.7344-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.76953 0.97656-1.3633 1.7188-1.7812 0.73828-0.41406 1.5859-0.625 2.5469-0.625 0.9375 0 1.7656 0.21094 2.4844 0.625 0.71875 0.40625 1.2695 0.96875 1.6562 1.6875 0.39453 0.71094 0.59375 1.5117 0.59375 2.4062zm-1.7031-0.34375c0-0.625-0.14062-1.1602-0.42188-1.6094-0.27344-0.44531-0.64844-0.78516-1.125-1.0156-0.46875-0.23828-0.99219-0.35938-1.5625-0.35938-0.82422 0-1.5273 0.26562-2.1094 0.79688-0.58594 0.52344-0.91797 1.25-1 2.1875z"/>
-</g>
-<g transform="translate(387.84 1152.7)">
-<path d="m3.0312-8.2656c0.28125-0.5625 0.6875-1 1.2188-1.3125 0.53906-0.3125 1.1914-0.46875 1.9531-0.46875v1.6875h-0.42188c-1.8359 0-2.75 1-2.75 3v5.3594h-1.6406v-9.8594h1.6406z"/>
-</g>
-<g transform="translate(394.55 1152.7)">
-<path d="m3.3906-8.5156v5.8125c0 0.48047 0.097656 0.82031 0.29688 1.0156 0.20703 0.19922 0.5625 0.29688 1.0625 0.29688h1.2031v1.3906h-1.4688c-0.91797 0-1.6055-0.20703-2.0625-0.625-0.44922-0.42578-0.67188-1.1172-0.67188-2.0781v-5.8125h-1.2812v-1.3438h1.2812v-2.4844h1.6406v2.4844h2.5625v1.3438z"/>
-</g>
-<g transform="translate(401.1 1152.7)">
-<path d="m14.109-12.453v12.453h-1.6406v-9.2812l-4.1406 9.2812h-1.1406l-4.1562-9.3125v9.3125h-1.6406v-12.453h1.7656l4.6094 10.297 4.5938-10.297z"/>
-</g>
-<g transform="translate(416.6 1152.7)">
-<path d="m0.78125-4.9688c0-1.0078 0.20312-1.8945 0.60938-2.6562 0.40625-0.75781 0.96094-1.3477 1.6719-1.7656 0.71875-0.42578 1.5156-0.64062 2.3906-0.64062 0.86328 0 1.6133 0.1875 2.25 0.5625 0.63281 0.375 1.1094 0.84375 1.4219 1.4062v-1.7969h1.6562v9.8594h-1.6562v-1.8438c-0.32422 0.58594-0.80859 1.0625-1.4531 1.4375-0.63672 0.375-1.3828 0.5625-2.2344 0.5625-0.875 0-1.668-0.21094-2.375-0.64062-0.71094-0.4375-1.2656-1.0391-1.6719-1.8125-0.40625-0.78125-0.60938-1.6719-0.60938-2.6719zm8.3438 0.015625c0-0.73828-0.15234-1.3828-0.45312-1.9375-0.30469-0.55078-0.71094-0.97266-1.2188-1.2656-0.5-0.30078-1.0586-0.45312-1.6719-0.45312-0.61719 0-1.1797 0.14844-1.6875 0.4375-0.5 0.29297-0.90234 0.71484-1.2031 1.2656-0.29297 0.55469-0.4375 1.1992-0.4375 1.9375 0 0.76172 0.14453 1.4219 0.4375 1.9844 0.30078 0.55469 0.70312 0.97656 1.2031 1.2656 0.50781 0.29297 1.0703 0.4375 1.6875 0.4375 0.61328 0 1.1719-0.14453 1.6719-0.4375 0.50781-0.28906 0.91406-0.71094 1.2188-1.2656 0.30078-0.5625 0.45312-1.2188 0.45312-1.9688z"/>
-</g>
-<g transform="translate(428.77 1152.7)">
-<path d="m6.1875-10.047c1.1953 0 2.1641 0.36719 2.9062 1.0938 0.75 0.73047 1.125 1.7773 1.125 3.1406v5.8125h-1.6094v-5.5781c0-0.98828-0.25-1.7422-0.75-2.2656-0.49219-0.51953-1.1641-0.78125-2.0156-0.78125-0.86719 0-1.5547 0.27344-2.0625 0.8125-0.5 0.54297-0.75 1.3281-0.75 2.3594v5.4531h-1.6406v-9.8594h1.6406v1.4062c0.32031-0.50781 0.75781-0.89844 1.3125-1.1719 0.5625-0.28125 1.1758-0.42188 1.8438-0.42188z"/>
-</g>
-<g transform="translate(440.29 1152.7)">
-<path d="m0.78125-4.9688c0-1.0078 0.20312-1.8945 0.60938-2.6562 0.40625-0.75781 0.96094-1.3477 1.6719-1.7656 0.71875-0.42578 1.5156-0.64062 2.3906-0.64062 0.86328 0 1.6133 0.1875 2.25 0.5625 0.63281 0.375 1.1094 0.84375 1.4219 1.4062v-1.7969h1.6562v9.8594h-1.6562v-1.8438c-0.32422 0.58594-0.80859 1.0625-1.4531 1.4375-0.63672 0.375-1.3828 0.5625-2.2344 0.5625-0.875 0-1.668-0.21094-2.375-0.64062-0.71094-0.4375-1.2656-1.0391-1.6719-1.8125-0.40625-0.78125-0.60938-1.6719-0.60938-2.6719zm8.3438 0.015625c0-0.73828-0.15234-1.3828-0.45312-1.9375-0.30469-0.55078-0.71094-0.97266-1.2188-1.2656-0.5-0.30078-1.0586-0.45312-1.6719-0.45312-0.61719 0-1.1797 0.14844-1.6875 0.4375-0.5 0.29297-0.90234 0.71484-1.2031 1.2656-0.29297 0.55469-0.4375 1.1992-0.4375 1.9375 0 0.76172 0.14453 1.4219 0.4375 1.9844 0.30078 0.55469 0.70312 0.97656 1.2031 1.2656 0.50781 0.29297 1.0703 0.4375 1.6875 0.4375 0.61328 0 1.1719-0.14453 1.6719-0.4375 0.50781-0.28906 0.91406-0.71094 1.2188-1.2656 0.30078-0.5625 0.45312-1.2188 0.45312-1.9688z"/>
-</g>
-<g transform="translate(452.46 1152.7)">
-<path d="m5.4531-10.031c0.85156 0 1.5977 0.1875 2.2344 0.5625 0.64453 0.375 1.125 0.84375 1.4375 1.4062v-1.7969h1.6562v10.078c0 0.89453-0.19531 1.6914-0.57812 2.3906-0.38672 0.70703-0.9375 1.2578-1.6562 1.6562-0.71094 0.39453-1.5391 0.59375-2.4844 0.59375-1.293 0-2.3711-0.30859-3.2344-0.92188-0.86719-0.60547-1.375-1.4375-1.5312-2.5h1.625c0.17578 0.60156 0.54688 1.0859 1.1094 1.4531 0.5625 0.36328 1.2383 0.54688 2.0312 0.54688 0.90625 0 1.6406-0.28125 2.2031-0.84375 0.57031-0.5625 0.85938-1.3555 0.85938-2.375v-2.0781c-0.32422 0.58594-0.80469 1.0703-1.4375 1.4531-0.63672 0.375-1.3828 0.5625-2.2344 0.5625-0.875 0-1.6719-0.21094-2.3906-0.64062-0.71094-0.4375-1.2656-1.0391-1.6719-1.8125-0.40625-0.78125-0.60938-1.6719-0.60938-2.6719 0-1.0078 0.20312-1.8945 0.60938-2.6562 0.40625-0.75781 0.96094-1.3477 1.6719-1.7656 0.71875-0.42578 1.5156-0.64062 2.3906-0.64062zm3.6719 5.0781c0-0.73828-0.15234-1.3828-0.45312-1.9375-0.30469-0.55078-0.71094-0.97266-1.2188-1.2656-0.5-0.30078-1.0586-0.45312-1.6719-0.45312-0.61719 0-1.1797 0.14844-1.6875 0.4375-0.5 0.29297-0.90234 0.71484-1.2031 1.2656-0.29297 0.55469-0.4375 1.1992-0.4375 1.9375 0 0.76172 0.14453 1.4219 0.4375 1.9844 0.30078 0.55469 0.70312 0.97656 1.2031 1.2656 0.50781 0.29297 1.0703 0.4375 1.6875 0.4375 0.61328 0 1.1719-0.14453 1.6719-0.4375 0.50781-0.28906 0.91406-0.71094 1.2188-1.2656 0.30078-0.5625 0.45312-1.2188 0.45312-1.9688z"/>
-</g>
-<g transform="translate(464.63 1152.7)">
-<path d="m10.391-5.3125c0 0.3125-0.023437 0.64844-0.0625 1h-7.875c0.050781 0.96875 0.37891 1.7305 0.98438 2.2812 0.61328 0.54297 1.3516 0.8125 2.2188 0.8125 0.70703 0 1.2969-0.16406 1.7656-0.5 0.47656-0.33203 0.8125-0.77344 1-1.3281h1.7656c-0.26172 0.94922-0.78906 1.7188-1.5781 2.3125-0.79297 0.59375-1.7773 0.89062-2.9531 0.89062-0.9375 0-1.7773-0.20703-2.5156-0.625-0.74219-0.41406-1.3203-1.0078-1.7344-1.7812-0.41797-0.78125-0.625-1.6797-0.625-2.7031 0-1.0195 0.20312-1.9102 0.60938-2.6719 0.40625-0.76953 0.97656-1.3633 1.7188-1.7812 0.73828-0.41406 1.5859-0.625 2.5469-0.625 0.9375 0 1.7656 0.21094 2.4844 0.625 0.71875 0.40625 1.2695 0.96875 1.6562 1.6875 0.39453 0.71094 0.59375 1.5117 0.59375 2.4062zm-1.7031-0.34375c0-0.625-0.14062-1.1602-0.42188-1.6094-0.27344-0.44531-0.64844-0.78516-1.125-1.0156-0.46875-0.23828-0.99219-0.35938-1.5625-0.35938-0.82422 0-1.5273 0.26562-2.1094 0.79688-0.58594 0.52344-0.91797 1.25-1 2.1875z"/>
-</g>
-<g transform="translate(475.79 1152.7)">
-<path d="m3.0312-8.2656c0.28125-0.5625 0.6875-1 1.2188-1.3125 0.53906-0.3125 1.1914-0.46875 1.9531-0.46875v1.6875h-0.42188c-1.8359 0-2.75 1-2.75 3v5.3594h-1.6406v-9.8594h1.6406z"/>
-</g>
-</g>
-<g fill="#303b54">
-<g transform="translate(668.01 437.79)">
-<path d="m7.3125-24.438v24.438h-4.8906v-24.438z"/>
-</g>
-<g transform="translate(677.73 437.79)">
-<path d="m10.844 0.25c-1.6992 0-3.2305-0.28906-4.5938-0.875-1.3672-0.58203-2.4492-1.4219-3.25-2.5156-0.79297-1.1016-1.1992-2.3984-1.2188-3.8906h5.25c0.070312 1 0.42578 1.793 1.0625 2.375 0.64453 0.58594 1.5312 0.875 2.6562 0.875 1.1328 0 2.0312-0.26953 2.6875-0.8125 0.65625-0.55078 0.98438-1.2695 0.98438-2.1562 0-0.72656-0.22656-1.3203-0.67188-1.7812-0.4375-0.46875-0.99219-0.83594-1.6562-1.1094-0.66797-0.26953-1.5859-0.56641-2.75-0.89062-1.5859-0.46875-2.875-0.92578-3.875-1.375-0.99219-0.45703-1.8398-1.1445-2.5469-2.0625-0.71094-0.92578-1.0625-2.1602-1.0625-3.7031 0-1.4453 0.35938-2.707 1.0781-3.7812 0.72656-1.0703 1.7422-1.8945 3.0469-2.4688 1.3008-0.57031 2.7969-0.85938 4.4844-0.85938 2.5195 0 4.5664 0.61719 6.1406 1.8438 1.5703 1.2188 2.4414 2.9297 2.6094 5.125h-5.3906c-0.054687-0.84375-0.41406-1.5352-1.0781-2.0781-0.65625-0.55078-1.5391-0.82812-2.6406-0.82812-0.94922 0-1.7109 0.24609-2.2812 0.73438-0.57422 0.49219-0.85938 1.2031-0.85938 2.1406 0 0.64844 0.21094 1.1875 0.64062 1.625 0.4375 0.42969 0.97266 0.77734 1.6094 1.0469 0.64453 0.27344 1.5508 0.57812 2.7188 0.92188 1.582 0.46875 2.875 0.9375 3.875 1.4062 1.0078 0.46875 1.875 1.1719 2.5938 2.1094 0.72656 0.92969 1.0938 2.1523 1.0938 3.6719 0 1.3047-0.33984 2.5156-1.0156 3.6406-0.67969 1.1172-1.6719 2.0078-2.9844 2.6719-1.3047 0.66797-2.8555 1-4.6562 1z"/>
-</g>
-<g transform="translate(699.04 437.79)">
-<path d="m13.75 0.25c-2.2812 0-4.3828-0.53516-6.2969-1.6094-1.918-1.0703-3.4375-2.5625-4.5625-4.4688-1.1172-1.9062-1.6719-4.0547-1.6719-6.4531 0-2.3828 0.55469-4.5234 1.6719-6.4219 1.125-1.9062 2.6445-3.3945 4.5625-4.4688 1.9141-1.0703 4.0156-1.6094 6.2969-1.6094 2.3125 0 4.4141 0.53906 6.3125 1.6094 1.9062 1.0742 3.4102 2.5625 4.5156 4.4688 1.1133 1.8984 1.6719 4.0391 1.6719 6.4219 0 2.3984-0.55859 4.5469-1.6719 6.4531-1.1055 1.9062-2.6172 3.3984-4.5312 4.4688-1.9062 1.0742-4.0078 1.6094-6.2969 1.6094zm0-4.375c1.4688 0 2.7578-0.33203 3.875-1 1.125-0.66406 2-1.6133 2.625-2.8438 0.63281-1.2383 0.95312-2.6758 0.95312-4.3125 0-1.6328-0.32031-3.0625-0.95312-4.2812-0.625-1.2266-1.5-2.1719-2.625-2.8281-1.1172-0.65625-2.4062-0.98438-3.875-0.98438s-2.7734 0.32812-3.9062 0.98438c-1.125 0.65625-2.0078 1.6016-2.6406 2.8281-0.625 1.2188-0.9375 2.6484-0.9375 4.2812 0 1.6367 0.3125 3.0742 0.9375 4.3125 0.63281 1.2305 1.5156 2.1797 2.6406 2.8438 1.1328 0.66797 2.4375 1 3.9062 1z"/>
-</g>
-<g transform="translate(726.51 437.79)"/>
-<g transform="translate(734.84 437.79)">
-<path d="m3.3906-5.5312c2.2383-1.8633 4.0234-3.4219 5.3594-4.6719 1.332-1.25 2.4414-2.5508 3.3281-3.9062 0.88281-1.3516 1.3281-2.6797 1.3281-3.9844 0-1.1875-0.28125-2.1172-0.84375-2.7969-0.5625-0.67578-1.4297-1.0156-2.5938-1.0156-1.168 0-2.0703 0.39062-2.7031 1.1719-0.625 0.78125-0.94922 1.8516-0.96875 3.2031h-4.75c0.09375-2.8008 0.92578-4.9258 2.5-6.375 1.5703-1.4453 3.5703-2.1719 6-2.1719 2.6562 0 4.6953 0.71094 6.125 2.125 1.4258 1.4062 2.1406 3.2656 2.1406 5.5781 0 1.8242-0.49609 3.5625-1.4844 5.2188-0.98047 1.6562-2.1016 3.1016-3.3594 4.3281-1.2617 1.2188-2.9023 2.6953-4.9219 4.4219h10.312v4.0625h-17.281v-3.6406z"/>
-</g>
-<g transform="translate(754.93 437.79)">
-<path d="m18.094-21.812-9.3125 21.812h-4.9688l9.375-21.25h-11.969v-4.1875h16.875z"/>
-</g>
-<g transform="translate(774.1 437.79)">
-<path d="m1.8594-13.094c0-4.0312 0.72656-7.1875 2.1875-9.4688 1.457-2.2891 3.8789-3.4375 7.2656-3.4375 3.375 0 5.7891 1.1484 7.25 3.4375 1.457 2.2812 2.1875 5.4375 2.1875 9.4688 0 4.0625-0.73047 7.25-2.1875 9.5625-1.4609 2.3125-3.875 3.4688-7.25 3.4688-3.3867 0-5.8086-1.1562-7.2656-3.4688-1.4609-2.3125-2.1875-5.5-2.1875-9.5625zm14.062 0c0-1.7266-0.10938-3.1797-0.32812-4.3594-0.21875-1.1758-0.66406-2.1328-1.3281-2.875-0.66797-0.75-1.6523-1.125-2.9531-1.125-1.3125 0-2.3047 0.375-2.9688 1.125-0.66797 0.74219-1.1094 1.6992-1.3281 2.875-0.21875 1.1797-0.32812 2.6328-0.32812 4.3594 0 1.7734 0.10156 3.2617 0.3125 4.4688 0.20703 1.1992 0.64844 2.168 1.3281 2.9062 0.67578 0.73047 1.6719 1.0938 2.9844 1.0938 1.3008 0 2.2891-0.36328 2.9688-1.0938 0.67578-0.73828 1.1172-1.707 1.3281-2.9062 0.20703-1.207 0.3125-2.6953 0.3125-4.4688z"/>
-</g>
-<g transform="translate(796.71 437.79)">
-<path d="m1.8594-13.094c0-4.0312 0.72656-7.1875 2.1875-9.4688 1.457-2.2891 3.8789-3.4375 7.2656-3.4375 3.375 0 5.7891 1.1484 7.25 3.4375 1.457 2.2812 2.1875 5.4375 2.1875 9.4688 0 4.0625-0.73047 7.25-2.1875 9.5625-1.4609 2.3125-3.875 3.4688-7.25 3.4688-3.3867 0-5.8086-1.1562-7.2656-3.4688-1.4609-2.3125-2.1875-5.5-2.1875-9.5625zm14.062 0c0-1.7266-0.10938-3.1797-0.32812-4.3594-0.21875-1.1758-0.66406-2.1328-1.3281-2.875-0.66797-0.75-1.6523-1.125-2.9531-1.125-1.3125 0-2.3047 0.375-2.9688 1.125-0.66797 0.74219-1.1094 1.6992-1.3281 2.875-0.21875 1.1797-0.32812 2.6328-0.32812 4.3594 0 1.7734 0.10156 3.2617 0.3125 4.4688 0.20703 1.1992 0.64844 2.168 1.3281 2.9062 0.67578 0.73047 1.6719 1.0938 2.9844 1.0938 1.3008 0 2.2891-0.36328 2.9688-1.0938 0.67578-0.73828 1.1172-1.707 1.3281-2.9062 0.20703-1.207 0.3125-2.6953 0.3125-4.4688z"/>
-</g>
-<g transform="translate(819.31 437.79)">
-<path d="m1.2656-21v-4.5156h8.4219v25.516h-5.0312v-21z"/>
-</g>
-<g transform="translate(674.41 472.29)">
-<path d="m1.2188-12.25c0-2.4062 0.53906-4.5547 1.625-6.4531 1.0938-1.9062 2.5781-3.3906 4.4531-4.4531s3.9766-1.5938 6.3125-1.5938c2.7266 0 5.1172 0.70312 7.1719 2.1094 2.0625 1.3984 3.5 3.3359 4.3125 5.8125h-5.6406c-0.55469-1.1641-1.3398-2.0391-2.3594-2.625-1.0117-0.58203-2.1836-0.875-3.5156-0.875-1.4297 0-2.6953 0.33594-3.7969 1-1.1055 0.65625-1.9688 1.5938-2.5938 2.8125-0.61719 1.2109-0.92188 2.6328-0.92188 4.2656 0 1.6172 0.30469 3.0391 0.92188 4.2656 0.625 1.2188 1.4883 2.1641 2.5938 2.8281 1.1016 0.65625 2.3672 0.98438 3.7969 0.98438 1.332 0 2.5039-0.29688 3.5156-0.89062 1.0195-0.59375 1.8047-1.4727 2.3594-2.6406h5.6406c-0.8125 2.5-2.2422 4.4453-4.2812 5.8281-2.043 1.3867-4.4453 2.0781-7.2031 2.0781-2.3359 0-4.4375-0.52344-6.3125-1.5781-1.875-1.0625-3.3594-2.5352-4.4531-4.4219-1.0859-1.8945-1.625-4.0469-1.625-6.4531z"/>
-</g>
-<g transform="translate(701.28 472.29)">
-<path d="m11.031 0.3125c-1.875 0-3.5586-0.41016-5.0469-1.2344-1.4922-0.83203-2.6641-2.0039-3.5156-3.5156-0.85547-1.5195-1.2812-3.2695-1.2812-5.25 0-1.9883 0.4375-3.7383 1.3125-5.25 0.875-1.5195 2.0664-2.6914 3.5781-3.5156 1.5195-0.83203 3.2188-1.25 5.0938-1.25 1.8633 0 3.5508 0.41797 5.0625 1.25 1.5195 0.82422 2.7188 1.9961 3.5938 3.5156 0.875 1.5117 1.3125 3.2617 1.3125 5.25 0 1.9805-0.45312 3.7305-1.3594 5.25-0.89844 1.5117-2.1094 2.6836-3.6406 3.5156-1.5234 0.82422-3.2266 1.2344-5.1094 1.2344zm0-4.2656c0.88281 0 1.7188-0.21094 2.5-0.64062 0.78125-0.4375 1.3984-1.0859 1.8594-1.9531 0.46875-0.86328 0.70312-1.9102 0.70312-3.1406 0-1.8438-0.48438-3.2578-1.4531-4.25-0.96875-1-2.1523-1.5-3.5469-1.5-1.3984 0-2.5703 0.5-3.5156 1.5-0.94922 0.99219-1.4219 2.4062-1.4219 4.25 0 1.8359 0.45703 3.25 1.375 4.25 0.92578 0.99219 2.0938 1.4844 3.5 1.4844z"/>
-</g>
-<g transform="translate(723.6 472.29)">
-<path d="m13.156-19.672c2.3125 0 4.1758 0.73047 5.5938 2.1875 1.4258 1.4609 2.1406 3.4961 2.1406 6.1094v11.375h-4.8906v-10.703c0-1.5391-0.38672-2.7227-1.1562-3.5469-0.77344-0.83203-1.8242-1.25-3.1562-1.25-1.3555 0-2.4219 0.41797-3.2031 1.25-0.78125 0.82422-1.1719 2.0078-1.1719 3.5469v10.703h-4.8906v-19.391h4.8906v2.4219c0.65625-0.84375 1.4883-1.5039 2.5-1.9844 1.0195-0.47656 2.1328-0.71875 3.3438-0.71875z"/>
-</g>
-<g transform="translate(746.73 472.29)">
-<path d="m8.125-15.359v9.375c0 0.65625 0.15625 1.1328 0.46875 1.4219 0.3125 0.29297 0.84375 0.4375 1.5938 0.4375h2.2656v4.125h-3.0781c-4.125 0-6.1875-2.0039-6.1875-6.0156v-9.3438h-2.3125v-4.0312h2.3125v-4.7969h4.9375v4.7969h4.3281v4.0312z"/>
-</g>
-<g transform="translate(760.31 472.29)">
-<path d="m7.3125-16.375c0.63281-1.0312 1.457-1.8359 2.4688-2.4219 1.0195-0.58203 2.1797-0.875 3.4844-0.875v5.1406h-1.2969c-1.543 0-2.7031 0.36719-3.4844 1.0938-0.78125 0.71875-1.1719 1.9805-1.1719 3.7812v9.6562h-4.8906v-19.391h4.8906z"/>
-</g>
-<g transform="translate(774.45 472.29)">
-<path d="m11.031 0.3125c-1.875 0-3.5586-0.41016-5.0469-1.2344-1.4922-0.83203-2.6641-2.0039-3.5156-3.5156-0.85547-1.5195-1.2812-3.2695-1.2812-5.25 0-1.9883 0.4375-3.7383 1.3125-5.25 0.875-1.5195 2.0664-2.6914 3.5781-3.5156 1.5195-0.83203 3.2188-1.25 5.0938-1.25 1.8633 0 3.5508 0.41797 5.0625 1.25 1.5195 0.82422 2.7188 1.9961 3.5938 3.5156 0.875 1.5117 1.3125 3.2617 1.3125 5.25 0 1.9805-0.45312 3.7305-1.3594 5.25-0.89844 1.5117-2.1094 2.6836-3.6406 3.5156-1.5234 0.82422-3.2266 1.2344-5.1094 1.2344zm0-4.2656c0.88281 0 1.7188-0.21094 2.5-0.64062 0.78125-0.4375 1.3984-1.0859 1.8594-1.9531 0.46875-0.86328 0.70312-1.9102 0.70312-3.1406 0-1.8438-0.48438-3.2578-1.4531-4.25-0.96875-1-2.1523-1.5-3.5469-1.5-1.3984 0-2.5703 0.5-3.5156 1.5-0.94922 0.99219-1.4219 2.4062-1.4219 4.25 0 1.8359 0.45703 3.25 1.375 4.25 0.92578 0.99219 2.0938 1.4844 3.5 1.4844z"/>
-</g>
-<g transform="translate(796.77 472.29)">
-<path d="m7.3125-25.906v25.906h-4.8906v-25.906z"/>
-</g>
-<g transform="translate(806.5 472.29)">
-<path d="m9.8281 0.3125c-1.5859 0-3.0078-0.28906-4.2656-0.85938-1.2617-0.57031-2.2617-1.3477-3-2.3281-0.73047-0.97656-1.1328-2.0625-1.2031-3.25h4.9375c0.09375 0.75 0.45703 1.3711 1.0938 1.8594 0.64453 0.49219 1.4453 0.73438 2.4062 0.73438 0.9375 0 1.6641-0.1875 2.1875-0.5625 0.53125-0.375 0.79688-0.85156 0.79688-1.4375 0-0.625-0.32422-1.0938-0.96875-1.4062-0.64844-0.32031-1.668-0.67188-3.0625-1.0469-1.4492-0.34375-2.6367-0.70312-3.5625-1.0781-0.91797-0.375-1.7109-0.94531-2.375-1.7188-0.66797-0.76953-1-1.8047-1-3.1094 0-1.0703 0.30469-2.0508 0.92188-2.9375 0.625-0.89453 1.5156-1.5977 2.6719-2.1094 1.1562-0.50781 2.5156-0.76562 4.0781-0.76562 2.3125 0 4.1562 0.57812 5.5312 1.7344s2.1328 2.7148 2.2812 4.6719h-4.7031c-0.0625-0.76953-0.38281-1.3789-0.95312-1.8281-0.57422-0.45703-1.3398-0.6875-2.2969-0.6875-0.88672 0-1.5703 0.16406-2.0469 0.48438-0.48047 0.32422-0.71875 0.77734-0.71875 1.3594 0 0.65625 0.32812 1.1562 0.98438 1.5 0.65625 0.33594 1.6719 0.67969 3.0469 1.0312 1.3945 0.34375 2.5469 0.70312 3.4531 1.0781 0.91406 0.375 1.707 0.95312 2.375 1.7344 0.66406 0.78125 1.0078 1.8125 1.0312 3.0938 0 1.125-0.3125 2.1328-0.9375 3.0156-0.61719 0.88672-1.5 1.5781-2.6562 2.0781s-2.5078 0.75-4.0469 0.75z"/>
-</g>
-</g>
-<g fill="#192131">
-<g transform="translate(735.16 182.75)">
-<path d="m2.6875 0v-22.75h6.7656c0.9375 0.011719 1.8516 0.13672 2.75 0.375 0.89453 0.23047 1.6914 0.58984 2.3906 1.0781 0.69531 0.49219 1.2539 1.1172 1.6719 1.875 0.41406 0.76172 0.61719 1.6719 0.60938 2.7344-0.011719 0.59375-0.10938 1.1367-0.29688 1.625-0.17969 0.49219-0.42969 0.93359-0.75 1.3281-0.3125 0.38672-0.68359 0.72656-1.1094 1.0156-0.42969 0.29297-0.88281 0.54297-1.3594 0.75 0.60156 0.17969 1.1562 0.43359 1.6562 0.76562 0.50781 0.32422 0.94531 0.71875 1.3125 1.1875 0.36328 0.46094 0.64453 0.98047 0.84375 1.5625 0.20703 0.58594 0.3125 1.2148 0.3125 1.8906 0.007813 1.0625-0.19531 2-0.60938 2.8125-0.41797 0.8125-0.97656 1.4961-1.6719 2.0469-0.69922 0.54297-1.5078 0.96094-2.4219 1.25-0.90625 0.29297-1.8438 0.44531-2.8125 0.45312zm2.9062-10.641v8.1875h4.4531c0.60156-0.007813 1.1758-0.10938 1.7188-0.29688 0.53906-0.19531 1.0195-0.46875 1.4375-0.8125 0.41406-0.34375 0.74219-0.76562 0.98438-1.2656 0.25-0.5 0.375-1.0664 0.375-1.7031 0.007812-0.64453-0.10156-1.2188-0.32812-1.7188-0.21875-0.5-0.52734-0.92188-0.92188-1.2656-0.39844-0.35156-0.85938-0.625-1.3906-0.8125s-1.1055-0.28906-1.7188-0.3125zm0-2.4062h4.0312c0.53906-0.007813 1.0703-0.09375 1.5938-0.25 0.51953-0.16406 0.98438-0.39844 1.3906-0.70312 0.40625-0.3125 0.73438-0.69141 0.98438-1.1406 0.25-0.44531 0.375-0.96875 0.375-1.5625 0-0.63281-0.125-1.1758-0.375-1.625-0.24219-0.44531-0.57031-0.8125-0.98438-1.0938-0.40625-0.28906-0.88281-0.50391-1.4219-0.64062-0.53125-0.13281-1.0781-0.20703-1.6406-0.21875h-3.9531z"/>
-</g>
-<g transform="translate(754.36 182.75)">
-<path d="m14.625-5.75c0-0.69531-0.16406-1.2852-0.48438-1.7656-0.3125-0.47656-0.71875-0.87891-1.2188-1.2031-0.5-0.33203-1.0547-0.60938-1.6562-0.82812-0.59375-0.21875-1.168-0.41406-1.7188-0.59375-0.80469-0.25781-1.6211-0.57031-2.4531-0.9375-0.82422-0.36328-1.5781-0.8125-2.2656-1.3438-0.67969-0.53125-1.2344-1.1562-1.6719-1.875-0.42969-0.72656-0.64062-1.582-0.64062-2.5625 0-0.97656 0.21094-1.8516 0.64062-2.625 0.4375-0.76953 1.0039-1.4219 1.7031-1.9531 0.69531-0.53125 1.4883-0.92969 2.375-1.2031 0.88281-0.28125 1.7734-0.42188 2.6719-0.42188 0.98828 0 1.9414 0.16797 2.8594 0.5 0.91406 0.32422 1.7266 0.78125 2.4375 1.375 0.70703 0.59375 1.2734 1.3125 1.7031 2.1562 0.42578 0.84375 0.64844 1.7891 0.67188 2.8281h-2.9688c-0.085937-0.65625-0.24609-1.25-0.48438-1.7812-0.24219-0.53906-0.55859-1.0039-0.95312-1.3906-0.39844-0.38281-0.87109-0.67969-1.4219-0.89062-0.54297-0.21875-1.1562-0.32812-1.8438-0.32812-0.55469 0-1.0938 0.078125-1.625 0.23438-0.52344 0.15625-0.99219 0.39062-1.4062 0.70312-0.40625 0.3125-0.73438 0.69922-0.98438 1.1562-0.24219 0.46094-0.35938 0.99219-0.35938 1.5938 0.007812 0.65625 0.17578 1.2148 0.5 1.6719 0.32031 0.44922 0.72656 0.82812 1.2188 1.1406 0.5 0.3125 1.0352 0.57422 1.6094 0.78125 0.58203 0.21094 1.1289 0.39062 1.6406 0.54688 0.5625 0.17969 1.1289 0.38281 1.7031 0.60938 0.57031 0.21875 1.125 0.47656 1.6562 0.76562 0.53125 0.29297 1.0234 0.62109 1.4844 0.98438 0.45703 0.36719 0.85938 0.78125 1.2031 1.25 0.34375 0.46094 0.60938 0.96875 0.79688 1.5312 0.19531 0.55469 0.29688 1.168 0.29688 1.8438 0 1.0234-0.23047 1.9141-0.6875 2.6719-0.44922 0.76172-1.0312 1.3984-1.75 1.9062-0.71875 0.5-1.5312 0.88281-2.4375 1.1406-0.90625 0.25-1.8125 0.375-2.7188 0.375-1.0117 0-2-0.15625-2.9688-0.46875s-1.8398-0.75781-2.6094-1.3438c-0.76172-0.59375-1.3828-1.3125-1.8594-2.1562-0.48047-0.85156-0.73438-1.8203-0.76562-2.9062h2.9531c0.09375 0.71094 0.28516 1.3398 0.57812 1.8906 0.28906 0.54297 0.66406 1.0078 1.125 1.3906 0.45703 0.375 0.98438 0.66406 1.5781 0.85938 0.60156 0.1875 1.2578 0.28125 1.9688 0.28125 0.5625 0 1.1133-0.066406 1.6562-0.20312 0.55078-0.14453 1.0391-0.36328 1.4688-0.65625 0.42578-0.30078 0.77344-0.67578 1.0469-1.125 0.26953-0.45703 0.40625-1 0.40625-1.625z"/>
-</g>
-<g transform="translate(773.56 182.75)">
-<path d="m2.7188-22.75h13.75v2.5156h-5.4531v17.734h5.4531v2.5h-13.75v-2.5h5.3281v-17.734h-5.3281z"/>
-</g>
-<g transform="translate(1081.6 154.58)">
-<path d="m14.031-9.1719h-8.6406v9.1719h-2.6719v-20.766h12.766v2.25h-10.094v7.1094h8.6406z"/>
-</g>
-<g transform="translate(1099.1 154.58)">
-<path d="m2.8906-15.438h7.8906v13.156h5.0469v2.2812h-12.938v-2.2812h5.25v-10.859h-5.25zm4.9062-4.0469c0-0.4375 0.12891-0.80469 0.39062-1.1094 0.26953-0.30078 0.67188-0.45312 1.2031-0.45312 0.51953 0 0.91016 0.15234 1.1719 0.45312 0.26953 0.30469 0.40625 0.67188 0.40625 1.1094 0 0.42969-0.13672 0.78906-0.40625 1.0781-0.26172 0.28125-0.65234 0.42188-1.1719 0.42188-0.53125 0-0.93359-0.14062-1.2031-0.42188-0.26172-0.28906-0.39062-0.64844-0.39062-1.0781z"/>
-</g>
-<g transform="translate(1116.6 154.58)">
-<path d="m4.8438-15.438 0.1875 2.2812c0.5625-0.80078 1.25-1.4258 2.0625-1.875 0.82031-0.44531 1.7383-0.67578 2.75-0.6875 0.8125 0 1.5469 0.11719 2.2031 0.34375 0.66406 0.23047 1.2266 0.58984 1.6875 1.0781 0.46875 0.48047 0.82812 1.0938 1.0781 1.8438 0.25 0.74219 0.375 1.625 0.375 2.6562v9.7969h-2.625v-9.75c0-0.67578-0.078125-1.2539-0.23438-1.7344-0.15625-0.47656-0.38672-0.86328-0.6875-1.1562-0.29297-0.28906-0.65625-0.50391-1.0938-0.64062-0.42969-0.13281-0.92188-0.20312-1.4844-0.20312-0.88672 0-1.668 0.22656-2.3438 0.67188-0.66797 0.4375-1.1992 1.0156-1.5938 1.7344v11.078h-2.6406v-15.438z"/>
-</g>
-<g transform="translate(1134.2 154.58)">
-<path d="m12.625 0c-0.10547-0.19531-0.1875-0.44531-0.25-0.75-0.0625-0.30078-0.10938-0.61328-0.14062-0.9375-0.26172 0.27344-0.55859 0.52734-0.89062 0.76562-0.32422 0.23047-0.68359 0.4375-1.0781 0.625-0.39844 0.17969-0.82031 0.31641-1.2656 0.42188-0.44922 0.10156-0.92188 0.15625-1.4219 0.15625-0.82422 0-1.5703-0.11719-2.2344-0.34375-0.65625-0.23828-1.2148-0.5625-1.6719-0.96875-0.46094-0.40625-0.82031-0.88281-1.0781-1.4375-0.25-0.5625-0.375-1.1641-0.375-1.8125 0-0.84375 0.16406-1.582 0.5-2.2188 0.34375-0.64453 0.82031-1.1758 1.4375-1.5938 0.625-0.42578 1.3672-0.74219 2.2344-0.95312 0.875-0.20703 1.8477-0.3125 2.9219-0.3125h2.8906v-1.2188c0-0.45703-0.089844-0.875-0.26562-1.25-0.16797-0.375-0.40625-0.69141-0.71875-0.95312-0.3125-0.25781-0.69922-0.45703-1.1562-0.59375-0.44922-0.14453-0.95312-0.21875-1.5156-0.21875-0.52344 0-0.99219 0.070312-1.4062 0.20312-0.41797 0.125-0.77344 0.29688-1.0625 0.51562-0.28125 0.21875-0.5 0.48047-0.65625 0.78125-0.15625 0.30469-0.23438 0.61719-0.23438 0.9375h-2.6406c0-0.5625 0.14062-1.1133 0.42188-1.6562 0.28125-0.53906 0.6875-1.0234 1.2188-1.4531 0.53125-0.4375 1.1719-0.78516 1.9219-1.0469 0.75781-0.26953 1.6172-0.40625 2.5781-0.40625 0.875 0 1.6875 0.10938 2.4375 0.32812 0.75 0.21094 1.3945 0.53125 1.9375 0.96875 0.55078 0.42969 0.98438 0.96484 1.2969 1.6094 0.32031 0.64844 0.48438 1.4023 0.48438 2.2656v7.1875c0 0.51172 0.046875 1.0547 0.14062 1.625 0.09375 0.57422 0.22266 1.0742 0.39062 1.5v0.23438zm-4.6562-2.0156c0.50781 0 0.98828-0.0625 1.4375-0.1875 0.44531-0.13281 0.85156-0.3125 1.2188-0.53125 0.36328-0.21875 0.67578-0.46875 0.9375-0.75 0.26953-0.28125 0.48438-0.57031 0.64062-0.875v-3.125h-2.4531c-1.543 0-2.7461 0.23047-3.6094 0.6875-0.85547 0.44922-1.2812 1.1641-1.2812 2.1406 0 0.38672 0.0625 0.74219 0.1875 1.0625 0.13281 0.32422 0.32812 0.60547 0.57812 0.84375 0.25781 0.23047 0.58203 0.41406 0.96875 0.54688 0.39453 0.125 0.85156 0.1875 1.375 0.1875z"/>
-</g>
-<g transform="translate(1151.7 154.58)">
-<path d="m4.8438-15.438 0.1875 2.2812c0.5625-0.80078 1.25-1.4258 2.0625-1.875 0.82031-0.44531 1.7383-0.67578 2.75-0.6875 0.8125 0 1.5469 0.11719 2.2031 0.34375 0.66406 0.23047 1.2266 0.58984 1.6875 1.0781 0.46875 0.48047 0.82812 1.0938 1.0781 1.8438 0.25 0.74219 0.375 1.625 0.375 2.6562v9.7969h-2.625v-9.75c0-0.67578-0.078125-1.2539-0.23438-1.7344-0.15625-0.47656-0.38672-0.86328-0.6875-1.1562-0.29297-0.28906-0.65625-0.50391-1.0938-0.64062-0.42969-0.13281-0.92188-0.20312-1.4844-0.20312-0.88672 0-1.668 0.22656-2.3438 0.67188-0.66797 0.4375-1.1992 1.0156-1.5938 1.7344v11.078h-2.6406v-15.438z"/>
-</g>
-<g transform="translate(1169.3 154.58)">
-<path d="m9.0625-1.8594c0.46875 0 0.92578-0.070313 1.375-0.21875 0.45703-0.15625 0.86328-0.36719 1.2188-0.64062 0.35156-0.26953 0.63281-0.58594 0.84375-0.95312 0.21875-0.36328 0.33203-0.75781 0.34375-1.1875h2.5c-0.011719 0.67969-0.19531 1.3281-0.54688 1.9531-0.34375 0.625-0.80859 1.1719-1.3906 1.6406-0.57422 0.46875-1.2422 0.84375-2 1.125-0.75 0.28125-1.5312 0.42188-2.3438 0.42188-1.168 0-2.1953-0.21094-3.0781-0.625-0.875-0.41406-1.6055-0.97656-2.1875-1.6875-0.58594-0.70703-1.0234-1.5234-1.3125-2.4531-0.29297-0.92578-0.4375-1.9062-0.4375-2.9375v-0.59375c0-1.0195 0.14453-1.9922 0.4375-2.9219 0.28906-0.9375 0.72656-1.7578 1.3125-2.4688 0.58203-0.70703 1.3125-1.2695 2.1875-1.6875 0.88281-0.41406 1.9102-0.625 3.0781-0.625 0.90625 0 1.7383 0.14844 2.5 0.4375 0.76953 0.28125 1.4297 0.67188 1.9844 1.1719 0.5625 0.5 1 1.0938 1.3125 1.7812 0.32031 0.6875 0.48438 1.4219 0.48438 2.2031h-2.5c-0.011719-0.46875-0.11719-0.90625-0.3125-1.3125-0.19922-0.41406-0.46484-0.78125-0.79688-1.0938-0.32422-0.32031-0.71875-0.57031-1.1875-0.75-0.46094-0.17578-0.95312-0.26562-1.4844-0.26562-0.82422 0-1.5156 0.16797-2.0781 0.5-0.55469 0.32422-1 0.75-1.3438 1.2812-0.33594 0.52344-0.57812 1.1094-0.73438 1.7656-0.14844 0.65625-0.21875 1.3203-0.21875 1.9844v0.59375c0 0.67969 0.070312 1.3516 0.21875 2.0156 0.15625 0.65625 0.39844 1.25 0.73438 1.7812 0.34375 0.52344 0.78906 0.94922 1.3438 1.2812 0.55078 0.32422 1.2422 0.48438 2.0781 0.48438z"/>
-</g>
-<g transform="translate(1186.8 154.58)">
-<path d="m9.2969 0.28125c-1.0859 0-2.0781-0.18359-2.9844-0.54688-0.90625-0.375-1.6836-0.89453-2.3281-1.5625-0.64844-0.66406-1.1523-1.4531-1.5156-2.3594-0.36719-0.91406-0.54688-1.9102-0.54688-2.9844v-0.60938c0-1.2383 0.19531-2.3477 0.59375-3.3281 0.40625-0.98828 0.9375-1.8203 1.5938-2.5 0.66406-0.6875 1.4219-1.207 2.2656-1.5625 0.84375-0.36328 1.7031-0.54688 2.5781-0.54688 1.1133 0 2.0859 0.19531 2.9219 0.57812 0.83203 0.38672 1.5234 0.91797 2.0781 1.5938 0.55078 0.67969 0.96094 1.4805 1.2344 2.4062 0.26953 0.91797 0.40625 1.918 0.40625 3v1.1719h-11.031c0.03125 0.71094 0.16406 1.375 0.40625 2 0.23828 0.61719 0.57031 1.1523 1 1.6094 0.42578 0.46094 0.92969 0.82422 1.5156 1.0938 0.59375 0.26172 1.2422 0.39062 1.9531 0.39062 0.94531 0 1.7852-0.1875 2.5156-0.5625 0.72656-0.38281 1.3359-0.89062 1.8281-1.5156l1.6094 1.25c-0.25 0.39844-0.57031 0.77344-0.95312 1.125-0.38672 0.35547-0.83594 0.67188-1.3438 0.95312-0.5 0.27344-1.0742 0.49219-1.7188 0.65625-0.63672 0.16406-1.3281 0.25-2.0781 0.25zm-0.34375-13.828c-0.53125 0-1.0391 0.10156-1.5156 0.29688-0.46875 0.1875-0.89844 0.46875-1.2812 0.84375-0.375 0.375-0.69531 0.83984-0.95312 1.3906-0.26172 0.54297-0.44531 1.1719-0.54688 1.8906h8.2969v-0.20312c-0.03125-0.50781-0.13281-1.0156-0.29688-1.5156-0.16797-0.50781-0.41406-0.96094-0.73438-1.3594-0.32422-0.40625-0.73047-0.72656-1.2188-0.96875-0.49219-0.25-1.0742-0.375-1.75-0.375z"/>
-</g>
-<g transform="translate(1274.3 154.58)">
-<path d="m13.906-9.6094h-8.6719v7.375h10.109v2.2344h-12.75v-20.766h12.625v2.25h-9.9844v6.6719h8.6719z"/>
-</g>
-<g transform="translate(1291.8 154.58)">
-<path d="m4.8438-15.438 0.1875 2.2812c0.5625-0.80078 1.25-1.4258 2.0625-1.875 0.82031-0.44531 1.7383-0.67578 2.75-0.6875 0.8125 0 1.5469 0.11719 2.2031 0.34375 0.66406 0.23047 1.2266 0.58984 1.6875 1.0781 0.46875 0.48047 0.82812 1.0938 1.0781 1.8438 0.25 0.74219 0.375 1.625 0.375 2.6562v9.7969h-2.625v-9.75c0-0.67578-0.078125-1.2539-0.23438-1.7344-0.15625-0.47656-0.38672-0.86328-0.6875-1.1562-0.29297-0.28906-0.65625-0.50391-1.0938-0.64062-0.42969-0.13281-0.92188-0.20312-1.4844-0.20312-0.88672 0-1.668 0.22656-2.3438 0.67188-0.66797 0.4375-1.1992 1.0156-1.5938 1.7344v11.078h-2.6406v-15.438z"/>
-</g>
-<g transform="translate(1309.3 154.58)">
-<path d="m9.2969 0.28125c-1.0859 0-2.0781-0.18359-2.9844-0.54688-0.90625-0.375-1.6836-0.89453-2.3281-1.5625-0.64844-0.66406-1.1523-1.4531-1.5156-2.3594-0.36719-0.91406-0.54688-1.9102-0.54688-2.9844v-0.60938c0-1.2383 0.19531-2.3477 0.59375-3.3281 0.40625-0.98828 0.9375-1.8203 1.5938-2.5 0.66406-0.6875 1.4219-1.207 2.2656-1.5625 0.84375-0.36328 1.7031-0.54688 2.5781-0.54688 1.1133 0 2.0859 0.19531 2.9219 0.57812 0.83203 0.38672 1.5234 0.91797 2.0781 1.5938 0.55078 0.67969 0.96094 1.4805 1.2344 2.4062 0.26953 0.91797 0.40625 1.918 0.40625 3v1.1719h-11.031c0.03125 0.71094 0.16406 1.375 0.40625 2 0.23828 0.61719 0.57031 1.1523 1 1.6094 0.42578 0.46094 0.92969 0.82422 1.5156 1.0938 0.59375 0.26172 1.2422 0.39062 1.9531 0.39062 0.94531 0 1.7852-0.1875 2.5156-0.5625 0.72656-0.38281 1.3359-0.89062 1.8281-1.5156l1.6094 1.25c-0.25 0.39844-0.57031 0.77344-0.95312 1.125-0.38672 0.35547-0.83594 0.67188-1.3438 0.95312-0.5 0.27344-1.0742 0.49219-1.7188 0.65625-0.63672 0.16406-1.3281 0.25-2.0781 0.25zm-0.34375-13.828c-0.53125 0-1.0391 0.10156-1.5156 0.29688-0.46875 0.1875-0.89844 0.46875-1.2812 0.84375-0.375 0.375-0.69531 0.83984-0.95312 1.3906-0.26172 0.54297-0.44531 1.1719-0.54688 1.8906h8.2969v-0.20312c-0.03125-0.50781-0.13281-1.0156-0.29688-1.5156-0.16797-0.50781-0.41406-0.96094-0.73438-1.3594-0.32422-0.40625-0.73047-0.72656-1.2188-0.96875-0.49219-0.25-1.0742-0.375-1.75-0.375z"/>
-</g>
-<g transform="translate(1326.9 154.58)">
-<path d="m12.594-15.719c0.25 0 0.50391 0.011719 0.76562 0.03125 0.26953 0.011719 0.52344 0.03125 0.76562 0.0625 0.25 0.03125 0.47266 0.074219 0.67188 0.125 0.20703 0.042969 0.37891 0.09375 0.51562 0.15625l-0.35938 2.5781c-0.51172-0.11328-1-0.19531-1.4688-0.25-0.46094-0.050781-0.9375-0.078125-1.4375-0.078125-1.2422 0-2.2461 0.28125-3.0156 0.84375-0.76172 0.5625-1.3242 1.3438-1.6875 2.3438v9.9062h-2.6562v-15.438h2.5156l0.125 2.4531c0.63281-0.84375 1.3906-1.5078 2.2656-2 0.88281-0.48828 1.8828-0.73438 3-0.73438z"/>
-</g>
-<g transform="translate(1344.4 154.58)">
-<path d="m2-7.8438c0-1.1562 0.14062-2.2109 0.42188-3.1719 0.28125-0.96875 0.6875-1.7969 1.2188-2.4844 0.53125-0.69531 1.1758-1.2383 1.9375-1.625 0.75781-0.39453 1.6172-0.59375 2.5781-0.59375 0.95703 0 1.7891 0.17188 2.5 0.51562 0.71875 0.33594 1.332 0.82031 1.8438 1.4531l0.125-1.6875h2.3906v15.109c0 1.0195-0.16406 1.9219-0.48438 2.7031-0.3125 0.78906-0.75781 1.4609-1.3281 2.0156-0.57422 0.55078-1.2617 0.96875-2.0625 1.25-0.80469 0.28906-1.6875 0.4375-2.6562 0.4375-0.39844 0-0.85547-0.046875-1.375-0.14062-0.51172-0.085938-1.0312-0.23047-1.5625-0.4375-0.52344-0.21094-1.0273-0.48438-1.5156-0.82812-0.49219-0.33594-0.91406-0.75781-1.2656-1.2656l1.375-1.5781c0.32031 0.38281 0.65625 0.71094 1 0.98438 0.34375 0.26953 0.6875 0.48438 1.0312 0.64062 0.35156 0.16406 0.70703 0.28516 1.0625 0.35938 0.35156 0.070312 0.70703 0.10938 1.0625 0.10938 0.625 0 1.1875-0.09375 1.6875-0.28125 0.50781-0.17969 0.94141-0.4375 1.2969-0.78125 0.35156-0.34375 0.625-0.77734 0.8125-1.2969 0.19531-0.51172 0.29688-1.1016 0.29688-1.7656v-1.3281c-0.52344 0.59375-1.1328 1.0469-1.8281 1.3594-0.69922 0.30078-1.5117 0.45312-2.4375 0.45312-0.9375 0-1.7891-0.19922-2.5469-0.59375-0.76172-0.39453-1.4062-0.94531-1.9375-1.6562-0.52344-0.70703-0.92969-1.5352-1.2188-2.4844-0.28125-0.95703-0.42188-1.9883-0.42188-3.0938zm2.6406 0.29688c0 0.75 0.078125 1.4648 0.23438 2.1406 0.15625 0.67969 0.39844 1.2734 0.73438 1.7812 0.34375 0.51172 0.77344 0.91797 1.2969 1.2188 0.51953 0.30469 1.1445 0.45312 1.875 0.45312 0.45703 0 0.86719-0.050781 1.2344-0.15625 0.375-0.11328 0.70312-0.26953 0.98438-0.46875 0.28906-0.19531 0.55078-0.42969 0.78125-0.70312 0.22656-0.28125 0.42969-0.58594 0.60938-0.92188v-7.0781c-0.17969-0.32031-0.38281-0.61328-0.60938-0.875-0.23047-0.26953-0.49219-0.50391-0.78125-0.70312-0.29297-0.19531-0.62109-0.34766-0.98438-0.45312-0.36719-0.11328-0.76562-0.17188-1.2031-0.17188-0.74219 0-1.375 0.15625-1.9062 0.46875-0.52344 0.30469-0.95312 0.71484-1.2969 1.2344-0.33594 0.51172-0.57812 1.1094-0.73438 1.7969-0.15625 0.67969-0.23438 1.3906-0.23438 2.1406z"/>
-</g>
-<g transform="translate(1361.9 154.58)">
-<path d="m8.1562-5.4844 0.6875 1.875 4.7031-11.828h2.9531l-7.8281 17.812c-0.17969 0.40625-0.40625 0.83203-0.6875 1.2812-0.28125 0.44531-0.625 0.85938-1.0312 1.2344-0.39844 0.38281-0.85938 0.70312-1.3906 0.95312-0.53125 0.25781-1.1484 0.39062-1.8438 0.39062-0.125 0-0.26562-0.011719-0.42188-0.03125-0.14844-0.011719-0.29688-0.027344-0.45312-0.046875-0.14844-0.023438-0.28906-0.046875-0.42188-0.078125-0.13672-0.03125-0.24609-0.058594-0.32812-0.078125l0.4375-2.1406h0.26562c0.11328 0.007813 0.23438 0.019531 0.35938 0.03125 0.125 0.007813 0.24219 0.015625 0.35938 0.015625 0.11328 0.007812 0.20312 0.015625 0.26562 0.015625 0.36328 0 0.69141-0.10156 0.98438-0.29688 0.30078-0.19922 0.56641-0.4375 0.79688-0.71875 0.23828-0.27344 0.44141-0.55859 0.60938-0.85938 0.16406-0.29297 0.29688-0.53125 0.39062-0.71875l1.0625-2.0625-6.6562-14.703h2.9531z"/>
-</g>
-<g transform="translate(1312.1 205.5)">
-<path d="m9.2969 0.28125c-1.0859 0-2.0781-0.18359-2.9844-0.54688-0.90625-0.375-1.6836-0.89453-2.3281-1.5625-0.64844-0.66406-1.1523-1.4531-1.5156-2.3594-0.36719-0.91406-0.54688-1.9102-0.54688-2.9844v-0.60938c0-1.2383 0.19531-2.3477 0.59375-3.3281 0.40625-0.98828 0.9375-1.8203 1.5938-2.5 0.66406-0.6875 1.4219-1.207 2.2656-1.5625 0.84375-0.36328 1.7031-0.54688 2.5781-0.54688 1.1133 0 2.0859 0.19531 2.9219 0.57812 0.83203 0.38672 1.5234 0.91797 2.0781 1.5938 0.55078 0.67969 0.96094 1.4805 1.2344 2.4062 0.26953 0.91797 0.40625 1.918 0.40625 3v1.1719h-11.031c0.03125 0.71094 0.16406 1.375 0.40625 2 0.23828 0.61719 0.57031 1.1523 1 1.6094 0.42578 0.46094 0.92969 0.82422 1.5156 1.0938 0.59375 0.26172 1.2422 0.39062 1.9531 0.39062 0.94531 0 1.7852-0.1875 2.5156-0.5625 0.72656-0.38281 1.3359-0.89062 1.8281-1.5156l1.6094 1.25c-0.25 0.39844-0.57031 0.77344-0.95312 1.125-0.38672 0.35547-0.83594 0.67188-1.3438 0.95312-0.5 0.27344-1.0742 0.49219-1.7188 0.65625-0.63672 0.16406-1.3281 0.25-2.0781 0.25zm-0.34375-13.828c-0.53125 0-1.0391 0.10156-1.5156 0.29688-0.46875 0.1875-0.89844 0.46875-1.2812 0.84375-0.375 0.375-0.69531 0.83984-0.95312 1.3906-0.26172 0.54297-0.44531 1.1719-0.54688 1.8906h8.2969v-0.20312c-0.03125-0.50781-0.13281-1.0156-0.29688-1.5156-0.16797-0.50781-0.41406-0.96094-0.73438-1.3594-0.32422-0.40625-0.73047-0.72656-1.2188-0.96875-0.49219-0.25-1.0742-0.375-1.75-0.375z"/>
-</g>
-<g transform="translate(1329.6 205.5)">
-<path d="m8.7344-19.172v3.7344h5.875v2.0469h-5.875v8.3906c0 0.59375 0.070313 1.0898 0.21875 1.4844 0.15625 0.38672 0.36328 0.69922 0.625 0.9375 0.26953 0.23047 0.57812 0.39062 0.92188 0.48438 0.35156 0.09375 0.72266 0.14062 1.1094 0.14062 0.28906 0 0.58594-0.015625 0.89062-0.046875 0.30078-0.03125 0.59766-0.070312 0.89062-0.125 0.28906-0.050781 0.5625-0.10156 0.8125-0.15625 0.25-0.050781 0.45703-0.09375 0.625-0.125l0.35938 1.8594c-0.21875 0.13672-0.48438 0.25781-0.79688 0.35938-0.3125 0.09375-0.65625 0.17969-1.0312 0.25-0.36719 0.070312-0.75781 0.125-1.1719 0.15625-0.40625 0.039062-0.82031 0.0625-1.2344 0.0625-0.67969 0-1.3203-0.09375-1.9219-0.28125-0.59375-0.19531-1.1094-0.50391-1.5469-0.92188-0.4375-0.42578-0.78125-0.97266-1.0312-1.6406-0.25-0.67578-0.375-1.4883-0.375-2.4375v-8.3906h-4.0469v-2.0469h4.0469v-3.7344z"/>
-</g>
-<g transform="translate(1347.2 205.5)">
-<path d="m9.0625-1.8594c0.46875 0 0.92578-0.070313 1.375-0.21875 0.45703-0.15625 0.86328-0.36719 1.2188-0.64062 0.35156-0.26953 0.63281-0.58594 0.84375-0.95312 0.21875-0.36328 0.33203-0.75781 0.34375-1.1875h2.5c-0.011719 0.67969-0.19531 1.3281-0.54688 1.9531-0.34375 0.625-0.80859 1.1719-1.3906 1.6406-0.57422 0.46875-1.2422 0.84375-2 1.125-0.75 0.28125-1.5312 0.42188-2.3438 0.42188-1.168 0-2.1953-0.21094-3.0781-0.625-0.875-0.41406-1.6055-0.97656-2.1875-1.6875-0.58594-0.70703-1.0234-1.5234-1.3125-2.4531-0.29297-0.92578-0.4375-1.9062-0.4375-2.9375v-0.59375c0-1.0195 0.14453-1.9922 0.4375-2.9219 0.28906-0.9375 0.72656-1.7578 1.3125-2.4688 0.58203-0.70703 1.3125-1.2695 2.1875-1.6875 0.88281-0.41406 1.9102-0.625 3.0781-0.625 0.90625 0 1.7383 0.14844 2.5 0.4375 0.76953 0.28125 1.4297 0.67188 1.9844 1.1719 0.5625 0.5 1 1.0938 1.3125 1.7812 0.32031 0.6875 0.48438 1.4219 0.48438 2.2031h-2.5c-0.011719-0.46875-0.11719-0.90625-0.3125-1.3125-0.19922-0.41406-0.46484-0.78125-0.79688-1.0938-0.32422-0.32031-0.71875-0.57031-1.1875-0.75-0.46094-0.17578-0.95312-0.26562-1.4844-0.26562-0.82422 0-1.5156 0.16797-2.0781 0.5-0.55469 0.32422-1 0.75-1.3438 1.2812-0.33594 0.52344-0.57812 1.1094-0.73438 1.7656-0.14844 0.65625-0.21875 1.3203-0.21875 1.9844v0.59375c0 0.67969 0.070312 1.3516 0.21875 2.0156 0.15625 0.65625 0.39844 1.25 0.73438 1.7812 0.34375 0.52344 0.78906 0.94922 1.3438 1.2812 0.55078 0.32422 1.2422 0.48438 2.0781 0.48438z"/>
-</g>
-<g transform="translate(1364.7 205.5)">
-<path d="m7.0781-1.7188c0-0.28125 0.039063-0.53906 0.125-0.78125 0.09375-0.25 0.22266-0.46875 0.39062-0.65625 0.17578-0.1875 0.39062-0.33203 0.64062-0.4375 0.25781-0.10156 0.5625-0.15625 0.90625-0.15625s0.64453 0.054688 0.90625 0.15625c0.25781 0.10547 0.47656 0.25 0.65625 0.4375 0.17578 0.1875 0.3125 0.40625 0.40625 0.65625 0.09375 0.24219 0.14062 0.5 0.14062 0.78125s-0.046875 0.54297-0.14062 0.78125c-0.09375 0.24219-0.23047 0.45312-0.40625 0.64062-0.17969 0.17969-0.39844 0.3125-0.65625 0.40625-0.26172 0.10156-0.5625 0.15625-0.90625 0.15625s-0.64844-0.054687-0.90625-0.15625c-0.25-0.09375-0.46484-0.22656-0.64062-0.40625-0.16797-0.1875-0.29688-0.39844-0.39062-0.64062-0.085937-0.23828-0.125-0.5-0.125-0.78125z"/>
-</g>
-</g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 28.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 1920.1 1829.6"
+   style="enable-background:new 0 0 1920.1 1829.6;"
+   xml:space="preserve"
+   sodipodi:docname="marchitecture.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs1824" /><sodipodi:namedview
+   id="namedview1822"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="false"
+   inkscape:zoom="0.47715348"
+   inkscape:cx="1681.8488"
+   inkscape:cy="830.96952"
+   inkscape:window-width="1850"
+   inkscape:window-height="1016"
+   inkscape:window-x="0"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<style
+   type="text/css"
+   id="style2">
+	.st0{fill:#BFBFBF;}
+	.st1{fill:#7D9199;}
+	.st2{fill:#566366;}
+	.st3{fill:#FFFFFF;}
+	.st4{fill:#3D516E;}
+	.st5{fill:#FFFFFF;stroke:#1E2837;stroke-width:2.5;stroke-miterlimit:10;}
+	.st6{fill:#3D516E;stroke:#1E2837;stroke-width:2.5;stroke-miterlimit:10;}
+	.st7{fill:#192131;stroke:#1E2837;stroke-width:2.5;stroke-miterlimit:10;}
+	.st8{fill:#1E2837;}
+	.st9{fill:none;}
+	.st10{fill:#1904D1;}
+	.st11{fill:#08A8CC;}
+	.st12{fill:#FFC000;}
+	.st13{fill:#FF445F;}
+	.st14{clip-path:url(#SVGID_00000130624350506670490850000017160803374787275157_);}
+	.st15{fill:url(#SVGID_00000091717655616569527520000002486848384549953468_);}
+	.st16{fill:url(#SVGID_00000109713466382614415240000006933141471293271994_);}
+	.st17{fill:#ECFF80;}
+	.st18{fill:none;stroke:#1E2837;stroke-width:9.5;stroke-miterlimit:10;}
+	.st19{fill:#449FD8;}
+	.st20{fill:#F04D5C;}
+	.st21{fill:#005EB8;}
+	.st22{fill:#003B5C;}
+	.st23{fill:#E2F5FC;}
+	.st24{fill:#CDECF6;}
+	.st25{fill:#B5D2F3;}
+	.st26{fill:#FE733E;}
+	.st27{fill:#FE6446;}
+	.st28{opacity:0.3;fill:#FE6446;enable-background:new    ;}
+	.st29{opacity:0.5;fill:#FEA777;enable-background:new    ;}
+	.st30{fill:#FE6B3C;}
+	.st31{fill:#070909;}
+	.st32{fill:#090B0B;}
+	.st33{fill:#70CAF2;}
+	.st34{fill:#B4E3F9;}
+	.st35{fill:#3F79AD;}
+	.st36{fill:#6D41FF;}
+	.st37{fill:#221F1F;}
+	.st38{fill:#67CFE3;}
+	.st39{fill:#DFCAA3;}
+	.st40{fill:#648C1A;}
+	.st41{clip-path:url(#SVGID_00000107567823597211816750000012015247447072993211_);}
+	.st42{fill:url(#path46_00000083083334355360634570000017459131939516265125_);}
+	.st43{clip-path:url(#SVGID_00000103228263483173218040000006025288990685110444_);}
+	.st44{fill:url(#path64_00000041260091989746487190000016052828091217848983_);}
+	.st45{clip-path:url(#SVGID_00000154387568337359472580000018262270707292995486_);}
+	.st46{fill:url(#path82_00000165932265094261303020000009039157838686694323_);}
+	.st47{clip-path:url(#SVGID_00000145754695143958457990000017872607747562094773_);}
+	.st48{fill:url(#path100_00000170959815068468309030000018007278693454462355_);}
+	.st49{clip-path:url(#SVGID_00000113337754716495614820000001024927496503917696_);}
+	.st50{fill:url(#path118_00000109000653828078515080000016203103768436590249_);}
+	.st51{fill:#696566;}
+	.st52{clip-path:url(#SVGID_00000137133898225204334290000005396136007570524337_);}
+	.st53{fill:url(#path142_00000167359118750622073700000011930371520236878472_);}
+	.st54{clip-path:url(#SVGID_00000147903176429251113720000011097529573822592668_);}
+	.st55{fill:url(#path160_00000150091039984730823410000015993319374399792795_);}
+	.st56{clip-path:url(#SVGID_00000055688461289007648690000001633402396649770645_);}
+	.st57{fill:url(#path178_00000170990930426358819420000013296330665021099195_);}
+	.st58{fill:url(#SVGID_00000029023372980381325130000017242520154034119825_);}
+	.st59{fill:url(#SVGID_00000146466735994187611010000017120180104836953781_);}
+	.st60{fill:url(#SVGID_00000129177283352100491880000006108402646586235289_);}
+	.st61{fill:url(#SVGID_00000147900385226215294360000004881794617679617671_);}
+	.st62{fill:url(#SVGID_00000131349711770467803770000004864098058785654181_);}
+	.st63{fill:url(#SVGID_00000005229694565821285540000016081363572032850824_);}
+	.st64{fill:url(#SVGID_00000119118595447895158860000008713473905698787002_);}
+	.st65{fill:url(#SVGID_00000107578674082593822570000015279308826817436305_);}
+	.st66{fill:#00B4C8;}
+	.st67{fill:#326CE5;}
+	.st68{clip-path:url(#SVGID_00000111875801069681346530000005543307288849640117_);}
+	.st69{fill:#E75225;}
+	.st70{stroke:#000000;stroke-width:13.28;}
+	.st71{fill:#336791;}
+	.st72{fill:none;stroke:#FFFFFF;stroke-width:4.43;stroke-linecap:round;stroke-linejoin:round;}
+	.st73{fill:none;stroke:#FFFFFF;stroke-width:4.43;stroke-linecap:round;stroke-linejoin:bevel;}
+	.st74{fill:#FFFFFF;stroke:#FFFFFF;stroke-width:1.48;}
+	.st75{fill:#FFFFFF;stroke:#FFFFFF;stroke-width:0.74;}
+	.st76{fill:url(#SVGID_00000118363700809363192510000009917811205386737026_);}
+	.st77{fill:url(#SVGID_00000109752484426236977110000014097232270572010379_);}
+	.st78{fill:#231F20;}
+	.st79{fill:#173F74;}
+	.st80{fill:#00214C;}
+	.st81{fill:#754C29;}
+	.st82{fill:#603913;}
+	.st83{fill:#F7941D;}
+	.st84{fill:#F47729;}
+	.st85{fill:#3C2415;}
+	.st86{fill:#603D19;}
+	.st87{fill:#573819;}
+	.st88{fill:#533414;}
+	.st89{fill:#E6E7E8;}
+	.st90{fill:#A7A9AC;}
+	.st91{fill:#EF4136;}
+	.st92{fill:#FBB040;}
+	.st93{fill:#239DE0;}
+	.st94{fill:#FDFDFE;}
+	.st95{font-family:'Poppins-SemiBold';}
+	.st96{font-size:36px;}
+	.st97{font-size:34px;}
+	.st98{fill:#303B54;}
+	.st99{font-family:'RobotoMono-Bold';}
+</style>
+<symbol
+   id="A"
+   viewBox="-28.8 -32 57.7 64">
+	<g
+   id="g16">
+		<path
+   class="st0"
+   d="M-17.2,32c0,0-3.6-12-3.3-15.6c0.2-2.5,4.8-5.8,4.8-5.8s-2.5-3-3.5-4.7s-2.6-5.7-2.6-5.7s-7.6,9-7,13.4    C-28,18.9-17.2,32-17.2,32z M17.3,32c0,0,3.6-12,3.3-15.6c-0.2-2.5-4.8-5.8-4.8-5.8s2.5-3,3.5-4.7s2.5-5.7,2.5-5.7s7.6,9,7,13.4    C28.2,18.9,17.3,32,17.3,32L17.3,32z"
+   id="path4" />
+		<path
+   class="st1"
+   d="M0.2,17.9c-10.1,0-19.1-7.2-22-17.7L0.2-7V17.9z"
+   id="path6" />
+		<path
+   class="st2"
+   d="M0.2,18c10.1,0,19.1-7.2,22-17.7L0.2-7V18L0.2,18z"
+   id="path8" />
+		<path
+   class="st1"
+   d="M0.2,0.3h-22v-15.4c0,0,8.9-3.5,12.6-6.3c3-2.3,8.9-10.6,8.9-10.6h0.6L0.2,0.3L0.2,0.3z"
+   id="path10" />
+		<path
+   class="st2"
+   d="M0.2,0.5h22v-15.4c0,0-8.9-3.5-12.6-6.3C6.5-23.6,0.7-32,0.7-32H0.2V0.5z"
+   id="path12" />
+		<path
+   class="st3"
+   d="M-2.6,1c0,1.5,1.2,2.8,2.8,2.8S2.9,2.5,2.9,1S1.7-1.8,0.2-1.8S-2.6-0.5-2.6,1z"
+   id="path14" />
+	</g>
+</symbol>
+<g
+   id="Lager_1-2_00000111180535557823632960000013643181150438161549_">
+	<path
+   class="st4"
+   d="M1610.5,1702.8c-2.1-0.4-4.2-0.6-6.3-0.6c-17.6,0-36.9,12.7-48.1,41.3c0.9-1.4,1.9-2.7,2.8-4   c7.7-9.8,17.7-15.2,28.1-15.2c1.6,0,3.2,0.1,4.7,0.4c10.3,1.7,17.9,7.1,21,14.8c3.1,7.8,1,17-5.8,25.9c-2.2,2.9-5.2,5.5-9,8.1   c13-5,25.2-11.6,31.7-20.2C1648.2,1729,1636.4,1707.4,1610.5,1702.8z"
+   id="path19" />
+	<path
+   class="st4"
+   d="M1603.8,1763.3c12.9-16.9,5-31.6-12.8-34.6c-1.3-0.2-2.7-0.3-4.1-0.3c-11.4,0-23.9,7.8-32,25.2   c0.2-0.3,0.4-0.5,0.6-0.8c5.9-7.2,13.3-11.1,20.9-11.1c0.9,0,1.8,0.1,2.7,0.2c7.3,1,12.8,4.7,15,10.1c1.4,3.4,2.6,10.4-4.5,19.6   c-1.2,1.6-2.8,3.1-4.8,4.6C1592.7,1772.8,1599.8,1768.5,1603.8,1763.3L1603.8,1763.3z"
+   id="path21" />
+	<path
+   class="st4"
+   d="M1586.7,1769.1c9.3-11.9,4.2-21.9-8-23.5c-0.7-0.1-1.5-0.1-2.2-0.1c-11.8,0-26.1,12.3-29.5,40.9   C1547,1786.3,1577.4,1781,1586.7,1769.1z"
+   id="path23" />
+	<path
+   class="st4"
+   d="M1660.1,1753.6c0.4-2.8,2.5-4.1,5.6-4.1c2.1,0,3.8,0.8,3.8,2.5s-0.6,2.6-2.7,3.4l-7.3,2.5L1660.1,1753.6   L1660.1,1753.6L1660.1,1753.6z M1658.5,1766v-0.8l8.9-3c6-2.1,9.3-4.5,9.3-10.7c0-5-3.9-8.5-10.3-8.5c-7.8,0-12.9,4.3-13.8,10.1   l-1.5,11.1c-0.1,0.9-0.2,1.8-0.2,2.6c0,5.2,3.4,8.5,10.9,8.5h10.2l1-6.6c0,0-6.1,0-10.2,0C1659.9,1768.8,1658.5,1767.8,1658.5,1766   L1658.5,1766L1658.5,1766z M1693.7,1731h-12.3l-1,6.6h4.7l-4.3,31.2h-5.4l-1,6.6h18.4l1-6.6h-5.4L1693.7,1731L1693.7,1731z    M1787.4,1730.1h-7.6l-1.2,8.3h7.6L1787.4,1730.1L1787.4,1730.1z M1785.6,1743h-12.4l-1,6.6h4.7l-2.7,19.1h-5.4l-1,6.6h18.4l1-6.6   h-5.4L1785.6,1743L1785.6,1743z M1804.9,1743L1804.9,1743c-7.3,0-13.2,3.3-13.2,9.7c0,9.4,12.9,8.2,12.9,13c0,2.7-2.7,3-5,3   c-5,0-9.7,0-9.7,0l-0.9,6.6c0,0,4.5,0,10,0c8.5,0,13.6-4.3,13.6-10.6c0-9.6-12.9-8.8-12.9-12.9c0-1.4,1.5-2.3,4.7-2.3   c3.6,0,8.7,0,8.7,0l0.9-6.5L1804.9,1743L1804.9,1743z M1737.8,1743L1737.8,1743c-7.3,0-13.2,3.3-13.2,9.7c0,9.4,12.9,8.2,12.9,13   c0,2.7-2.7,3-5,3c-5,0-9.7,0-9.7,0l-1,6.6c0,0,4.5,0,10,0c8.5,0,13.6-4.3,13.6-10.6c0-9.6-12.9-8.8-12.9-12.9   c0-1.4,1.5-2.3,4.7-2.3c3.6,0,8.7,0,8.7,0l0.9-6.5C1746.7,1743,1742.8,1743,1737.8,1743L1737.8,1743L1737.8,1743z M1857.2,1743   L1857.2,1743c-7.3,0-13.2,3.3-13.2,9.7c0,9.4,12.9,8.2,12.9,13c0,2.7-2.7,3-5,3c-5,0-9.7,0-9.7,0l-1,6.6c0,0,4.5,0,10,0   c8.5,0,13.6-4.3,13.6-10.6c0-9.6-12.9-8.8-12.9-12.9c0-1.4,1.5-2.3,4.7-2.3c3.6,0,8.7,0,8.7,0l0.9-6.5L1857.2,1743L1857.2,1743z    M1837.3,1743l-9.8,20.4l-4-20.4h-8.1l6.9,30.4l-6.8,13.5h7.7l22.2-43.9H1837.3L1837.3,1743L1837.3,1743z M1713.9,1754.3l-1.5,10.9   c-0.3,2.2-2.7,3.6-5.3,3.6c-2.4,0-4.1-1.2-4.1-3.2c0-0.8,0.1-1.7,0.3-2.6l1.5-9.8c0.4-2.5,2.7-3.7,5.2-3.7c2.3,0,4.1,1.2,4.1,3.2   C1714.1,1753.3,1714,1753.7,1713.9,1754.3L1713.9,1754.3L1713.9,1754.3z M1716.3,1743l-0.6,2.5c0,0-2.2-2.5-6.5-2.5   c-6.3,0-11.1,4.4-11.9,10.5l-1.6,11.4c-0.1,0.6-0.1,1.2-0.1,1.7c0,5.4,3.7,8.7,9.2,8.7c4.7,0,7.2-2.6,7.2-2.6l-0.1,2.6h6.9   l4.6-32.3L1716.3,1743L1716.3,1743z M1759,1767c0-0.5,0.1-1.5,0.2-1.9l2.2-15.5h6.1l1-6.5h-6l1-7h-7.6l-1,7h-5.9l-1,6.5h5.9   l-2.3,16.2c-0.1,1-0.3,2.1-0.3,2.7c0,4.7,2.7,6.9,9.3,6.9c4.9,0,5.2,0,5.2,0l0.9-6.6h-3.9C1759.7,1768.7,1759,1768.2,1759,1767   L1759,1767z"
+   id="path25" />
+</g>
+<path
+   class="st5"
+   d="M1890.8,1637.6h-443.9c-10.7,0-19.4-8.7-19.4-19.4v-269.4c0-10.7,8.7-19.4,19.4-19.4h443.9  c10.7,0,19.4,8.7,19.4,19.4v269.4C1910.2,1628.9,1901.5,1637.6,1890.8,1637.6z"
+   id="path28" />
+<path
+   class="st6"
+   d="M1586.9,1637.6h-139c-11.1,0-20.1-9-20.1-20.1v-268c0-11.1,9-20.1,20.1-20.1h139c11.1,0,20.1,9,20.1,20.1v268  C1607,1628.6,1598,1637.6,1586.9,1637.6z"
+   id="path30" />
+<path
+   class="st5"
+   d="M1890.8,1305.7H854.1c-10.7,0-19.4-8.7-19.4-19.4V1017c0-10.7,8.7-19.4,19.4-19.4h1036.7  c10.7,0,19.4,8.7,19.4,19.4v269.4C1910.2,1297.1,1901.5,1305.7,1890.8,1305.7z"
+   id="path32" />
+<path
+   class="st7"
+   d="M993.9,1305.8h-139c-11.1,0-20.1-9-20.1-20.1v-268c0-11.1,9-20.1,20.1-20.1h139c11.1,0,20.1,9,20.1,20.1v268  C1014,1296.9,1005,1305.8,993.9,1305.8z"
+   id="path34" />
+<path
+   class="st5"
+   d="M1890.5,973.1H853.8c-10.7,0-19.4-8.7-19.4-19.4V684.4c0-10.7,8.7-19.4,19.4-19.4h1036.7  c10.7,0,19.4,8.7,19.4,19.4v269.4C1909.9,964.5,1901.3,973.1,1890.5,973.1z"
+   id="path36" />
+<path
+   class="st7"
+   d="M994.1,973.1h-139c-11.1,0-20.1-9-20.1-20.1V685c0-11.1,9-20.1,20.1-20.1h139c11.1,0,20.1,9,20.1,20.1v268  C1014.2,964.2,1005.2,973.1,994.1,973.1z"
+   id="path38" />
+<path
+   class="st5"
+   d="M1890.8,642.1h-394.4c-10.7,0-19.4-8.7-19.4-19.4V353.4c0-10.7,8.7-19.4,19.4-19.4h394.4  c10.7,0,19.4,8.7,19.4,19.4v269.4C1910.2,633.4,1901.5,642.1,1890.8,642.1z"
+   id="path40" />
+<path
+   class="st6"
+   d="M1636.3,642.1h-139c-11.1,0-20.1-9-20.1-20.1V354c0-11.1,9-20.1,20.1-20.1h139c11.1,0,20.1,9,20.1,20.1v268  C1656.4,633.1,1647.4,642.1,1636.3,642.1z"
+   id="path42" />
+<path
+   class="st5"
+   d="M1888.4,311.4h-813.8c-10.7,0-19.4-8.7-19.4-19.4V22.6c0-10.7,8.7-19.4,19.4-19.4h813.8  c10.7,0,19.4,8.7,19.4,19.4V292C1907.8,302.7,1899.1,311.4,1888.4,311.4z"
+   id="path44" />
+<path
+   class="st6"
+   d="M1214.5,311.4h-139c-11.1,0-20.1-9-20.1-20.1v-268c0-11.1,9-20.1,20.1-20.1h139c11.1,0,20.1,9,20.1,20.1v268  C1234.6,302.4,1225.6,311.4,1214.5,311.4z"
+   id="path46" />
+<path
+   class="st5"
+   d="M1013.8,311.1H561.9c-10.7,0-19.4-8.7-19.4-19.4V22.4c0-10.7,8.7-19.4,19.4-19.4h451.8  c10.7,0,19.4,8.7,19.4,19.4v269.4C1033.2,302.5,1024.5,311.1,1013.8,311.1z"
+   id="path48" />
+<path
+   class="st6"
+   d="M701.6,311.4h-139c-11.1,0-20.1-9-20.1-20.1v-268c0-11.1,9-20.1,20.1-20.1h139c11.1,0,20.1,9,20.1,20.1v268  C721.7,302.4,712.7,311.4,701.6,311.4z"
+   id="path50" />
+<path
+   class="st5"
+   d="M501.4,311.4H49.5c-10.7,0-19.4-8.7-19.4-19.4V22.6c0-10.7,8.7-19.4,19.4-19.4h451.8c10.7,0,19.4,8.7,19.4,19.4  V292C520.8,302.7,512.1,311.4,501.4,311.4z"
+   id="path52" />
+<path
+   class="st6"
+   d="M190.1,311.4H51c-11.1,0-20.1-9-20.1-20.1v-268c0-11.1,9-20.1,20.1-20.1h139c11.1,0,20.1,9,20.1,20.1v268  C210.2,302.4,201.2,311.4,190.1,311.4z"
+   id="path54" />
+<path
+   class="st5"
+   d="M1387.4,1637.3H45c-10.7,0-19.4-8.7-19.4-19.4v-269.4c0-10.7,8.7-19.4,19.4-19.4h1342.3  c10.7,0,19.4,8.7,19.4,19.4v269.4C1406.8,1628.6,1398.1,1637.3,1387.4,1637.3z"
+   id="path56" />
+<path
+   class="st5"
+   d="M794.3,1305h-748c-10.7,0-19.4-8.7-19.4-19.4v-269.4c0-10.7,8.7-19.4,19.4-19.4h748c10.7,0,19.4,8.7,19.4,19.4  v269.4C813.7,1296.3,805,1305,794.3,1305z"
+   id="path58" />
+<path
+   class="st5"
+   d="M794.4,972.9h-748c-10.7,0-19.4-8.7-19.4-19.4V684.1c0-10.7,8.7-19.4,19.4-19.4h748c10.7,0,19.4,8.7,19.4,19.4  v269.4C813.8,964.2,805.1,972.9,794.4,972.9z"
+   id="path60" />
+<path
+   class="st5"
+   d="M1434.3,642.1H50.7c-10.7,0-19.4-8.7-19.4-19.4V353.4c0-10.7,8.7-19.4,19.4-19.4h1383.7  c10.7,0,19.4,8.7,19.4,19.4v269.4C1453.7,633.4,1445.1,642.1,1434.3,642.1z"
+   id="path62" />
+<path
+   class="st7"
+   d="M190.1,642.1H51c-11.1,0-20.1-9-20.1-20.1V354c0.1-11,9-20,20.1-20h139c11.1,0,20.1,9,20.1,20.1v268  C210.2,633.1,201.2,642.1,190.1,642.1z"
+   id="path64" />
+<path
+   class="st7"
+   d="M185.9,972.9h-139c-11.1,0-20.1-9-20.1-20.1v-268c0-11.1,9-20.1,20.1-20.1h139c11.1,0,20.1,9,20.1,20.1v268  C205.9,963.9,197,972.9,185.9,972.9z"
+   id="path66" />
+<path
+   class="st7"
+   d="M185.9,1305h-139c-11.1,0-20.1-9-20.1-20.1v-268c0-11.1,9-20.1,20.1-20.1h139c11.1,0,20.1,9,20.1,20.1v268  C205.9,1296,197,1305,185.9,1305z"
+   id="path68" />
+<path
+   class="st7"
+   d="M185.2,1637.3h-139c-11.1,0-20.1-9-20.1-20.1v-268c0-11.1,9-20.1,20.1-20.1h139c11.1,0,20.1,9,20.1,20.1v268  C205.3,1628.3,196.3,1637.3,185.2,1637.3z"
+   id="path70" />
+<g
+   id="g94">
+	<path
+   class="st8"
+   d="M1095.8,1250.1l-9.2-11.3v11.3h-5.1v-25.3h5.1v11.3l9.2-11.3h6.1l-10.4,12.6l10.7,12.8L1095.8,1250.1   L1095.8,1250.1z"
+   id="path72" />
+	<path
+   class="st8"
+   d="M1124.2,1230v20.1h-5.1v-2.5c-0.7,0.9-1.5,1.6-2.6,2.1s-2.2,0.7-3.4,0.7c-1.6,0-3-0.3-4.2-1s-2.2-1.6-2.8-2.9   c-0.7-1.3-1-2.8-1-4.6V1230h5.1v11.1c0,1.6,0.4,2.8,1.2,3.7c0.8,0.9,1.9,1.3,3.3,1.3s2.5-0.4,3.3-1.3s1.2-2.1,1.2-3.7V1230H1124.2   L1124.2,1230z"
+   id="path74" />
+	<path
+   class="st8"
+   d="M1136.6,1230.6c1.2-0.6,2.5-0.9,3.9-0.9c1.7,0,3.3,0.4,4.7,1.3s2.5,2.1,3.3,3.6s1.2,3.4,1.2,5.4   s-0.4,3.9-1.2,5.5c-0.8,1.6-1.9,2.8-3.3,3.7s-2.9,1.3-4.7,1.3c-1.5,0-2.8-0.3-3.9-0.9s-2-1.4-2.7-2.3v2.9h-5.1v-26.8h5.1v9.7   C1134.5,1232,1135.4,1231.2,1136.6,1230.6L1136.6,1230.6z M1143.8,1236.8c-0.5-0.9-1.2-1.6-2-2c-0.8-0.5-1.7-0.7-2.6-0.7   s-1.8,0.2-2.6,0.7s-1.5,1.2-2,2.1s-0.7,1.9-0.7,3.2s0.2,2.3,0.7,3.2c0.5,0.9,1.2,1.6,2,2.1s1.7,0.7,2.6,0.7s1.8-0.2,2.6-0.7   s1.5-1.2,2-2.1s0.7-2,0.7-3.2S1144.3,1237.7,1143.8,1236.8L1143.8,1236.8z"
+   id="path76" />
+	<path
+   class="st8"
+   d="M1171.6,1241.6h-14.7c0.1,1.4,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5   c-0.6,1.9-1.7,3.5-3.3,4.8c-1.6,1.2-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4   s0.4-3.9,1.3-5.5c0.8-1.6,2-2.8,3.6-3.6s3.3-1.3,5.3-1.3s3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.2,5.2   C1171.7,1240.3,1171.7,1241,1171.6,1241.6L1171.6,1241.6z M1166.5,1238.1c0-1.3-0.5-2.3-1.4-3.1c-0.9-0.8-2-1.2-3.4-1.2   c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2H1166.5L1166.5,1238.1z"
+   id="path78" />
+	<path
+   class="st8"
+   d="M1182.7,1230.6c1.1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1   v-20h5.1v3.1C1180.8,1232,1181.6,1231.2,1182.7,1230.6L1182.7,1230.6z"
+   id="path80" />
+	<path
+   class="st8"
+   d="M1206.3,1231.9c1.5,1.5,2.2,3.6,2.2,6.3v11.8h-5.1v-11c0-1.6-0.4-2.8-1.2-3.7s-1.9-1.3-3.3-1.3   s-2.5,0.4-3.3,1.3s-1.2,2.1-1.2,3.7v11.1h-5.1V1230h5.1v2.5c0.7-0.9,1.5-1.6,2.6-2.1s2.2-0.7,3.5-0.7   C1202.9,1229.7,1204.8,1230.4,1206.3,1231.9L1206.3,1231.9z"
+   id="path82" />
+	<path
+   class="st8"
+   d="M1231.5,1241.6h-14.7c0.1,1.4,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5   c-0.6,1.9-1.7,3.5-3.3,4.8c-1.6,1.2-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6s-1.3-3.4-1.3-5.4s0.4-3.9,1.3-5.5   c0.8-1.6,2-2.8,3.6-3.6s3.3-1.3,5.3-1.3s3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.2,5.2C1231.6,1240.3,1231.6,1241,1231.5,1241.6   L1231.5,1241.6z M1226.4,1238.1c0-1.3-0.5-2.3-1.4-3.1c-0.9-0.8-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2   H1226.4L1226.4,1238.1z"
+   id="path84" />
+	<path
+   class="st8"
+   d="M1240.9,1234.2v9.7c0,0.7,0.2,1.2,0.5,1.5s0.9,0.4,1.7,0.4h2.4v4.3h-3.2c-4.3,0-6.4-2.1-6.4-6.2v-9.7h-2.4   v-4.2h2.4v-5h5.1v5h4.5v4.2L1240.9,1234.2L1240.9,1234.2z"
+   id="path86" />
+	<path
+   class="st8"
+   d="M1267.2,1241.6h-14.7c0.1,1.4,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5   c-0.6,1.9-1.7,3.5-3.3,4.8c-1.6,1.2-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4   s0.4-3.9,1.3-5.5c0.8-1.6,2-2.8,3.6-3.6s3.3-1.3,5.3-1.3s3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.2,5.2   C1267.3,1240.3,1267.3,1241,1267.2,1241.6L1267.2,1241.6z M1262.1,1238.1c0-1.3-0.5-2.3-1.4-3.1c-0.9-0.8-2-1.2-3.4-1.2   c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2H1262.1L1262.1,1238.1z"
+   id="path88" />
+	<path
+   class="st8"
+   d="M1273.9,1249.5c-1.3-0.6-2.3-1.4-3.1-2.4c-0.8-1-1.2-2.1-1.2-3.4h5.1c0.1,0.8,0.5,1.4,1.1,1.9s1.5,0.8,2.5,0.8   s1.7-0.2,2.3-0.6s0.8-0.9,0.8-1.5c0-0.7-0.3-1.1-1-1.5s-1.7-0.7-3.2-1.1s-2.7-0.7-3.7-1.1s-1.8-1-2.5-1.8s-1-1.9-1-3.2   c0-1.1,0.3-2.1,1-3.1s1.6-1.6,2.8-2.2c1.2-0.5,2.6-0.8,4.2-0.8c2.4,0,4.3,0.6,5.7,1.8c1.4,1.2,2.2,2.8,2.4,4.8h-4.9   c-0.1-0.8-0.4-1.4-1-1.9s-1.4-0.7-2.4-0.7c-0.9,0-1.6,0.2-2.1,0.5s-0.7,0.8-0.7,1.4c0,0.7,0.3,1.2,1,1.5s1.7,0.7,3.2,1.1   c1.4,0.4,2.7,0.7,3.6,1.1s1.8,1,2.4,1.8s1.1,1.9,1.1,3.2c0,1.2-0.3,2.2-1,3.1s-1.6,1.6-2.8,2.2s-2.6,0.8-4.2,0.8   S1275.3,1250.1,1273.9,1249.5L1273.9,1249.5z"
+   id="path90" />
+	<path
+   class="st8"
+   d="M1300.9,1225.3c1.2,0.7,2.1,1.6,2.7,2.7s1,2.5,1,4s-0.3,2.8-1,3.9s-1.6,2.1-2.7,2.7s-2.5,1-4,1s-2.8-0.3-4-1   s-2.1-1.6-2.8-2.7s-1-2.5-1-3.9s0.3-2.8,1-4s1.6-2.1,2.8-2.7c1.2-0.7,2.5-1,4-1S1299.7,1224.7,1300.9,1225.3z M1301.1,1236.3   c1.1-1.1,1.6-2.5,1.6-4.2s-0.5-3.2-1.6-4.3c-1.1-1.1-2.4-1.6-4.2-1.6s-3.1,0.5-4.2,1.6c-1,1.1-1.6,2.5-1.6,4.3s0.5,3.2,1.6,4.2   c1,1.1,2.4,1.6,4.2,1.6S1300.1,1237.4,1301.1,1236.3z M1300,1232c-0.2,0.4-0.6,0.7-1.1,0.9l1.9,3h-2.8l-1.6-2.7h-0.2v2.7h-2.4v-7.8   h3.8c0.8,0,1.5,0.2,2,0.7s0.8,1.1,0.8,1.8C1300.4,1231.2,1300.2,1231.6,1300,1232L1300,1232z M1296.1,1231.3h1.2   c0.2,0,0.3-0.1,0.4-0.1s0.2-0.2,0.2-0.4c0-0.4-0.2-0.5-0.6-0.5h-1.2V1231.3z"
+   id="path92" />
+</g>
+<g
+   id="g118">
+	<path
+   class="st8"
+   d="M1616.3,1230.7c1.1-2,2.7-3.5,4.6-4.6s4.1-1.7,6.6-1.7c2.8,0,5.3,0.7,7.4,2.2c2.1,1.4,3.6,3.5,4.5,6h-5.8   c-0.6-1.2-1.4-2.1-2.4-2.7c-1.1-0.6-2.3-0.9-3.6-0.9c-1.5,0-2.8,0.3-3.9,1c-1.2,0.7-2,1.7-2.7,2.9s-1,2.7-1,4.4s0.3,3.1,1,4.4   s1.5,2.2,2.7,2.9s2.5,1,3.9,1s2.6-0.3,3.6-0.9c1.1-0.6,1.9-1.5,2.4-2.7h5.8c-0.8,2.6-2.3,4.6-4.4,6s-4.6,2.2-7.4,2.2   c-2.4,0-4.6-0.6-6.6-1.7c-1.9-1.1-3.5-2.6-4.6-4.6s-1.7-4.2-1.7-6.7S1615.2,1232.7,1616.3,1230.7L1616.3,1230.7z"
+   id="path96" />
+	<path
+   class="st8"
+   d="M1647,1249.1c-1.6-0.9-2.8-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4s0.4-3.9,1.4-5.4s2.2-2.8,3.7-3.6   c1.6-0.9,3.3-1.3,5.3-1.3s3.7,0.4,5.3,1.3c1.6,0.9,2.8,2.1,3.7,3.6c0.9,1.6,1.4,3.4,1.4,5.4s-0.5,3.9-1.4,5.4s-2.2,2.8-3.8,3.6   s-3.3,1.3-5.3,1.3S1648.6,1250,1647,1249.1L1647,1249.1z M1654.8,1245.3c0.8-0.4,1.5-1.1,1.9-2s0.7-2,0.7-3.3   c0-1.9-0.5-3.4-1.5-4.4s-2.2-1.5-3.7-1.5s-2.7,0.5-3.6,1.5c-1,1-1.5,2.5-1.5,4.4s0.5,3.4,1.4,4.4s2.2,1.5,3.6,1.5   C1653.2,1246,1654,1245.8,1654.8,1245.3L1654.8,1245.3z"
+   id="path98" />
+	<path
+   class="st8"
+   d="M1683,1231.9c1.5,1.5,2.2,3.6,2.2,6.3v11.8h-5.1v-11c0-1.6-0.4-2.8-1.2-3.7s-1.9-1.3-3.3-1.3s-2.5,0.4-3.3,1.3   s-1.2,2.1-1.2,3.7v11.1h-5.1V1230h5.1v2.5c0.7-0.9,1.5-1.6,2.6-2.1s2.2-0.7,3.5-0.7C1679.6,1229.7,1681.6,1230.4,1683,1231.9   L1683,1231.9z"
+   id="path100" />
+	<path
+   class="st8"
+   d="M1695.6,1234.2v9.7c0,0.7,0.2,1.2,0.5,1.5s0.9,0.4,1.7,0.4h2.4v4.3h-3.2c-4.3,0-6.4-2.1-6.4-6.2v-9.7h-2.4   v-4.2h2.4v-5h5.1v5h4.5v4.2L1695.6,1234.2L1695.6,1234.2z"
+   id="path102" />
+	<path
+   class="st8"
+   d="M1703.3,1234.6c0.8-1.6,1.9-2.8,3.3-3.6s2.9-1.3,4.7-1.3c1.5,0,2.8,0.3,3.9,0.9s2,1.4,2.7,2.3v-2.9h5.1v20.1   h-5.1v-2.9c-0.7,0.9-1.6,1.7-2.7,2.3c-1.2,0.6-2.5,0.9-4,0.9c-1.7,0-3.2-0.4-4.6-1.3s-2.5-2.1-3.3-3.7s-1.2-3.4-1.2-5.5   S1702.5,1236.1,1703.3,1234.6L1703.3,1234.6z M1717.2,1236.9c-0.5-0.9-1.1-1.6-2-2s-1.7-0.7-2.7-0.7s-1.8,0.2-2.6,0.7   c-0.8,0.5-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.7,3.2c0.5,0.9,1.2,1.6,2,2.1s1.7,0.7,2.6,0.7s1.8-0.2,2.7-0.7s1.5-1.2,2-2   c0.5-0.9,0.7-1.9,0.7-3.2S1717.7,1237.7,1717.2,1236.9L1717.2,1236.9z"
+   id="path104" />
+	<path
+   class="st8"
+   d="M1728,1226.7c-0.6-0.6-0.9-1.3-0.9-2.1s0.3-1.6,0.9-2.1s1.3-0.8,2.2-0.8s1.6,0.3,2.2,0.8s0.9,1.3,0.9,2.1   s-0.3,1.6-0.9,2.1s-1.3,0.8-2.2,0.8S1728.6,1227.3,1728,1226.7z M1732.7,1230v20.1h-5.1V1230H1732.7z"
+   id="path106" />
+	<path
+   class="st8"
+   d="M1754.3,1231.9c1.5,1.5,2.2,3.6,2.2,6.3v11.8h-5.1v-11c0-1.6-0.4-2.8-1.2-3.7s-1.9-1.3-3.3-1.3   s-2.5,0.4-3.3,1.3s-1.2,2.1-1.2,3.7v11.1h-5.1V1230h5.1v2.5c0.7-0.9,1.5-1.6,2.6-2.1s2.2-0.7,3.5-0.7   C1750.9,1229.7,1752.8,1230.4,1754.3,1231.9L1754.3,1231.9z"
+   id="path108" />
+	<path
+   class="st8"
+   d="M1779.5,1241.6h-14.7c0.1,1.4,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5   c-0.6,1.9-1.7,3.5-3.3,4.8c-1.6,1.2-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6s-1.3-3.4-1.3-5.4s0.4-3.9,1.3-5.5   c0.8-1.6,2-2.8,3.6-3.6s3.3-1.3,5.3-1.3s3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.2,5.2C1779.6,1240.3,1779.6,1241,1779.5,1241.6   L1779.5,1241.6z M1774.4,1238.1c0-1.3-0.5-2.3-1.4-3.1c-0.9-0.8-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2   H1774.4L1774.4,1238.1z"
+   id="path110" />
+	<path
+   class="st8"
+   d="M1790.6,1230.6c1.1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1   v-20h5.1v3.1C1788.7,1232,1789.6,1231.2,1790.6,1230.6L1790.6,1230.6z"
+   id="path112" />
+	<path
+   class="st8"
+   d="M1797.2,1234.6c0.8-1.6,1.9-2.8,3.3-3.6s3-1.3,4.7-1.3c1.3,0,2.6,0.3,3.7,0.8s2.1,1.3,2.8,2.3v-9.5h5.2v26.8   h-5.2v-3c-0.6,1-1.5,1.8-2.7,2.4s-2.4,0.9-3.9,0.9c-1.7,0-3.2-0.4-4.6-1.3s-2.5-2.1-3.3-3.7s-1.2-3.4-1.2-5.5   S1796.4,1236.1,1797.2,1234.6L1797.2,1234.6z M1811.1,1236.9c-0.5-0.9-1.1-1.6-2-2s-1.7-0.7-2.7-0.7s-1.8,0.2-2.6,0.7   c-0.8,0.5-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.7,3.2c0.5,0.9,1.2,1.6,2,2.1s1.7,0.7,2.6,0.7s1.8-0.2,2.7-0.7   c0.8-0.5,1.5-1.2,2-2s0.7-1.9,0.7-3.2S1811.5,1237.7,1811.1,1236.9L1811.1,1236.9z"
+   id="path114" />
+	<path
+   class="st8"
+   d="M1832.3,1225.3c1.2,0.7,2.1,1.6,2.7,2.7c0.7,1.2,1,2.5,1,4s-0.3,2.8-1,3.9c-0.7,1.2-1.6,2.1-2.7,2.7   s-2.5,1-4,1s-2.8-0.3-4-1s-2.1-1.6-2.8-2.7s-1-2.5-1-3.9s0.3-2.8,1-4s1.6-2.1,2.8-2.7c1.2-0.7,2.5-1,4-1   S1831.2,1224.7,1832.3,1225.3z M1832.5,1236.3c1.1-1.1,1.6-2.5,1.6-4.2s-0.5-3.2-1.6-4.3c-1.1-1.1-2.4-1.6-4.2-1.6   s-3.1,0.5-4.2,1.6c-1,1.1-1.6,2.5-1.6,4.3s0.5,3.2,1.6,4.2c1,1.1,2.4,1.6,4.2,1.6S1831.5,1237.4,1832.5,1236.3z M1831.4,1232   c-0.2,0.4-0.6,0.7-1.1,0.9l1.9,3h-2.8l-1.6-2.7h-0.2v2.7h-2.4v-7.8h3.8c0.8,0,1.5,0.2,2,0.7s0.8,1.1,0.8,1.8   C1831.8,1231.2,1831.6,1231.6,1831.4,1232L1831.4,1232z M1827.5,1231.3h1.2c0.2,0,0.3-0.1,0.4-0.1s0.2-0.2,0.2-0.4   c0-0.4-0.2-0.5-0.6-0.5h-1.2V1231.3L1827.5,1231.3z"
+   id="path116" />
+</g>
+<path
+   class="st9"
+   d="M1021.9,533.5c-1.4,0-2.8,0.1-4.2,0.3c-1.3,0.2-2.7,0.6-3.9,1.2c-1.1,0.5-2.1,1.3-2.8,2.4  c-0.7,1.1-1.1,2.5-1,3.8c0,1,0.1,2,0.4,3c0.4,1.3,1.2,2.5,2.4,3.2c1.9,1.2,4.4,1.7,7.7,1.7c3.9,0,6.9-0.2,8.9-0.6v-14  c-1-0.3-2-0.5-3-0.6C1024.9,533.6,1023.4,533.5,1021.9,533.5L1021.9,533.5z"
+   id="path120" />
+<g
+   id="g138">
+	<path
+   class="st8"
+   d="M304.1,1224.8v4.1h-10.5v6.5h8.1v4h-8.1v10.7h-5.1v-25.3L304.1,1224.8L304.1,1224.8z"
+   id="path122" />
+	<path
+   class="st8"
+   d="M312.4,1223.2v26.8h-5.1v-26.8H312.4z"
+   id="path124" />
+	<path
+   class="st8"
+   d="M336,1230v20.1h-5.1v-2.5c-0.6,0.9-1.5,1.6-2.6,2.1s-2.2,0.7-3.4,0.7c-1.6,0-3-0.3-4.2-1s-2.2-1.6-2.9-2.9   c-0.7-1.3-1-2.8-1-4.6V1230h5.1v11.1c0,1.6,0.4,2.8,1.2,3.7c0.8,0.9,1.9,1.3,3.3,1.3s2.5-0.4,3.3-1.3s1.2-2.1,1.2-3.7V1230H336   L336,1230z"
+   id="path126" />
+	<path
+   class="st8"
+   d="M359.2,1241.6h-14.7c0.1,1.4,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5c-0.6,1.9-1.7,3.5-3.3,4.8   c-1.6,1.2-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4s0.4-3.9,1.3-5.5s2-2.8,3.5-3.6   s3.3-1.3,5.3-1.3s3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.2,5.2C359.3,1240.3,359.3,1241,359.2,1241.6L359.2,1241.6z    M354.1,1238.1c0-1.3-0.5-2.3-1.4-3.1c-0.9-0.8-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2H354.1L354.1,1238.1   z"
+   id="path128" />
+	<path
+   class="st8"
+   d="M379.6,1231.9c1.5,1.5,2.2,3.6,2.2,6.3v11.8h-5.1v-11c0-1.6-0.4-2.8-1.2-3.7s-1.9-1.3-3.3-1.3   s-2.5,0.4-3.3,1.3s-1.2,2.1-1.2,3.7v11.1h-5.1V1230h5.1v2.5c0.7-0.9,1.5-1.6,2.6-2.1s2.2-0.7,3.5-0.7   C376.2,1229.7,378.1,1230.4,379.6,1231.9L379.6,1231.9z"
+   id="path130" />
+	<path
+   class="st8"
+   d="M392.2,1234.2v9.7c0,0.7,0.2,1.2,0.5,1.5s0.9,0.4,1.6,0.4h2.4v4.3h-3.2c-4.3,0-6.4-2.1-6.4-6.2v-9.7h-2.4v-4.2   h2.4v-5h5.1v5h4.5v4.2L392.2,1234.2L392.2,1234.2z"
+   id="path132" />
+	<path
+   class="st8"
+   d="M399.9,1234.6c0.8-1.6,1.9-2.8,3.3-3.6s3-1.3,4.7-1.3c1.3,0,2.5,0.3,3.7,0.8s2.1,1.3,2.8,2.3v-9.5h5.1v26.8   h-5.1v-3c-0.6,1-1.5,1.8-2.6,2.4s-2.5,0.9-4,0.9c-1.7,0-3.2-0.4-4.6-1.3s-2.5-2.1-3.3-3.7s-1.2-3.4-1.2-5.5   S399.1,1236.1,399.9,1234.6L399.9,1234.6z M413.8,1236.9c-0.5-0.9-1.1-1.6-2-2c-0.8-0.5-1.7-0.7-2.6-0.7s-1.8,0.2-2.6,0.7   s-1.5,1.1-1.9,2c-0.5,0.9-0.7,1.9-0.7,3.1s0.2,2.3,0.7,3.2c0.5,0.9,1.1,1.6,2,2.1c0.8,0.5,1.7,0.7,2.6,0.7s1.8-0.2,2.6-0.7   s1.5-1.2,2-2c0.5-0.9,0.7-1.9,0.7-3.2S414.3,1237.7,413.8,1236.9L413.8,1236.9z"
+   id="path134" />
+	<path
+   class="st8"
+   d="M435.1,1225.3c1.2,0.7,2.1,1.6,2.7,2.7s1,2.5,1,4s-0.3,2.8-1,3.9s-1.6,2.1-2.7,2.7s-2.5,1-4,1s-2.8-0.3-4-1   s-2.1-1.6-2.8-2.7s-1-2.5-1-3.9s0.3-2.8,1-4s1.6-2.1,2.8-2.7c1.2-0.7,2.5-1,4-1S433.9,1224.7,435.1,1225.3z M435.3,1236.3   c1-1.1,1.6-2.5,1.6-4.2s-0.5-3.2-1.6-4.3c-1-1.1-2.5-1.6-4.2-1.6s-3.1,0.5-4.2,1.6c-1,1.1-1.6,2.5-1.6,4.3s0.5,3.2,1.6,4.2   c1,1.1,2.4,1.6,4.2,1.6S434.2,1237.4,435.3,1236.3z M434.1,1232c-0.2,0.4-0.6,0.7-1.1,0.9l1.9,3h-2.8l-1.6-2.7h-0.2v2.7h-2.4v-7.8   h3.8c0.9,0,1.5,0.2,2,0.7s0.8,1.1,0.8,1.8C434.5,1231.2,434.4,1231.6,434.1,1232L434.1,1232z M430.3,1231.3h1.2   c0.2,0,0.3-0.1,0.4-0.1s0.2-0.2,0.2-0.4c0-0.4-0.2-0.5-0.6-0.5h-1.2V1231.3z"
+   id="path136" />
+</g>
+<g
+   id="g152">
+	<path
+   class="st8"
+   d="M1398.3,898.3c1.1-2,2.7-3.5,4.6-4.6s4.1-1.7,6.6-1.7c2.8,0,5.3,0.7,7.4,2.2s3.6,3.5,4.5,6h-5.8   c-0.6-1.2-1.4-2.1-2.4-2.7s-2.3-0.9-3.6-0.9c-1.5,0-2.8,0.3-3.9,1c-1.2,0.7-2,1.7-2.7,2.9s-1,2.7-1,4.4s0.3,3.1,1,4.4   c0.6,1.3,1.5,2.2,2.7,2.9s2.5,1,3.9,1s2.6-0.3,3.6-0.9c1.1-0.6,1.9-1.5,2.4-2.7h5.8c-0.8,2.6-2.3,4.6-4.4,6s-4.6,2.2-7.4,2.2   c-2.4,0-4.6-0.5-6.6-1.7c-1.9-1.1-3.5-2.6-4.6-4.6s-1.7-4.2-1.7-6.7S1397.2,900.3,1398.3,898.3L1398.3,898.3z"
+   id="path140" />
+	<path
+   class="st8"
+   d="M1425.3,902.2c0.8-1.6,1.9-2.8,3.3-3.6s2.9-1.3,4.7-1.3c1.5,0,2.8,0.3,3.9,0.9c1.1,0.6,2,1.4,2.7,2.3v-2.9h5.1   v20.1h-5.1v-2.9c-0.7,0.9-1.6,1.7-2.7,2.3c-1.2,0.6-2.5,0.9-4,0.9c-1.7,0-3.2-0.4-4.6-1.3c-1.4-0.9-2.5-2.1-3.3-3.7   s-1.2-3.4-1.2-5.5S1424.5,903.8,1425.3,902.2L1425.3,902.2z M1439.1,904.5c-0.5-0.9-1.1-1.6-2-2c-0.8-0.5-1.7-0.7-2.7-0.7   s-1.8,0.2-2.6,0.7c-0.8,0.5-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.7,3.2s1.2,1.6,2,2.1s1.7,0.7,2.6,0.7s1.8-0.2,2.7-0.7   c0.8-0.5,1.5-1.2,2-2c0.5-0.9,0.7-1.9,0.7-3.2S1439.6,905.4,1439.1,904.5L1439.1,904.5z"
+   id="path142" />
+	<path
+   class="st8"
+   d="M1454.7,890.9v26.8h-5.1v-26.8H1454.7z"
+   id="path144" />
+	<path
+   class="st8"
+   d="M1459.6,894.4c-0.6-0.6-0.9-1.3-0.9-2.1s0.3-1.5,0.9-2.1s1.3-0.8,2.2-0.8s1.6,0.3,2.2,0.8   c0.6,0.6,0.9,1.3,0.9,2.1s-0.3,1.5-0.9,2.1s-1.3,0.8-2.2,0.8S1460.2,895,1459.6,894.4z M1464.4,897.6v20.1h-5.1v-20.1H1464.4z"
+   id="path146" />
+	<path
+   class="st8"
+   d="M1469,902.2c0.8-1.6,2-2.8,3.5-3.6s3.2-1.3,5.2-1.3c2.5,0,4.6,0.6,6.2,1.9s2.7,3,3.3,5.2h-5.5   c-0.3-0.9-0.8-1.5-1.5-2s-1.5-0.7-2.6-0.7c-1.4,0-2.6,0.5-3.4,1.6s-1.3,2.5-1.3,4.5s0.4,3.4,1.3,4.4s2,1.6,3.4,1.6   c2.1,0,3.4-0.9,4-2.8h5.5c-0.6,2.2-1.7,3.9-3.3,5.2s-3.7,1.9-6.2,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.5-3.6s-1.3-3.4-1.3-5.5   S1468.1,903.8,1469,902.2L1469,902.2z"
+   id="path148" />
+	<path
+   class="st8"
+   d="M1494.2,916.8c-1.6-0.9-2.8-2.1-3.6-3.6s-1.3-3.4-1.3-5.4s0.4-3.9,1.4-5.4s2.2-2.8,3.7-3.6   c1.6-0.9,3.3-1.3,5.3-1.3s3.7,0.4,5.3,1.3c1.6,0.9,2.8,2.1,3.7,3.6c0.9,1.6,1.4,3.4,1.4,5.4s-0.5,3.9-1.4,5.4s-2.2,2.8-3.8,3.6   s-3.3,1.3-5.3,1.3S1495.7,917.6,1494.2,916.8L1494.2,916.8z M1502,913c0.8-0.5,1.5-1.1,1.9-2s0.7-2,0.7-3.3c0-1.9-0.5-3.4-1.5-4.4   s-2.2-1.5-3.7-1.5s-2.7,0.5-3.6,1.5c-1,1-1.5,2.5-1.5,4.4s0.5,3.4,1.4,4.4s2.2,1.5,3.6,1.5C1500.3,913.6,1501.2,913.4,1502,913   L1502,913z"
+   id="path150" />
+</g>
+<g
+   id="g160">
+	<path
+   class="st8"
+   d="M606.1,563.1c2,1,3.6,2.5,4.7,4.4s1.7,4.2,1.7,6.7s-0.5,4.8-1.7,6.7c-1.1,1.9-2.7,3.4-4.7,4.4s-4.4,1.6-7,1.6   h-8.8v-25.3h8.8C601.7,561.6,604.1,562.1,606.1,563.1L606.1,563.1z M605.1,580.4c1.5-1.5,2.2-3.5,2.2-6.1s-0.7-4.7-2.2-6.2   s-3.5-2.2-6.2-2.2h-3.6v16.7h3.6C601.5,582.6,603.6,581.8,605.1,580.4z"
+   id="path154" />
+	<path
+   class="st8"
+   d="M634.4,578.4h-14.7c0.1,1.5,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5c-0.6,1.9-1.7,3.5-3.3,4.8   c-1.6,1.2-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3c-1.5-0.9-2.7-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4s0.4-3.9,1.3-5.5   c0.8-1.6,2-2.8,3.5-3.6s3.3-1.3,5.3-1.3s3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.2,5.2C634.5,577.1,634.5,577.8,634.4,578.4   L634.4,578.4z M629.3,575c0-1.3-0.5-2.3-1.4-3.1s-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2H629.3L629.3,575z   "
+   id="path156" />
+	<path
+   class="st8"
+   d="M649,586.9l-4.1-6.2l-3.7,6.2h-5.4l6.6-10.1l-6.6-10h5.7l4.1,6.2l3.7-6.2h5.4l-6.6,10l6.7,10.1H649z"
+   id="path158" />
+</g>
+<g
+   id="g174">
+	<path
+   class="st8"
+   d="M806.9,561.7v4.1h-10.5v6.5h8.1v4h-8.1V587h-5.1v-25.3H806.9L806.9,561.7z"
+   id="path162" />
+	<path
+   class="st8"
+   d="M810.1,571.5c0.8-1.6,1.9-2.8,3.3-3.6s2.9-1.3,4.7-1.3c1.5,0,2.8,0.3,3.9,0.9c1.1,0.6,2,1.4,2.7,2.3v-2.9h5.1   V587h-5.1v-2.9c-0.7,0.9-1.5,1.7-2.7,2.3s-2.5,0.9-4,0.9c-1.7,0-3.2-0.4-4.6-1.3c-1.4-0.9-2.5-2.1-3.3-3.7   c-0.8-1.6-1.2-3.4-1.2-5.5C808.9,574.9,809.3,573.1,810.1,571.5L810.1,571.5z M824,573.8c-0.5-0.9-1.1-1.6-2-2   c-0.8-0.5-1.7-0.7-2.7-0.7c-0.9,0-1.8,0.2-2.6,0.7s-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.8,3.2c0.5,0.9,1.2,1.6,2,2.1   s1.7,0.7,2.6,0.7c0.9,0,1.8-0.2,2.7-0.7c0.8-0.5,1.5-1.2,2-2c0.5-0.9,0.7-1.9,0.7-3.2S824.5,574.7,824,573.8L824,573.8z"
+   id="path164" />
+	<path
+   class="st8"
+   d="M839.5,560.2V587h-5.1v-26.8H839.5L839.5,560.2z"
+   id="path166" />
+	<path
+   class="st8"
+   d="M844.1,571.5c0.8-1.6,2-2.8,3.5-3.6c1.5-0.9,3.2-1.3,5.2-1.3c2.5,0,4.5,0.6,6.2,1.9c1.6,1.2,2.7,3,3.3,5.2   h-5.5c-0.3-0.9-0.8-1.5-1.5-2s-1.5-0.7-2.6-0.7c-1.5,0-2.6,0.5-3.4,1.6c-0.8,1-1.3,2.5-1.3,4.5c0,1.9,0.4,3.4,1.3,4.4   s2,1.6,3.5,1.6c2,0,3.4-0.9,4-2.8h5.5c-0.5,2.2-1.7,3.9-3.3,5.2s-3.7,1.9-6.2,1.9c-1.9,0-3.7-0.4-5.2-1.3c-1.5-0.9-2.7-2.1-3.5-3.6   c-0.8-1.6-1.3-3.4-1.3-5.5C842.8,574.9,843.3,573.1,844.1,571.5L844.1,571.5z"
+   id="path168" />
+	<path
+   class="st8"
+   d="M869.3,586c-1.5-0.9-2.8-2.1-3.7-3.6s-1.3-3.4-1.3-5.4s0.5-3.9,1.3-5.4c0.9-1.6,2.1-2.8,3.7-3.7   c1.6-0.9,3.3-1.3,5.3-1.3c1.9,0,3.7,0.4,5.3,1.3c1.6,0.9,2.8,2.1,3.7,3.6s1.4,3.4,1.4,5.4c0,2.1-0.5,3.9-1.4,5.4s-2.2,2.8-3.8,3.7   s-3.3,1.3-5.3,1.3C872.6,587.3,870.8,586.9,869.3,586L869.3,586z M877.1,582.2c0.8-0.5,1.5-1.1,1.9-2c0.5-0.9,0.7-2,0.7-3.3   c0-1.9-0.5-3.4-1.5-4.4s-2.2-1.5-3.7-1.5s-2.7,0.5-3.6,1.5c-1,1-1.5,2.5-1.5,4.4s0.5,3.4,1.4,4.4c1,1,2.2,1.5,3.6,1.5   C875.4,582.9,876.3,582.6,877.1,582.2L877.1,582.2z"
+   id="path170" />
+	<path
+   class="st8"
+   d="M886.8,561.4h9.6v3h-2.9v9.8h-3.8v-9.8h-2.9L886.8,561.4L886.8,561.4z M914.5,561.4v12.8H911l-0.1-8l-3.3,8   H905l-3.3-8.3v8.3h-3.4v-12.8h5l3.1,8.2l3.3-8.2H914.5L914.5,561.4z"
+   id="path172" />
+</g>
+<g
+   id="g186">
+	<path
+   class="st8"
+   d="M1052.2,587.1l-9.2-11.3v11.3h-5.1v-25.3h5.1v11.3l9.2-11.4h6.1l-10.4,12.5l10.8,12.8L1052.2,587.1   L1052.2,587.1z"
+   id="path176" />
+	<path
+   class="st8"
+   d="M1080.5,567v20.1h-5.1v-2.5c-0.7,0.9-1.5,1.6-2.6,2c-1.1,0.5-2.2,0.8-3.4,0.8c-1.6,0-3-0.3-4.2-1   s-2.2-1.6-2.8-2.9s-1-2.8-1-4.6V567h5.1v11c0,1.6,0.4,2.8,1.2,3.7c0.8,0.9,1.9,1.3,3.3,1.3s2.5-0.4,3.3-1.3s1.2-2.1,1.2-3.7v-11   H1080.5L1080.5,567z"
+   id="path178" />
+	<path
+   class="st8"
+   d="M1092.8,567.6c1.1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1   v-20.1h5.1v3.1C1090.9,569,1091.7,568.2,1092.8,567.6z"
+   id="path180" />
+	<path
+   class="st8"
+   d="M1118,578.5h-14.7c0.1,1.5,0.6,2.6,1.5,3.4c0.9,0.8,2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5   c-0.6,1.9-1.7,3.5-3.3,4.8s-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3c-1.5-0.9-2.7-2.1-3.6-3.6s-1.3-3.4-1.3-5.4   c0-2.1,0.4-3.9,1.3-5.5c0.8-1.6,2-2.8,3.6-3.6s3.3-1.3,5.3-1.3c1.9,0,3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.3,3.2,1.3,5.2   C1118.1,577.3,1118.1,577.9,1118,578.5L1118,578.5z M1112.8,575.1c0-1.3-0.5-2.3-1.4-3.1s-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.2   c-0.9,0.8-1.4,1.8-1.6,3.2L1112.8,575.1L1112.8,575.1z"
+   id="path182" />
+	<path
+   class="st8"
+   d="M1121.3,571.5c0.8-1.6,1.9-2.8,3.3-3.6s3-1.3,4.7-1.3c1.3,0,2.6,0.3,3.7,0.8c1.2,0.6,2.1,1.3,2.8,2.3v-9.5h5.1   V587h-5.2v-3c-0.6,1-1.5,1.8-2.6,2.4s-2.4,0.9-3.9,0.9c-1.7,0-3.2-0.4-4.6-1.3s-2.5-2.1-3.3-3.7c-0.8-1.6-1.2-3.4-1.2-5.5   C1120.2,574.8,1120.6,573,1121.3,571.5L1121.3,571.5z M1135.2,573.8c-0.5-0.9-1.1-1.6-2-2s-1.7-0.7-2.7-0.7c-0.9,0-1.8,0.2-2.6,0.7   c-0.8,0.5-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.8,3.2c0.5,0.9,1.2,1.6,2,2.1s1.7,0.7,2.6,0.7s1.8-0.2,2.7-0.7   c0.8-0.5,1.5-1.2,2-2c0.5-0.9,0.7-1.9,0.7-3.2S1135.7,574.7,1135.2,573.8L1135.2,573.8z"
+   id="path184" />
+</g>
+<g
+   id="g210">
+	<path
+   class="st8"
+   d="M531.8,1567.9c-0.6,1.2-1.6,2.1-3,2.9s-3.1,1.1-5.2,1.1h-4.2v9.7h-5.1v-25.3h9.3c2,0,3.6,0.3,5,1   s2.4,1.6,3.1,2.8s1,2.5,1,4C532.7,1565.5,532.4,1566.8,531.8,1567.9L531.8,1567.9z M526.5,1566.8c0.7-0.6,1-1.5,1-2.7   c0-2.5-1.4-3.7-4.1-3.7h-4v7.4h4C524.8,1567.8,525.8,1567.5,526.5,1566.8L526.5,1566.8z"
+   id="path188" />
+	<path
+   class="st8"
+   d="M543.6,1562.1c1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10H536v-20.1   h5.1v3.1C541.7,1563.6,542.5,1562.7,543.6,1562.1L543.6,1562.1z"
+   id="path190" />
+	<path
+   class="st8"
+   d="M553.9,1580.6c-1.5-0.9-2.8-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4s0.5-3.9,1.4-5.4s2.2-2.8,3.7-3.6   c1.6-0.9,3.3-1.3,5.3-1.3s3.7,0.4,5.3,1.3s2.8,2.1,3.7,3.6c0.9,1.6,1.4,3.4,1.4,5.4s-0.5,3.9-1.4,5.4c-0.9,1.6-2.2,2.8-3.8,3.6   s-3.3,1.3-5.3,1.3S555.5,1581.5,553.9,1580.6L553.9,1580.6z M561.8,1576.8c0.8-0.4,1.5-1.1,1.9-2s0.7-2,0.7-3.3   c0-1.9-0.5-3.4-1.5-4.4s-2.2-1.5-3.7-1.5s-2.7,0.5-3.6,1.5c-1,1-1.5,2.5-1.5,4.4s0.5,3.4,1.4,4.4s2.2,1.5,3.6,1.5   C560.1,1577.5,560.9,1577.3,561.8,1576.8L561.8,1576.8z"
+   id="path192" />
+	<path
+   class="st8"
+   d="M603.9,1563.5c1.5,1.5,2.3,3.6,2.3,6.3v11.8h-5.1v-11.1c0-1.6-0.4-2.8-1.2-3.6s-1.9-1.2-3.3-1.2   s-2.5,0.4-3.3,1.2c-0.8,0.8-1.2,2-1.2,3.6v11.1H587v-11.1c0-1.6-0.4-2.8-1.2-3.6s-1.9-1.2-3.3-1.2s-2.5,0.4-3.3,1.2s-1.2,2-1.2,3.6   v11.1h-5v-20.1h5.1v2.4c0.7-0.8,1.5-1.5,2.5-2s2.2-0.7,3.4-0.7c1.6,0,3,0.3,4.2,1s2.2,1.6,2.9,2.8c0.7-1.2,1.6-2.1,2.8-2.8   c1.2-0.7,2.6-1.1,4-1.1C600.4,1561.2,602.4,1562,603.9,1563.5L603.9,1563.5z"
+   id="path194" />
+	<path
+   class="st8"
+   d="M629.2,1573.1h-14.7c0.1,1.4,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5c-0.6,1.9-1.7,3.5-3.3,4.8   c-1.6,1.2-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4s0.4-3.9,1.3-5.5   c0.8-1.6,2-2.8,3.5-3.6s3.3-1.3,5.3-1.3s3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.2,5.2C629.3,1571.8,629.3,1572.5,629.2,1573.1   L629.2,1573.1z M624.1,1569.7c0-1.3-0.5-2.3-1.4-3.1c-0.9-0.8-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2   H624.1L624.1,1569.7z"
+   id="path196" />
+	<path
+   class="st8"
+   d="M638.6,1565.7v9.7c0,0.7,0.2,1.2,0.5,1.5s0.9,0.4,1.7,0.4h2.4v4.3H640c-4.3,0-6.4-2.1-6.4-6.2v-9.7h-2.4v-4.2   h2.4v-5h5.1v5h4.5v4.2L638.6,1565.7L638.6,1565.7z"
+   id="path198" />
+	<path
+   class="st8"
+   d="M661.8,1562.2c1.2,0.7,2.1,1.6,2.8,2.9s1,2.8,1,4.7v11.8h-5.1v-11.1c0-1.6-0.4-2.8-1.2-3.7s-1.9-1.3-3.3-1.3   s-2.5,0.4-3.3,1.3s-1.2,2.1-1.2,3.7v11.1h-5.1v-26.8h5.1v9.2c0.7-0.9,1.5-1.6,2.6-2.1s2.3-0.7,3.6-0.7   C659.2,1561.2,660.6,1561.5,661.8,1562.2L661.8,1562.2z"
+   id="path200" />
+	<path
+   class="st8"
+   d="M688.5,1573.1h-14.7c0.1,1.4,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5c-0.6,1.9-1.7,3.5-3.3,4.8   c-1.6,1.2-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4s0.4-3.9,1.3-5.5   c0.8-1.6,2-2.8,3.5-3.6c1.5-0.8,3.3-1.3,5.3-1.3s3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.2,5.2   C688.7,1571.8,688.6,1572.5,688.5,1573.1L688.5,1573.1z M683.4,1569.7c0-1.3-0.5-2.3-1.4-3.1c-0.9-0.8-2-1.2-3.4-1.2   c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2H683.4L683.4,1569.7z"
+   id="path202" />
+	<path
+   class="st8"
+   d="M711,1561.5v20.1h-5.1v-2.5c-0.7,0.9-1.5,1.6-2.6,2.1c-1,0.5-2.2,0.7-3.4,0.7c-1.6,0-3-0.3-4.2-1   s-2.2-1.6-2.8-2.9c-0.7-1.3-1-2.8-1-4.6v-11.8h5.1v11.1c0,1.6,0.4,2.8,1.2,3.7c0.8,0.9,1.9,1.3,3.3,1.3s2.5-0.4,3.3-1.3   s1.2-2.1,1.2-3.7v-11.1L711,1561.5L711,1561.5z"
+   id="path204" />
+	<path
+   class="st8"
+   d="M718.9,1581c-1.3-0.6-2.3-1.4-3.1-2.4s-1.2-2.1-1.2-3.4h5.1c0.1,0.8,0.5,1.4,1.1,1.9s1.5,0.8,2.5,0.8   s1.7-0.2,2.3-0.6s0.8-0.9,0.8-1.5c0-0.7-0.3-1.1-1-1.5s-1.7-0.7-3.2-1.1s-2.7-0.7-3.7-1.1s-1.8-1-2.5-1.8s-1-1.9-1-3.2   c0-1.1,0.3-2.1,1-3.1s1.6-1.6,2.8-2.2c1.2-0.5,2.6-0.8,4.2-0.8c2.4,0,4.3,0.6,5.7,1.8c1.4,1.2,2.2,2.8,2.4,4.8h-4.9   c-0.1-0.8-0.4-1.4-1-1.9s-1.4-0.7-2.4-0.7c-0.9,0-1.6,0.2-2.1,0.5s-0.7,0.8-0.7,1.4c0,0.7,0.3,1.2,1,1.5s1.7,0.7,3.2,1.1   s2.7,0.7,3.6,1.1c0.9,0.4,1.8,1,2.5,1.8s1,1.9,1.1,3.2c0,1.2-0.3,2.2-1,3.1s-1.6,1.6-2.8,2.2s-2.6,0.8-4.2,0.8   S720.2,1581.6,718.9,1581L718.9,1581z"
+   id="path206" />
+	<path
+   class="st8"
+   d="M745.8,1556.9c1.2,0.7,2.1,1.6,2.7,2.7c0.7,1.2,1,2.5,1,4s-0.3,2.8-1,3.9s-1.6,2.1-2.7,2.7s-2.5,1-4,1   s-2.8-0.3-4-1s-2.1-1.6-2.8-2.7s-1-2.5-1-3.9s0.3-2.8,1-4s1.6-2.1,2.8-2.7c1.2-0.7,2.5-1,4-1S744.7,1556.2,745.8,1556.9z    M746,1567.8c1-1.1,1.6-2.5,1.6-4.2s-0.5-3.2-1.6-4.3c-1-1.1-2.5-1.6-4.2-1.6s-3.1,0.5-4.2,1.6c-1,1.1-1.6,2.5-1.6,4.3   s0.5,3.2,1.6,4.2c1,1.1,2.4,1.6,4.2,1.6S745,1568.9,746,1567.8z M744.9,1563.5c-0.2,0.4-0.6,0.7-1.1,0.9l1.9,3h-2.8l-1.6-2.7h-0.2   v2.7h-2.4v-7.8h3.8c0.8,0,1.5,0.2,2,0.7s0.8,1.1,0.8,1.8C745.3,1562.7,745.1,1563.1,744.9,1563.5L744.9,1563.5z M741.1,1562.8h1.2   c0.2,0,0.3-0.1,0.4-0.1s0.2-0.2,0.2-0.4c0-0.4-0.2-0.5-0.6-0.5h-1.2L741.1,1562.8L741.1,1562.8z"
+   id="path208" />
+</g>
+<g
+   id="g226">
+	<path
+   class="st8"
+   d="M857.8,1556.5v4.1H851v21.2h-5v-21.2h-6.8v-4.1H857.8z"
+   id="path212" />
+	<path
+   class="st8"
+   d="M876.5,1562.4c1.2,0.7,2.1,1.6,2.8,2.9s1,2.8,1,4.7v11.8h-5.1v-11.1c0-1.6-0.4-2.8-1.2-3.7s-1.9-1.3-3.3-1.3   c-1.4,0-2.5,0.4-3.3,1.3s-1.2,2.1-1.2,3.7v11.1h-5.1V1555h5.1v9.2c0.7-0.9,1.5-1.6,2.6-2.1s2.3-0.8,3.6-0.8   C874,1561.4,875.3,1561.7,876.5,1562.4L876.5,1562.4z"
+   id="path214" />
+	<path
+   class="st8"
+   d="M884.7,1566.2c0.8-1.6,1.9-2.8,3.3-3.6s2.9-1.3,4.7-1.3c1.5,0,2.8,0.3,3.9,0.9c1.1,0.6,2,1.4,2.7,2.3v-2.9h5.1   v20.1h-5.1v-2.9c-0.7,0.9-1.5,1.7-2.7,2.3s-2.5,0.9-4,0.9c-1.7,0-3.2-0.4-4.6-1.3c-1.4-0.9-2.5-2.1-3.3-3.7s-1.2-3.4-1.2-5.5   C883.5,1569.6,883.9,1567.8,884.7,1566.2L884.7,1566.2z M898.5,1568.5c-0.5-0.9-1.1-1.6-2-2s-1.7-0.7-2.7-0.7s-1.8,0.2-2.6,0.7   s-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.8,3.2c0.5,0.9,1.2,1.6,2,2.1s1.7,0.7,2.6,0.7c0.9,0,1.8-0.2,2.7-0.7s1.5-1.2,2-2   c0.5-0.9,0.7-1.9,0.7-3.2C899.3,1570.5,899,1569.4,898.5,1568.5L898.5,1568.5z"
+   id="path216" />
+	<path
+   class="st8"
+   d="M925.9,1563.6c1.5,1.5,2.2,3.6,2.2,6.3v11.8H923v-11.1c0-1.6-0.4-2.8-1.2-3.7s-1.9-1.3-3.3-1.3   c-1.4,0-2.5,0.4-3.3,1.3s-1.2,2.1-1.2,3.7v11.1h-5v-20.1h5.1v2.5c0.7-0.9,1.5-1.6,2.6-2.1c1-0.5,2.2-0.8,3.5-0.8   C922.5,1561.3,924.4,1562.1,925.9,1563.6L925.9,1563.6z"
+   id="path218" />
+	<path
+   class="st8"
+   d="M936.3,1580.8c-1.5-0.9-2.8-2.1-3.7-3.6c-0.9-1.6-1.3-3.4-1.3-5.4c0-2.1,0.5-3.9,1.3-5.4   c0.9-1.6,2.1-2.8,3.7-3.7s3.3-1.3,5.3-1.3c1.9,0,3.7,0.4,5.3,1.3s2.8,2.1,3.7,3.6c0.9,1.6,1.4,3.4,1.4,5.4c0,2.1-0.5,3.9-1.4,5.4   s-2.2,2.8-3.8,3.7s-3.3,1.3-5.3,1.3C939.6,1582,937.8,1581.6,936.3,1580.8L936.3,1580.8z M944.1,1576.9c0.8-0.4,1.5-1.1,1.9-2   c0.5-0.9,0.7-2,0.7-3.3c0-1.9-0.5-3.4-1.5-4.4s-2.2-1.5-3.7-1.5s-2.7,0.5-3.6,1.6c-1,1-1.5,2.5-1.5,4.4s0.5,3.4,1.4,4.4   s2.2,1.5,3.6,1.5C942.4,1577.6,943.3,1577.4,944.1,1576.9L944.1,1576.9z"
+   id="path220" />
+	<path
+   class="st8"
+   d="M958.6,1581.1c-1.3-0.6-2.3-1.4-3.1-2.4s-1.2-2.1-1.3-3.4h5.1c0.1,0.8,0.5,1.4,1.2,1.9s1.5,0.8,2.5,0.8   s1.7-0.2,2.3-0.6s0.8-0.9,0.8-1.5c0-0.7-0.3-1.1-1-1.5s-1.7-0.7-3.2-1.1s-2.7-0.7-3.7-1.1s-1.8-1-2.5-1.8s-1-1.9-1-3.2   c0-1.1,0.3-2.1,1-3.1s1.6-1.7,2.8-2.2s2.6-0.8,4.2-0.8c2.4,0,4.3,0.6,5.7,1.8c1.4,1.2,2.2,2.8,2.4,4.8h-4.9c-0.1-0.8-0.4-1.4-1-1.9   s-1.4-0.7-2.4-0.7c-0.9,0-1.6,0.2-2.1,0.5s-0.7,0.8-0.7,1.4c0,0.7,0.3,1.2,1,1.5s1.7,0.7,3.2,1.1s2.7,0.7,3.6,1.1   c0.9,0.4,1.8,1,2.5,1.8s1,1.9,1.1,3.2c0,1.2-0.3,2.2-1,3.1s-1.6,1.6-2.8,2.2c-1.2,0.5-2.6,0.8-4.2,0.8   C961.4,1582,959.9,1581.7,958.6,1581.1L958.6,1581.1z"
+   id="path222" />
+	<path
+   class="st8"
+   d="M973.2,1556.1h9.6v3h-2.9v9.8h-3.8v-9.8h-2.9L973.2,1556.1L973.2,1556.1z M1000.9,1556.1v12.8h-3.5l-0.1-8   l-3.3,8h-2.6l-3.3-8.3v8.3h-3.4v-12.8h5l3.1,8.2l3.3-8.2H1000.9L1000.9,1556.1z"
+   id="path224" />
+</g>
+<g
+   id="g238">
+	<path
+   class="st8"
+   d="M1289.8,561.6v4.1h-6.8v21.2h-5.1v-21.2h-6.8v-4.1H1289.8L1289.8,561.6z"
+   id="path228" />
+	<path
+   class="st8"
+   d="M1300.8,567.4c1.1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1   v-20.1h5.1v3.1C1298.9,568.8,1299.7,568,1300.8,567.4L1300.8,567.4z"
+   id="path230" />
+	<path
+   class="st8"
+   d="M1307.8,563.5c-0.6-0.6-0.9-1.3-0.9-2.1s0.3-1.5,0.9-2.1s1.3-0.8,2.2-0.8s1.6,0.3,2.2,0.8   c0.6,0.6,0.9,1.3,0.9,2.1s-0.3,1.5-0.9,2.1s-1.3,0.8-2.2,0.8S1308.4,564.1,1307.8,563.5z M1312.5,566.8v20.1h-5.1v-20.1H1312.5z"
+   id="path232" />
+	<path
+   class="st8"
+   d="M1325.6,582.2l5.1-15.4h5.4l-7.4,20.1h-6.2l-7.4-20.1h5.4L1325.6,582.2L1325.6,582.2z"
+   id="path234" />
+	<path
+   class="st8"
+   d="M1357.8,566.8l-12.4,29.6h-5.4l4.3-10l-8.1-19.6h5.7l5.2,14l5.3-14H1357.8L1357.8,566.8z"
+   id="path236" />
+</g>
+<g
+   id="g260">
+	<path
+   id="path1244"
+   class="st10"
+   d="M1312.8,464.5c-7.8-3.2-12.5-10-12.2-17.2l-16.7-8.7c-1.2,8.4,0.8,17.1,5.8,24.6   c5.3,8,13.1,14,23.2,17.5L1312.8,464.5L1312.8,464.5L1312.8,464.5z" />
+	<path
+   id="path1246"
+   class="st9"
+   d="M1313.4,481.6l-0.9-0.3c-10.1-3.5-18-9.4-23.5-17.8c-5.1-7.6-7.1-16.5-5.8-25l0.1-0.9l17.9,9.3   v0.3c-0.2,7.1,4.4,13.6,11.8,16.6l0.4,0.1V481.6L1313.4,481.6z M1284.4,439.6c-1,8,1.1,16.3,5.8,23.4c5.2,7.9,12.6,13.6,22,17   v-15.1c-7.6-3.2-12.3-9.9-12.2-17.2L1284.4,439.6L1284.4,439.6z" />
+	<path
+   id="path1248"
+   class="st10"
+   d="M1312.8,501.4v-18.7c-10.8-3.6-19.1-10-24.8-18.6c-5.4-8.1-7.4-17.5-5.9-26.5l-15.6-8.1   C1257.6,458.9,1277.6,490.2,1312.8,501.4z" />
+	<path
+   id="path1250"
+   class="st9"
+   d="M1313.4,502.2l-0.8-0.3c-17.2-5.5-31.4-15.9-40-29.4s-11-28.8-6.7-43.1l0.2-0.7l16.7,8.7   l-0.1,0.4c-1.5,8.9,0.6,18.1,5.8,26.1c5.8,8.7,14,14.9,24.5,18.3l0.4,0.1V502.2L1313.4,502.2L1313.4,502.2z M1266.9,430.5   c-8.3,28.9,11,58.8,45.3,70.1v-17.5c-10.6-3.6-18.9-9.8-24.7-18.7c-5.3-8-7.5-17.4-6.1-26.5L1266.9,430.5L1266.9,430.5z" />
+	<path
+   id="path1252"
+   class="st11"
+   d="M1315.1,482.6v18.9c34.6-11.5,55.3-42.7,46.6-71.7l-15.5,8.1c1.9,9.6,0.2,19-4.9,26.9   C1335.9,472.8,1326.6,478.9,1315.1,482.6L1315.1,482.6z" />
+	<path
+   id="path1254"
+   class="st9"
+   d="M1314.5,502.3v-20.1l0.4-0.1c11.8-3.7,20.7-9.8,25.8-17.6c5.1-7.7,6.8-16.9,4.8-26.5l-0.1-0.4   l16.6-8.7l0.2,0.7c8.7,28.9-11.9,60.7-46.9,72.4L1314.5,502.3L1314.5,502.3z M1315.7,483v17.6c33.6-11.6,53.4-42.1,45.5-70   l-14.4,7.5c1.8,9.7,0.1,19-5.1,26.9C1336.6,472.9,1327.6,479.1,1315.7,483z" />
+	<path
+   id="path1256"
+   class="st11"
+   d="M1327.7,447.4c0.1,7-4.5,13.2-12.6,17.1v16.3c10.8-3.5,19.5-9.4,24.5-16.9   c4.8-7.3,6.5-16.1,4.8-25.1L1327.7,447.4L1327.7,447.4z" />
+	<path
+   id="path1258"
+   class="st9"
+   d="M1314.5,481.6v-17.4l0.3-0.2c7.9-3.8,12.3-9.9,12.3-16.6v-0.3l17.8-9.2l0.2,0.8   c1.7,9.2,0,18-4.9,25.5c-5,7.5-13.5,13.5-24.8,17.2L1314.5,481.6L1314.5,481.6z M1315.7,464.9V480c10.6-3.6,18.6-9.3,23.3-16.4   c4.6-7,6.3-15.2,4.9-23.9l-15.6,8.1C1328.3,454.7,1323.7,460.9,1315.7,464.9L1315.7,464.9z" />
+	<path
+   id="path1260"
+   class="st12"
+   d="M1330.1,422.4c6.5,2.9,11.8,7.5,15.4,13.3c0.1,0.1,0.1,0.2,0.1,0.2l15.2-7.9   c-0.2-0.3-0.5-0.5-0.7-0.8c-5.6-8.1-12.9-14.2-21.9-18.2c-25.2-11.1-56.2-2.7-70.9,19l15.1,7.9   C1292.8,421,1313.5,415.1,1330.1,422.4L1330.1,422.4L1330.1,422.4z" />
+	<path
+   id="path1262"
+   class="st9"
+   d="M1345.4,436.7l-0.4-0.8c-3.5-5.7-8.7-10.2-15.1-13c-16.2-7.1-36.8-1.3-46.8,13.3l-0.3,0.5   l-16.2-8.5l0.3-0.5c14.9-21.9,46.4-30.4,71.8-19.2c9.1,4,16.5,10.2,22.1,18.4c0.2,0.3,0.4,0.5,0.6,0.8l0.5,0.5L1345.4,436.7   L1345.4,436.7z M1268.2,427.9l14.1,7.3c10.5-14.7,31.5-20.6,48.1-13.3c6.5,2.9,11.9,7.5,15.5,13.2l14-7.3c-0.1-0.1-0.2-0.2-0.3-0.4   c-5.5-8-12.8-14.1-21.6-17.9C1313.4,398.8,1282.9,406.8,1268.2,427.9L1268.2,427.9z" />
+	<path
+   id="path1264"
+   class="st12"
+   d="M1320.7,439.8c2.7,1.2,4.9,3.1,6.3,5.5c0.1,0.1,0.1,0.2,0.1,0.2l16.9-8.8   c-0.1-0.1-0.1-0.2-0.2-0.3c-3.3-5.5-8.4-9.9-14.5-12.6c-15.8-6.9-35.4-1.3-45.1,12.8l16.8,8.7   C1305.3,439.2,1313.7,436.7,1320.7,439.8L1320.7,439.8L1320.7,439.8z" />
+	<path
+   id="path1266"
+   class="st9"
+   d="M1326.9,446.4l-0.4-0.8c-1.4-2.3-3.5-4.2-6.1-5.3l0,0c-6.6-2.9-14.7-0.5-18.9,5.5l-0.3,0.5   l-17.9-9.3l0.3-0.5c10.1-14.5,29.8-20.1,46-13c6.3,2.8,11.4,7.2,14.8,12.8l0.4,0.8L1326.9,446.4L1326.9,446.4z M1314.4,437.9   c2.2,0,4.4,0.4,6.5,1.4l0,0c2.7,1.2,4.9,3.1,6.4,5.5l15.8-8.2c-3.3-5.3-8.2-9.5-14.1-12.1c-15.1-6.6-34.3-1.3-44,12.1l15.7,8.1   C1304,440.4,1309.2,437.9,1314.4,437.9L1314.4,437.9L1314.4,437.9z" />
+	<path
+   id="path1268"
+   class="st11"
+   d="M1381.2,419.4l-17.9,9.4c9.4,30.2-12.2,62.7-48.2,74.5v20.4l66.1-34.7V419.4L1381.2,419.4z" />
+	<path
+   id="path1270"
+   class="st9"
+   d="M1314.5,524.7v-21.8l0.4-0.1c36.1-11.7,57.1-44.1,47.9-73.8l-0.1-0.4l19.2-10.1v70.9l-0.3,0.2   L1314.5,524.7L1314.5,524.7z M1315.7,503.7v19l64.8-34.1v-68.2l-16.5,8.7C1373.2,459.1,1352,491.7,1315.7,503.7L1315.7,503.7   L1315.7,503.7z" />
+	<path
+   id="path1272"
+   class="st10"
+   d="M1246.9,419.4V489l65.9,34.7v-20.4c-36.7-11.4-57.6-44-48-74.5l-17.1-8.9L1246.9,419.4z" />
+	<path
+   id="path1274"
+   class="st9"
+   d="M1313.4,524.7l-67.2-35.4v-70.9l19.3,10l-0.1,0.4c-9.5,30.1,11.4,62.6,47.6,73.9l0.4,0.1   L1313.4,524.7L1313.4,524.7z M1247.5,488.6l64.6,34.1v-19c-36.3-11.5-57.4-44.2-48.1-74.7l-16.5-8.6V488.6L1247.5,488.6z" />
+	<path
+   id="path1276"
+   class="st12"
+   d="M1247.9,417.9l1.9,1l15.9,8.3c15.3-22.5,47.3-31.2,73.4-19.7c9.3,4.1,16.9,10.4,22.7,18.8   c0.2,0.3,0.4,0.6,0.7,0.9l17.8-9.2l-66.2-34.5L1247.9,417.9L1247.9,417.9z" />
+	<path
+   id="path1278"
+   class="st9"
+   d="M1265.9,428l-19.3-10l67.5-35.1l0.3,0.2l67.2,34.9l-19.2,10l-0.3-0.4c-0.3-0.3-0.6-0.6-0.8-0.9   c-5.7-8.3-13.2-14.6-22.4-18.6c-25.7-11.3-57.6-2.7-72.6,19.5L1265.9,428L1265.9,428z M1249.1,417.9l16.3,8.5   c15.5-22.3,47.9-30.9,73.9-19.4c9.4,4.1,17.1,10.5,22.9,19c0.1,0.1,0.2,0.3,0.3,0.4l16.3-8.5l-64.9-33.8L1249.1,417.9L1249.1,417.9   z" />
+	<path
+   id="path1280"
+   class="st13"
+   d="M1315,462.6c6.5-3.3,10.4-8.5,10.7-14.4c0,0,0-0.6,0-1.5c0-0.2-1.4-3.3-5.8-5.4   c-5.9-2.9-14.2-0.1-17.5,5.4c0,0-0.1,0.7,0,1.5c0.2,5.3,3.9,11.5,10.3,14.4l1.3,0.6L1315,462.6L1315,462.6z" />
+	<path
+   id="path1282"
+   class="st9"
+   d="M1313.9,463.8l-1.6-0.7c-7-3.1-10.4-9.7-10.6-14.9c0-0.9,0-1.6,0.1-1.6l0.1-0.2   c1.7-2.8,4.7-5,8.2-6.1c3.6-1.1,7.3-1,10.2,0.5c4.4,2.2,6.1,5.4,6.2,5.9c0.1,1,0,1.6,0,1.6c-0.3,6-4.3,11.5-11,14.9L1313.9,463.8   L1313.9,463.8z M1303,446.9c0,0.2-0.1,0.7,0,1.3c0.2,4.7,3.4,11,9.9,13.9l1,0.4l0.9-0.4c6.3-3.2,10.1-8.3,10.3-13.9   c0,0,0-0.6,0-1.5c-0.1-0.4-1.7-3.1-5.5-4.9c-2.6-1.3-6-1.4-9.2-0.4C1307.2,442.4,1304.5,444.4,1303,446.9L1303,446.9L1303,446.9z" />
+</g>
+<g
+   id="g284">
+	<path
+   class="st8"
+   d="M511.8,1248.7c-2-1.1-3.5-2.7-4.7-4.6s-1.7-4.2-1.7-6.7s0.6-4.7,1.7-6.7c1.2-2,2.7-3.5,4.7-4.6   s4.2-1.7,6.5-1.7s4.6,0.6,6.5,1.7s3.5,2.7,4.7,4.6c1.2,2,1.7,4.2,1.7,6.7s-0.6,4.7-1.7,6.7c-1.2,2-2.7,3.5-4.7,4.6   s-4.2,1.7-6.5,1.7S513.8,1249.8,511.8,1248.7L511.8,1248.7z M522.3,1244.8c1.2-0.7,2.1-1.7,2.7-3c0.7-1.3,1-2.8,1-4.5   s-0.3-3.2-1-4.4c-0.7-1.3-1.6-2.2-2.7-2.9s-2.5-1-4-1s-2.9,0.3-4,1s-2.1,1.7-2.7,2.9c-0.6,1.3-1,2.8-1,4.4s0.3,3.2,1,4.5   c0.6,1.3,1.6,2.3,2.7,3c1.2,0.7,2.5,1,4,1S521.2,1245.5,522.3,1244.8z"
+   id="path262" />
+	<path
+   class="st8"
+   d="M542.5,1230.6c1.2-0.6,2.5-0.9,3.9-0.9c1.7,0,3.3,0.4,4.7,1.3c1.4,0.8,2.5,2.1,3.3,3.6   c0.8,1.6,1.2,3.4,1.2,5.4s-0.4,3.9-1.2,5.5s-1.9,2.8-3.3,3.7s-2.9,1.3-4.7,1.3c-1.5,0-2.8-0.3-3.9-0.9c-1.1-0.6-2-1.4-2.7-2.3v12.4   h-5.1V1230h5.1v2.9C540.4,1232,541.3,1231.2,542.5,1230.6L542.5,1230.6z M549.6,1236.8c-0.5-0.9-1.2-1.6-2-2s-1.7-0.7-2.6-0.7   s-1.8,0.2-2.6,0.7s-1.5,1.2-2,2.1s-0.7,1.9-0.7,3.2s0.2,2.3,0.7,3.2c0.5,0.9,1.2,1.6,2,2.1s1.7,0.7,2.6,0.7s1.8-0.2,2.6-0.7   s1.5-1.2,2-2.1s0.7-2,0.7-3.2S550.1,1237.7,549.6,1236.8L549.6,1236.8z"
+   id="path264" />
+	<path
+   class="st8"
+   d="M577.4,1241.6h-14.7c0.1,1.4,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5c-0.6,1.9-1.7,3.5-3.3,4.8   c-1.6,1.2-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4s0.4-3.9,1.3-5.5   c0.8-1.6,2-2.8,3.5-3.6c1.5-0.8,3.3-1.3,5.3-1.3s3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.2,5.2   C577.6,1240.3,577.5,1241,577.4,1241.6L577.4,1241.6z M572.3,1238.1c0-1.3-0.5-2.3-1.4-3.1c-0.9-0.8-2-1.2-3.4-1.2   c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2H572.3L572.3,1238.1z"
+   id="path266" />
+	<path
+   class="st8"
+   d="M597.8,1231.9c1.5,1.5,2.2,3.6,2.2,6.3v11.8h-5v-11c0-1.6-0.4-2.8-1.2-3.7s-1.9-1.3-3.3-1.3s-2.5,0.4-3.3,1.3   s-1.2,2.1-1.2,3.7v11.1h-5.1V1230h5.1v2.5c0.7-0.9,1.5-1.6,2.6-2.1c1-0.5,2.2-0.7,3.5-0.7C594.4,1229.7,596.4,1230.4,597.8,1231.9   L597.8,1231.9z"
+   id="path268" />
+	<path
+   class="st8"
+   d="M608.5,1249.4c-1.4-0.6-2.5-1.5-3.3-2.6s-1.2-2.5-1.3-4h5.4c0.1,1,0.4,1.9,1.1,2.5s1.6,0.9,2.7,0.9   s2.1-0.3,2.8-0.8c0.7-0.6,1-1.3,1-2.2c0-0.8-0.2-1.4-0.7-1.8s-1-0.9-1.7-1.1c-0.7-0.3-1.6-0.6-2.8-0.9c-1.6-0.5-3-1-4-1.4   c-1-0.5-1.9-1.2-2.7-2.1c-0.7-1-1.1-2.2-1.1-3.8c0-1.5,0.4-2.8,1.1-3.9c0.8-1.1,1.8-2,3.2-2.6c1.3-0.6,2.9-0.9,4.6-0.9   c2.6,0,4.7,0.6,6.4,1.9s2.5,3,2.7,5.3h-5.6c0-0.9-0.4-1.6-1.1-2.2s-1.6-0.8-2.7-0.8c-1,0-1.8,0.2-2.4,0.8c-0.6,0.5-0.9,1.2-0.9,2.2   c0,0.7,0.2,1.2,0.7,1.7s1,0.8,1.7,1.1c0.7,0.3,1.6,0.6,2.8,1c1.6,0.5,3,1,4,1.4c1,0.5,1.9,1.2,2.7,2.2s1.1,2.2,1.1,3.8   c0,1.3-0.3,2.6-1,3.8s-1.7,2.1-3.1,2.8c-1.3,0.7-3,1-4.8,1C611.5,1250.3,609.9,1250,608.5,1249.4L608.5,1249.4z"
+   id="path270" />
+	<path
+   class="st8"
+   d="M644.8,1241.6h-14.7c0.1,1.4,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5c-0.6,1.9-1.7,3.5-3.3,4.8   c-1.6,1.2-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4s0.4-3.9,1.3-5.5   c0.8-1.6,2-2.8,3.5-3.6c1.5-0.8,3.3-1.3,5.3-1.3s3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.2,5.2   C644.9,1240.3,644.9,1241,644.8,1241.6L644.8,1241.6z M639.7,1238.1c0-1.3-0.5-2.3-1.4-3.1c-0.9-0.8-2-1.2-3.4-1.2   c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2H639.7L639.7,1238.1z"
+   id="path272" />
+	<path
+   class="st8"
+   d="M648.2,1234.6c0.8-1.6,1.9-2.8,3.3-3.6s2.9-1.3,4.7-1.3c1.5,0,2.8,0.3,3.9,0.9c1.1,0.6,2,1.4,2.7,2.3v-2.9h5.1   v20.1h-5.1v-2.9c-0.7,0.9-1.5,1.7-2.7,2.3s-2.5,0.9-4,0.9c-1.7,0-3.2-0.4-4.6-1.3c-1.4-0.9-2.5-2.1-3.3-3.7s-1.2-3.4-1.2-5.5   S647.4,1236.1,648.2,1234.6L648.2,1234.6z M662,1236.9c-0.5-0.9-1.1-1.6-2-2s-1.7-0.7-2.7-0.7s-1.8,0.2-2.6,0.7s-1.5,1.1-1.9,2   c-0.5,0.9-0.7,1.9-0.7,3.1s0.2,2.3,0.7,3.2c0.5,0.9,1.2,1.6,2,2.1s1.7,0.7,2.6,0.7s1.8-0.2,2.7-0.7s1.5-1.2,2-2s0.7-1.9,0.7-3.2   S662.5,1237.7,662,1236.9L662,1236.9z"
+   id="path274" />
+	<path
+   class="st8"
+   d="M680.1,1230.6c1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1v-20   h5.1v3.1C678.2,1232,679.1,1231.2,680.1,1230.6L680.1,1230.6z"
+   id="path276" />
+	<path
+   class="st8"
+   d="M686.7,1234.6c0.8-1.6,2-2.8,3.5-3.6s3.2-1.3,5.2-1.3c2.5,0,4.5,0.6,6.2,1.9s2.7,3,3.3,5.2h-5.5   c-0.3-0.9-0.8-1.6-1.5-2.1s-1.5-0.7-2.6-0.7c-1.5,0-2.6,0.5-3.5,1.6c-0.8,1.1-1.3,2.5-1.3,4.5s0.4,3.4,1.3,4.4   c0.8,1.1,2,1.6,3.5,1.6c2,0,3.4-0.9,4-2.8h5.5c-0.6,2.2-1.7,3.9-3.3,5.2c-1.6,1.3-3.7,1.9-6.2,1.9c-1.9,0-3.7-0.4-5.2-1.3   s-2.7-2.1-3.5-3.6c-0.8-1.6-1.3-3.4-1.3-5.5S685.9,1236.1,686.7,1234.6L686.7,1234.6z"
+   id="path278" />
+	<path
+   class="st8"
+   d="M723.6,1230.7c1.2,0.7,2.1,1.6,2.8,2.9s1,2.8,1,4.7v11.8h-5.1V1239c0-1.6-0.4-2.8-1.2-3.7s-1.9-1.3-3.3-1.3   s-2.5,0.4-3.3,1.3s-1.2,2.1-1.2,3.7v11.1h-5.1v-26.8h5.1v9.2c0.7-0.9,1.5-1.6,2.6-2.1s2.3-0.7,3.6-0.7   C721.1,1229.7,722.4,1230,723.6,1230.7L723.6,1230.7z"
+   id="path280" />
+	<path
+   class="st8"
+   d="M742.7,1225.3c1.2,0.7,2.1,1.6,2.7,2.7c0.7,1.2,1,2.5,1,4s-0.3,2.8-1,3.9c-0.7,1.2-1.6,2.1-2.7,2.7s-2.5,1-4,1   s-2.8-0.3-4-1s-2.1-1.6-2.8-2.7s-1-2.5-1-3.9s0.3-2.8,1-4s1.6-2.1,2.8-2.7c1.2-0.7,2.5-1,4-1S741.5,1224.7,742.7,1225.3z    M742.9,1236.3c1-1.1,1.6-2.5,1.6-4.2s-0.5-3.2-1.6-4.3c-1-1.1-2.5-1.6-4.2-1.6s-3.1,0.5-4.2,1.6c-1,1.1-1.6,2.5-1.6,4.3   s0.5,3.2,1.6,4.2c1,1.1,2.4,1.6,4.2,1.6S741.8,1237.4,742.9,1236.3z M741.7,1232c-0.2,0.4-0.6,0.7-1.1,0.9l1.9,3h-2.8l-1.6-2.7H738   v2.7h-2.4v-7.8h3.8c0.8,0,1.5,0.2,2,0.7s0.8,1.1,0.8,1.8C742.1,1231.2,742,1231.6,741.7,1232L741.7,1232z M737.9,1231.3h1.2   c0.2,0,0.3-0.1,0.4-0.1c0.1-0.1,0.2-0.2,0.2-0.4c0-0.4-0.2-0.5-0.6-0.5h-1.2L737.9,1231.3L737.9,1231.3z"
+   id="path282" />
+</g>
+<g
+   id="g302">
+	<path
+   class="st8"
+   d="M295.2,1563.9c-0.6-1.1-1.4-1.9-2.4-2.4c-1-0.6-2.2-0.8-3.5-0.8c-1.5,0-2.8,0.3-4,1s-2.1,1.6-2.7,2.9   s-1,2.7-1,4.3s0.3,3.2,1,4.4c0.7,1.3,1.6,2.2,2.8,2.9s2.6,1,4.1,1c1.9,0,3.5-0.5,4.8-1.5s2-2.5,2.4-4.3H288v-3.9h13.7v4.4   c-0.3,1.8-1.1,3.4-2.2,4.9s-2.5,2.7-4.3,3.6s-3.7,1.4-5.9,1.4c-2.4,0-4.6-0.6-6.6-1.7s-3.5-2.6-4.6-4.6s-1.7-4.2-1.7-6.7   s0.6-4.7,1.7-6.7s2.7-3.5,4.6-4.6c2-1.1,4.2-1.7,6.6-1.7c2.9,0,5.3,0.7,7.4,2.1s3.5,3.3,4.4,5.9L295.2,1563.9L295.2,1563.9z"
+   id="path286" />
+	<path
+   class="st8"
+   d="M312.7,1562.1c1-0.6,2.2-0.9,3.6-0.9v5.3H315c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1v-20.1   h5.1v3.1C310.8,1563.6,311.7,1562.7,312.7,1562.1z"
+   id="path288" />
+	<path
+   class="st8"
+   d="M319.3,1566.1c0.8-1.6,1.9-2.8,3.3-3.6c1.4-0.8,2.9-1.3,4.7-1.3c1.5,0,2.8,0.3,3.9,0.9s2,1.4,2.7,2.3v-2.9h5.1   v20.1h-5.1v-2.9c-0.6,0.9-1.5,1.7-2.7,2.3c-1.1,0.6-2.5,0.9-4,0.9c-1.7,0-3.2-0.4-4.6-1.3s-2.5-2.1-3.3-3.7s-1.2-3.4-1.2-5.5   S318.5,1567.6,319.3,1566.1L319.3,1566.1z M333.2,1568.4c-0.5-0.9-1.1-1.6-2-2c-0.8-0.5-1.7-0.7-2.6-0.7s-1.8,0.2-2.6,0.7   s-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.7,3.2c0.5,0.9,1.1,1.6,2,2.1c0.8,0.5,1.7,0.7,2.6,0.7s1.8-0.2,2.6-0.7s1.5-1.2,2-2   c0.5-0.9,0.7-1.9,0.7-3.2S333.7,1569.2,333.2,1568.4L333.2,1568.4z"
+   id="path290" />
+	<path
+   class="st8"
+   d="M352.8,1565.7h-3.5v15.9h-5.1v-15.9h-2.3v-4.2h2.3v-1c0-2.5,0.7-4.3,2.1-5.4c1.4-1.2,3.5-1.7,6.4-1.6v4.3   c-1.2,0-2.1,0.2-2.6,0.6s-0.7,1.2-0.7,2.4v0.8h3.5L352.8,1565.7L352.8,1565.7z"
+   id="path292" />
+	<path
+   class="st8"
+   d="M355.7,1566.1c0.8-1.6,1.9-2.8,3.3-3.6c1.4-0.8,2.9-1.3,4.7-1.3c1.5,0,2.8,0.3,3.9,0.9s2,1.4,2.7,2.3v-2.9h5.1   v20.1h-5.1v-2.9c-0.6,0.9-1.5,1.7-2.7,2.3c-1.1,0.6-2.5,0.9-4,0.9c-1.7,0-3.2-0.4-4.6-1.3s-2.5-2.1-3.3-3.7s-1.2-3.4-1.2-5.5   S354.9,1567.6,355.7,1566.1L355.7,1566.1z M369.5,1568.4c-0.5-0.9-1.1-1.6-2-2c-0.8-0.5-1.7-0.7-2.6-0.7s-1.8,0.2-2.6,0.7   s-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.7,3.2c0.5,0.9,1.1,1.6,2,2.1c0.8,0.5,1.7,0.7,2.6,0.7s1.8-0.2,2.6-0.7s1.5-1.2,2-2   c0.5-0.9,0.7-1.9,0.7-3.2S370,1569.2,369.5,1568.4L369.5,1568.4z"
+   id="path294" />
+	<path
+   class="st8"
+   d="M396.9,1563.5c1.5,1.5,2.2,3.6,2.2,6.3v11.8H394v-11.1c0-1.6-0.4-2.8-1.2-3.7s-1.9-1.3-3.3-1.3   s-2.5,0.4-3.3,1.3s-1.2,2.1-1.2,3.7v11.1h-5v-20.1h5.1v2.5c0.7-0.9,1.5-1.6,2.6-2.1s2.2-0.7,3.5-0.7   C393.5,1561.2,395.4,1562,396.9,1563.5L396.9,1563.5z"
+   id="path296" />
+	<path
+   class="st8"
+   d="M403.5,1566.1c0.8-1.6,1.9-2.8,3.3-3.6c1.4-0.8,2.9-1.3,4.7-1.3c1.5,0,2.8,0.3,3.9,0.9s2,1.4,2.7,2.3v-2.9h5.1   v20.1h-5.1v-2.9c-0.6,0.9-1.5,1.7-2.7,2.3c-1.1,0.6-2.5,0.9-4,0.9c-1.7,0-3.2-0.4-4.6-1.3s-2.5-2.1-3.3-3.7s-1.2-3.4-1.2-5.5   S402.7,1567.6,403.5,1566.1L403.5,1566.1z M417.4,1568.4c-0.5-0.9-1.1-1.6-2-2c-0.8-0.5-1.7-0.7-2.6-0.7s-1.8,0.2-2.6,0.7   s-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.7,3.2c0.5,0.9,1.1,1.6,2,2.1c0.8,0.5,1.7,0.7,2.6,0.7s1.8-0.2,2.6-0.7s1.5-1.2,2-2   c0.5-0.9,0.7-1.9,0.7-3.2S417.9,1569.2,417.4,1568.4L417.4,1568.4z"
+   id="path298" />
+	<path
+   class="st8"
+   d="M438.6,1556.9c1.2,0.7,2.1,1.6,2.7,2.7s1,2.5,1,4s-0.3,2.8-1,3.9c-0.6,1.2-1.6,2.1-2.7,2.7s-2.5,1-4,1   s-2.8-0.3-4-1s-2.1-1.6-2.8-2.7s-1-2.5-1-3.9s0.3-2.8,1-4s1.6-2.1,2.8-2.7c1.2-0.7,2.5-1,4-1S437.5,1556.2,438.6,1556.9z    M438.9,1567.8c1-1.1,1.6-2.5,1.6-4.2s-0.5-3.2-1.6-4.3c-1-1.1-2.5-1.6-4.2-1.6s-3.1,0.5-4.2,1.6c-1,1.1-1.6,2.5-1.6,4.3   s0.5,3.2,1.6,4.2c1,1.1,2.4,1.6,4.2,1.6S437.8,1568.9,438.9,1567.8z M437.7,1563.5c-0.2,0.4-0.6,0.7-1.1,0.9l1.9,3h-2.8l-1.6-2.7   h-0.2v2.7h-2.4v-7.8h3.8c0.9,0,1.5,0.2,2,0.7s0.8,1.1,0.8,1.8C438.1,1562.7,438,1563.1,437.7,1563.5L437.7,1563.5z M433.9,1562.8   h1.2c0.2,0,0.3-0.1,0.4-0.1c0.1-0.1,0.2-0.2,0.2-0.4c0-0.4-0.2-0.5-0.6-0.5h-1.2V1562.8z"
+   id="path300" />
+</g>
+<g
+   id="g328">
+	<path
+   class="st8"
+   d="M1091.1,1577.1H1081l-1.7,4.8h-5.3l9.1-25.3h5.9l9.1,25.3h-5.4L1091.1,1577.1L1091.1,1577.1z M1089.7,1573.1   l-3.7-10.6l-3.7,10.6H1089.7L1089.7,1573.1z"
+   id="path304" />
+	<path
+   class="st8"
+   d="M1106.2,1555.1v26.8h-5.1v-26.8H1106.2L1106.2,1555.1z"
+   id="path306" />
+	<path
+   class="st8"
+   d="M1129.4,1573.4h-14.7c0.1,1.4,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5   c-0.6,1.9-1.7,3.5-3.3,4.8s-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6s-1.3-3.4-1.3-5.4c0-2.1,0.4-3.9,1.3-5.5   c0.8-1.6,2-2.8,3.6-3.6s3.3-1.3,5.3-1.3c1.9,0,3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.3,5.2   C1129.6,1572.2,1129.5,1572.8,1129.4,1573.4L1129.4,1573.4z M1124.3,1570c0-1.3-0.5-2.3-1.4-3.1c-0.9-0.8-2-1.2-3.4-1.2   c-1.3,0-2.3,0.4-3.2,1.2c-0.9,0.8-1.4,1.8-1.6,3.2L1124.3,1570L1124.3,1570z"
+   id="path308" />
+	<path
+   class="st8"
+   d="M1140.5,1562.4c1.1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1   v-20.1h5.1v3.1C1138.6,1563.9,1139.5,1563,1140.5,1562.4L1140.5,1562.4z"
+   id="path310" />
+	<path
+   class="st8"
+   d="M1153.1,1566v9.7c0,0.7,0.2,1.2,0.5,1.5s0.9,0.4,1.7,0.4h2.4v4.3h-3.2c-4.3,0-6.4-2.1-6.4-6.2v-9.7h-2.4v-4.2   h2.4v-5h5.1v5h4.5v4.2L1153.1,1566L1153.1,1566z"
+   id="path312" />
+	<path
+   class="st8"
+   d="M1188.5,1556.5v25.3h-5.1v-16.5l-6.8,16.5h-3.8l-6.8-16.4v16.5h-5.1v-25.3h5.8l8.1,18.8l8-18.8L1188.5,1556.5   L1188.5,1556.5z"
+   id="path314" />
+	<path
+   class="st8"
+   d="M1193.1,1566.3c0.8-1.6,1.9-2.8,3.3-3.6s2.9-1.3,4.7-1.3c1.5,0,2.8,0.3,3.9,0.9s2,1.4,2.7,2.3v-2.9h5.1v20.1   h-5.1v-2.9c-0.7,0.9-1.6,1.7-2.7,2.3c-1.2,0.6-2.5,0.9-4,0.9c-1.7,0-3.2-0.4-4.6-1.3s-2.5-2.1-3.3-3.7s-1.2-3.4-1.2-5.5   C1191.9,1569.7,1192.3,1567.9,1193.1,1566.3L1193.1,1566.3z M1206.9,1568.6c-0.5-0.9-1.1-1.6-2-2s-1.7-0.7-2.7-0.7   c-0.9,0-1.8,0.2-2.6,0.7c-0.8,0.5-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.8,3.2c0.5,0.9,1.2,1.6,2,2.1s1.7,0.7,2.6,0.7   s1.8-0.2,2.7-0.7s1.5-1.2,2-2c0.5-0.9,0.7-1.9,0.7-3.2S1207.4,1569.5,1206.9,1568.6L1206.9,1568.6z"
+   id="path316" />
+	<path
+   class="st8"
+   d="M1234.3,1563.7c1.5,1.5,2.2,3.6,2.2,6.3v11.8h-5.1v-11.1c0-1.6-0.4-2.8-1.2-3.7s-1.9-1.3-3.3-1.3   s-2.5,0.4-3.3,1.3s-1.2,2.1-1.2,3.7v11.1h-5.1v-20.1h5.1v2.5c0.7-0.9,1.5-1.6,2.6-2.1s2.2-0.8,3.5-0.8   C1230.9,1561.4,1232.8,1562.2,1234.3,1563.7L1234.3,1563.7z"
+   id="path318" />
+	<path
+   class="st8"
+   d="M1240.9,1566.2c0.8-1.6,1.9-2.8,3.3-3.6s2.9-1.3,4.7-1.3c1.5,0,2.8,0.3,3.9,0.9s2,1.4,2.7,2.3v-2.9h5.1v20.1   h-5.1v-2.9c-0.7,0.9-1.6,1.7-2.7,2.3s-2.5,0.9-4,0.9c-1.7,0-3.2-0.4-4.6-1.3s-2.5-2.1-3.3-3.7s-1.2-3.4-1.2-5.5   C1239.7,1569.6,1240.1,1567.8,1240.9,1566.2L1240.9,1566.2z M1254.8,1568.5c-0.5-0.9-1.1-1.6-2-2s-1.7-0.7-2.7-0.7   c-0.9,0-1.8,0.2-2.6,0.7c-0.8,0.5-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.8,3.2c0.5,0.9,1.2,1.6,2,2.1s1.7,0.7,2.6,0.7   s1.8-0.2,2.7-0.7s1.5-1.2,2-2c0.5-0.9,0.7-1.9,0.7-3.2S1255.2,1569.4,1254.8,1568.5L1254.8,1568.5z"
+   id="path320" />
+	<path
+   class="st8"
+   d="M1277,1562.2c1.1,0.6,2,1.4,2.7,2.3v-2.9h5.1v20.2c0,1.9-0.4,3.5-1.1,5c-0.8,1.5-1.9,2.6-3.4,3.5   s-3.3,1.3-5.4,1.3c-2.8,0-5.2-0.7-7-2s-2.9-3.1-3.1-5.4h5c0.3,0.9,0.8,1.6,1.7,2.2c0.9,0.5,1.9,0.8,3.2,0.8c1.5,0,2.7-0.4,3.6-1.3   s1.4-2.2,1.4-4v-3.1c-0.7,0.9-1.6,1.7-2.7,2.4c-1.2,0.6-2.5,0.9-3.9,0.9c-1.7,0-3.2-0.4-4.6-1.3s-2.5-2.1-3.3-3.7s-1.2-3.4-1.2-5.5   c0-2,0.4-3.8,1.2-5.4c0.8-1.6,1.9-2.8,3.3-3.6s2.9-1.3,4.7-1.3C1274.6,1561.3,1275.9,1561.6,1277,1562.2L1277,1562.2z M1279,1568.5   c-0.5-0.9-1.1-1.6-2-2s-1.7-0.7-2.7-0.7s-1.8,0.2-2.6,0.7c-0.8,0.5-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.8,3.2   c0.5,0.9,1.2,1.6,2,2.1s1.7,0.7,2.6,0.7s1.8-0.2,2.7-0.7c0.8-0.5,1.5-1.2,2-2c0.5-0.9,0.7-1.9,0.7-3.2   C1279.7,1570.5,1279.5,1569.4,1279,1568.5L1279,1568.5z"
+   id="path322" />
+	<path
+   class="st8"
+   d="M1308,1573.2h-14.7c0.1,1.4,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5c-0.6,1.9-1.7,3.5-3.3,4.8   s-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4c0-2.1,0.4-3.9,1.3-5.5c0.8-1.6,2-2.8,3.6-3.6   s3.3-1.3,5.3-1.3c1.9,0,3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.3,5.2C1308.1,1572,1308.1,1572.6,1308,1573.2L1308,1573.2z    M1302.8,1569.8c0-1.3-0.5-2.3-1.4-3.1c-0.9-0.8-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.2c-0.9,0.8-1.4,1.8-1.6,3.2L1302.8,1569.8   L1302.8,1569.8z"
+   id="path324" />
+	<path
+   class="st8"
+   d="M1319.1,1562.2c1.1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1   v-20.1h5.1v3.1C1317.2,1563.6,1318,1562.8,1319.1,1562.2L1319.1,1562.2z"
+   id="path326" />
+</g>
+<g
+   id="g342">
+	<path
+   class="st8"
+   d="M330.2,892.4l-9.3,25.3h-6.2l-9.3-25.3h5.4l7,20.1l6.9-20.1H330.2L330.2,892.4z"
+   id="path330" />
+	<path
+   class="st8"
+   d="M351.4,909.2h-14.7c0.1,1.5,0.6,2.6,1.5,3.4c0.9,0.8,2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5   c-0.6,1.9-1.7,3.5-3.3,4.8s-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3c-1.5-0.9-2.7-2.1-3.6-3.6s-1.3-3.4-1.3-5.4s0.4-3.9,1.3-5.5   s2-2.8,3.5-3.6s3.3-1.3,5.3-1.3s3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.2,5.2C351.5,908,351.5,908.6,351.4,909.2L351.4,909.2z    M346.3,905.8c0-1.3-0.5-2.3-1.4-3.1s-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2H346.3L346.3,905.8z"
+   id="path332" />
+	<path
+   class="st8"
+   d="M359.9,890.9v26.8h-5.1v-26.8H359.9z"
+   id="path334" />
+	<path
+   class="st8"
+   d="M383.1,909.2h-14.7c0.1,1.5,0.6,2.6,1.5,3.4c0.9,0.8,2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5   c-0.6,1.9-1.7,3.5-3.3,4.8c-1.6,1.2-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3c-1.5-0.9-2.7-2.1-3.6-3.6s-1.3-3.4-1.3-5.4   s0.4-3.9,1.3-5.5s2-2.8,3.5-3.6s3.3-1.3,5.3-1.3s3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.2,5.2C383.2,908,383.2,908.6,383.1,909.2   L383.1,909.2z M378,905.8c0-1.3-0.5-2.3-1.4-3.1s-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2H378L378,905.8z"
+   id="path336" />
+	<path
+   class="st8"
+   d="M394.2,898.3c1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1v-20.1   h5.1v3.1C392.3,899.7,393.2,898.9,394.2,898.3L394.2,898.3z"
+   id="path338" />
+	<path
+   class="st8"
+   d="M404.6,916.8c-1.5-0.9-2.8-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4s0.5-3.9,1.4-5.4c0.9-1.6,2.1-2.8,3.7-3.6   c1.6-0.9,3.3-1.3,5.3-1.3s3.7,0.4,5.3,1.3s2.8,2.1,3.7,3.6s1.4,3.4,1.4,5.4s-0.5,3.9-1.4,5.4s-2.2,2.8-3.8,3.6   c-1.6,0.9-3.4,1.3-5.3,1.3S406.1,917.6,404.6,916.8L404.6,916.8z M412.4,913c0.8-0.5,1.5-1.1,1.9-2s0.7-2,0.7-3.3   c0-1.9-0.5-3.4-1.5-4.4s-2.2-1.5-3.7-1.5s-2.7,0.5-3.6,1.5c-1,1-1.5,2.5-1.5,4.4s0.5,3.4,1.4,4.4c1,1,2.2,1.5,3.6,1.5   C410.7,913.6,411.6,913.4,412.4,913L412.4,913z"
+   id="path340" />
+</g>
+<g
+   id="g356">
+	<path
+   class="st8"
+   d="M578.3,917.7l-5.6-9.9h-2.4v9.9h-5.1v-25.3h9.5c2,0,3.6,0.3,5,1s2.4,1.6,3.1,2.8s1,2.5,1,3.9   c0,1.7-0.5,3.2-1.5,4.5s-2.4,2.3-4.3,2.8l6.1,10.3H578.3L578.3,917.7z M570.4,904.1h4.2c1.4,0,2.4-0.3,3.1-1c0.7-0.7,1-1.6,1-2.8   s-0.3-2.1-1-2.7s-1.7-1-3.1-1h-4.2V904.1L570.4,904.1z"
+   id="path344" />
+	<path
+   class="st8"
+   d="M588.1,902.2c0.8-1.6,2-2.8,3.5-3.6s3.2-1.3,5.2-1.3c2.5,0,4.5,0.6,6.2,1.9s2.7,3,3.3,5.2h-5.5   c-0.3-0.9-0.8-1.5-1.5-2s-1.5-0.7-2.6-0.7c-1.5,0-2.6,0.5-3.5,1.6c-0.8,1-1.3,2.5-1.3,4.5s0.4,3.4,1.3,4.4c0.8,1,2,1.6,3.5,1.6   c2,0,3.4-0.9,4-2.8h5.5c-0.6,2.2-1.7,3.9-3.3,5.2s-3.7,1.9-6.2,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.5-3.6   c-0.8-1.6-1.3-3.4-1.3-5.5S587.3,903.8,588.1,902.2L588.1,902.2z"
+   id="path346" />
+	<path
+   class="st8"
+   d="M614.7,890.9v26.8h-5.1v-26.8H614.7z"
+   id="path348" />
+	<path
+   class="st8"
+   d="M623.1,916.8c-1.5-0.9-2.8-2.1-3.6-3.6s-1.3-3.4-1.3-5.4s0.5-3.9,1.4-5.4s2.2-2.8,3.7-3.6   c1.6-0.9,3.3-1.3,5.3-1.3s3.7,0.4,5.3,1.3s2.8,2.1,3.7,3.6s1.4,3.4,1.4,5.4s-0.5,3.9-1.4,5.4c-0.9,1.6-2.2,2.8-3.8,3.6   s-3.3,1.3-5.3,1.3S624.6,917.6,623.1,916.8L623.1,916.8z M630.9,913c0.8-0.5,1.5-1.1,1.9-2s0.7-2,0.7-3.3c0-1.9-0.5-3.4-1.5-4.4   s-2.2-1.5-3.7-1.5s-2.7,0.5-3.6,1.5c-1,1-1.5,2.5-1.5,4.4s0.5,3.4,1.4,4.4c1,1,2.2,1.5,3.6,1.5C629.2,913.6,630.1,913.4,630.9,913   L630.9,913z"
+   id="path350" />
+	<path
+   class="st8"
+   d="M659.1,899.6c1.5,1.5,2.2,3.6,2.2,6.3v11.8h-5.1v-11.1c0-1.6-0.4-2.8-1.2-3.7s-1.9-1.3-3.3-1.3   s-2.5,0.4-3.3,1.3s-1.2,2.1-1.2,3.7v11.1h-5.1v-20.1h5.1v2.5c0.7-0.9,1.5-1.5,2.6-2c1-0.5,2.2-0.7,3.5-0.7   C655.7,897.4,657.6,898.1,659.1,899.6L659.1,899.6z"
+   id="path352" />
+	<path
+   class="st8"
+   d="M684.3,909.2h-14.7c0.1,1.5,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5c-0.6,1.9-1.7,3.5-3.3,4.8   c-1.6,1.2-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3c-1.5-0.9-2.7-2.1-3.6-3.6s-1.3-3.4-1.3-5.4s0.4-3.9,1.3-5.5   c0.8-1.6,2-2.8,3.5-3.6s3.3-1.3,5.3-1.3s3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.2,5.2C684.4,908,684.4,908.6,684.3,909.2   L684.3,909.2z M679.2,905.8c0-1.3-0.5-2.3-1.4-3.1s-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2H679.2   L679.2,905.8z"
+   id="path354" />
+</g>
+<g
+   id="g378">
+	<path
+   class="st8"
+   d="M779,257l-5.6-9.9H771v9.9h-5v-25.3h9.5c2,0,3.6,0.3,5,1s2.4,1.6,3.1,2.8s1,2.5,1,3.9c0,1.7-0.5,3.2-1.4,4.5   c-1,1.3-2.4,2.3-4.3,2.8L785,257H779L779,257z M771,243.4h4.2c1.4,0,2.4-0.3,3.1-1c0.7-0.7,1-1.6,1-2.8s-0.3-2.1-1-2.7   s-1.7-1-3.1-1H771V243.4L771,243.4z"
+   id="path358" />
+	<path
+   class="st8"
+   d="M788.7,241.5c0.8-1.6,1.9-2.8,3.3-3.6s2.9-1.3,4.7-1.3c1.5,0,2.8,0.3,3.9,0.9c1.1,0.6,2,1.4,2.7,2.3v-2.9h5.1   V257h-5.1v-2.9c-0.7,0.9-1.5,1.7-2.7,2.3c-1.2,0.6-2.5,0.9-4,0.9c-1.7,0-3.2-0.4-4.6-1.3c-1.4-0.9-2.5-2.1-3.3-3.7   c-0.8-1.6-1.2-3.4-1.2-5.5C787.5,244.9,787.9,243.1,788.7,241.5L788.7,241.5z M802.6,243.8c-0.5-0.9-1.1-1.6-2-2s-1.7-0.7-2.7-0.7   s-1.8,0.2-2.6,0.7s-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.8,3.2c0.5,0.9,1.2,1.6,2,2.1s1.7,0.7,2.6,0.7c0.9,0,1.8-0.2,2.7-0.7   c0.8-0.5,1.5-1.1,2-2s0.7-1.9,0.7-3.2S803.1,244.7,802.6,243.8L802.6,243.8z"
+   id="path360" />
+	<path
+   class="st8"
+   d="M820.8,237.5c1.2-0.6,2.5-0.9,3.9-0.9c1.7,0,3.3,0.4,4.7,1.3s2.5,2.1,3.3,3.6c0.8,1.6,1.2,3.4,1.2,5.4   s-0.4,3.9-1.2,5.5s-1.9,2.8-3.3,3.7s-2.9,1.3-4.7,1.3c-1.5,0-2.8-0.3-3.9-0.9c-1.1-0.6-2-1.4-2.7-2.3v2.9H813v-26.8h5.1v9.7   C818.8,238.8,819.7,238.1,820.8,237.5L820.8,237.5z M828,243.7c-0.5-0.9-1.2-1.6-2-2c-0.8-0.5-1.7-0.7-2.6-0.7   c-0.9,0-1.8,0.2-2.6,0.7s-1.5,1.2-2,2.1c-0.5,0.9-0.7,1.9-0.7,3.2s0.2,2.3,0.8,3.2c0.5,0.9,1.2,1.6,2,2.1s1.7,0.7,2.6,0.7   c0.9,0,1.8-0.2,2.6-0.7s1.5-1.2,2-2.1s0.7-2,0.7-3.2C828.8,245.7,828.5,244.6,828,243.7L828,243.7z"
+   id="path362" />
+	<path
+   class="st8"
+   d="M845.1,237.4c1.2-0.6,2.5-0.9,3.9-0.9c1.7,0,3.3,0.4,4.7,1.3c1.4,0.8,2.5,2.1,3.3,3.6c0.8,1.6,1.2,3.4,1.2,5.4   s-0.4,3.9-1.2,5.5s-1.9,2.8-3.3,3.7s-2.9,1.3-4.7,1.3c-1.5,0-2.8-0.3-3.9-0.9c-1.1-0.6-2-1.4-2.7-2.3v2.9h-5.1v-26.8h5.1v9.7   C843,238.8,843.9,238,845.1,237.4L845.1,237.4z M852.2,243.7c-0.5-0.9-1.2-1.6-2-2c-0.8-0.5-1.7-0.7-2.6-0.7   c-0.9,0-1.8,0.2-2.6,0.7s-1.5,1.2-2,2.1c-0.5,0.9-0.7,1.9-0.7,3.2s0.2,2.3,0.8,3.1s1.2,1.6,2,2.1s1.7,0.7,2.6,0.7   c0.9,0,1.8-0.2,2.6-0.7s1.5-1.2,2-2.1c0.5-0.9,0.7-2,0.7-3.2C853,245.6,852.8,244.6,852.2,243.7L852.2,243.7z"
+   id="path364" />
+	<path
+   class="st8"
+   d="M861.8,233.6c-0.6-0.6-0.9-1.3-0.9-2.1c0-0.9,0.3-1.6,0.9-2.1c0.6-0.6,1.3-0.9,2.2-0.9s1.6,0.3,2.2,0.9   c0.6,0.6,0.9,1.3,0.9,2.1c0,0.9-0.3,1.6-0.9,2.1c-0.6,0.6-1.3,0.9-2.2,0.9C863.2,234.4,862.4,234.2,861.8,233.6L861.8,233.6z    M866.6,236.8v20.1h-5.1v-20.1L866.6,236.8L866.6,236.8z"
+   id="path366" />
+	<path
+   class="st8"
+   d="M877.1,241v9.7c0,0.7,0.2,1.2,0.5,1.5s0.9,0.4,1.7,0.4h2.4v4.3h-3.2c-4.3,0-6.4-2.1-6.4-6.2V241h-2.4v-4.2h2.4   v-5h5.1v5h4.5v4.2H877.1L877.1,241z"
+   id="path368" />
+	<path
+   class="st8"
+   d="M912.5,231.5v25.3h-5.1v-16.5l-6.8,16.5h-3.8l-6.8-16.4v16.5h-5.1v-25.3h5.8l8.1,18.8l8-18.8L912.5,231.5   L912.5,231.5z"
+   id="path370" />
+	<path
+   class="st8"
+   d="M936.1,261.3l-3.8-4.6c-1.1,0.3-2.2,0.4-3.3,0.4c-2.4,0-4.5-0.5-6.5-1.7c-2-1.1-3.6-2.6-4.7-4.6   s-1.8-4.2-1.8-6.7s0.6-4.7,1.7-6.7c1.2-2,2.7-3.5,4.7-4.6s4.2-1.7,6.5-1.7c2.4,0,4.6,0.6,6.5,1.7s3.5,2.6,4.7,4.6s1.7,4.2,1.7,6.6   c0,2.2-0.5,4.3-1.4,6.1c-1,1.9-2.2,3.4-3.9,4.5l5.8,6.5L936.1,261.3L936.1,261.3z M922.2,248.6c0.7,1.3,1.6,2.3,2.7,2.9s2.5,1,4,1   s2.9-0.4,4-1c1.2-0.7,2.1-1.7,2.7-3c0.7-1.3,1-2.8,1-4.5s-0.3-3.2-1-4.4c-0.7-1.3-1.6-2.2-2.7-2.9s-2.5-1-4-1s-2.9,0.3-4,1   c-1.2,0.7-2.1,1.6-2.7,2.9c-0.7,1.3-1,2.8-1,4.4C921.2,245.8,921.5,247.3,922.2,248.6L922.2,248.6z"
+   id="path372" />
+	<path
+   class="st8"
+   d="M943.8,231.3h9.6v3h-2.9v9.8h-3.8v-9.8h-2.9L943.8,231.3L943.8,231.3z M971.5,231.2V244H968l-0.1-8l-3.3,8H962   l-3.3-8.3v8.3h-3.4v-12.8h5l3.1,8.2l3.3-8.2H971.5L971.5,231.2z"
+   id="path374" />
+	<path
+   class="st8"
+   d="M987.6,231.9l1.8,3.3l-4.7,1.7l4.7,1.7l-1.9,3.4l-3.9-3.2l0.8,5h-3.8l0.8-5l-3.9,3.3l-2-3.5l4.7-1.7l-4.7-1.6   l1.8-3.3l4,3.2l-0.8-5h3.8l-0.9,5L987.6,231.9L987.6,231.9z"
+   id="path376" />
+</g>
+<g
+   id="g386">
+	<path
+   class="st8"
+   d="M869.2,132h50.5v-16.3c0-4.7-3.9-8.6-8.6-8.6h-66.8c-4.7,0-8.6,3.9-8.6,8.6v31.9c0,4.7,3.9,8.6,8.6,8.6h16.3   v-15.6C860.6,135.9,864.5,132,869.2,132z"
+   id="path380" />
+	<path
+   class="st8"
+   d="M839.3,102.1h50.5V85.8c0-4.7-3.9-8.6-8.6-8.6h-66.8c-4.7,0-8.6,3.9-8.6,8.6v31.9c0,4.7,3.9,8.6,8.6,8.6h16.3   v-15.6C830.7,106,834.6,102.1,839.3,102.1z"
+   id="path382" />
+	<path
+   class="st8"
+   d="M941,137h-66.8c-0.9,0-1.7,0.1-2.5,0.4c-0.2,0.1-0.4,0.1-0.6,0.2c-0.2,0.1-0.4,0.1-0.5,0.2   c-2.9,1.4-4.9,4.4-4.9,7.7v31.9c0,4.7,3.9,8.6,8.6,8.6H941c4.7,0,8.6-3.9,8.6-8.6v-31.9C949.6,140.9,945.7,137,941,137L941,137z"
+   id="path384" />
+</g>
+<g
+   id="g422">
+	<path
+   id="circle388"
+   d="m 1781.3,131.7 a 70.800003,70.800003 0 0 1 -70.8,70.8 70.800003,70.800003 0 0 1 -70.8,-70.8 70.800003,70.800003 0 0 1 70.8,-70.800006 70.800003,70.800003 0 0 1 70.8,70.800006 z" />
+	<g
+   id="g420">
+		<g
+   id="g418">
+			<g
+   id="g416">
+				<defs
+   id="defs391">
+					<path
+   id="SVGID_1_"
+   d="M1710.5,72.1L1710.5,72.1c32.9,0,59.6,26.7,59.6,59.6l0,0c0,32.9-26.7,59.6-59.6,59.6l0,0       c-32.9,0-59.6-26.7-59.6-59.6l0,0C1650.9,98.8,1677.6,72.1,1710.5,72.1z" />
+				</defs>
+				<clipPath
+   id="SVGID_00000177463133771399649070000005449959810631315358_">
+					<use
+   xlink:href="#SVGID_1_"
+   style="overflow:visible;"
+   id="use393" />
+				</clipPath>
+				<g
+   style="clip-path:url(#SVGID_00000177463133771399649070000005449959810631315358_);"
+   clip-path="url(#SVGID_00000177463133771399649070000005449959810631315358_)"
+   id="g414">
+					<g
+   id="g412">
+
+							<linearGradient
+   id="SVGID_00000125573222782265944380000002574103367559712679_"
+   gradientUnits="userSpaceOnUse"
+   x1="1702.9392"
+   y1="6190.9639"
+   x2="1693.3392"
+   y2="6190.8237"
+   gradientTransform="matrix(1 0 0 1 0 -6074.791)">
+							<stop
+   offset="0"
+   style="stop-color:#ECFF80;stop-opacity:0"
+   id="stop396" />
+							<stop
+   offset="1"
+   style="stop-color:#ECFF80"
+   id="stop398" />
+						</linearGradient>
+						<path
+   style="fill:url(#SVGID_00000125573222782265944380000002574103367559712679_);"
+   d="M1702.8,125.7v-9.8        c0-0.6-0.2-1.1-0.7-1.6l-8.5-8.5l-5.9,6.5l13.9,13.8C1702,126.7,1702.8,126.3,1702.8,125.7L1702.8,125.7L1702.8,125.7z"
+   id="path401" />
+
+							<linearGradient
+   id="SVGID_00000026151173829179994840000017201945421810806401_"
+   gradientUnits="userSpaceOnUse"
+   x1="1684.47"
+   y1="6221.8823"
+   x2="1672.5"
+   y2="6221.8823"
+   gradientTransform="matrix(1 0 0 1 0 -6074.791)">
+							<stop
+   offset="0"
+   style="stop-color:#ECFF80;stop-opacity:0"
+   id="stop403" />
+							<stop
+   offset="0.96"
+   style="stop-color:#ECFF80"
+   id="stop405" />
+						</linearGradient>
+						<path
+   style="fill:url(#SVGID_00000026151173829179994840000017201945421810806401_);"
+   d="M1684,149.4l-16.7-16.7l-6,6.5        l22.1,22.1c0.4,0.4,1.2,0.1,1.2-0.5V151C1684.7,150.3,1684.4,149.8,1684,149.4L1684,149.4L1684,149.4z"
+   id="path408" />
+						<path
+   class="st17"
+   d="M1706.3,72.4c-30,2.1-53.9,26.9-55.1,56.9c-1.1,29.3,19.1,54.1,46.3,60.2l-36.3-36.3        c-0.5-0.5-0.8-1.2-0.8-2v-11.7c0-0.5,0.6-0.7,0.9-0.4l6-6.5c-0.4-0.4-0.4-1,0-1.4l5.7-5.7c0.4-0.4,1-0.4,1.3,0l19.4,19.4        c0.8,0.8,1.3,1.9,1.3,3.1v20.2c0,2.9,1.2,5.7,3.2,7.8l14.8,14.8c3.8-0.2,7.4-0.7,11-1.5l-18.7-18.7c-0.9-0.9-1.4-2.2-1.4-3.5        v-19.6c0-3.2-1.3-6.3-3.5-8.6l-19.7-19.7c-0.4-0.4-0.4-1,0-1.4l5.7-5.7c0.4-0.4,1-0.4,1.3,0l5.9-6.5c-0.1-0.1-0.2-0.3-0.3-0.4        c-1.7-2.3-2.7-6.1-1.5-10.3c0.7-2.7,2.2-4.8,5-7.3c0.2-0.2,0.6-0.2,0.9,0l7.1,6.2l1.4,1.2c0.5,0.5,1.2,0.8,1.9,1l22.2,5.3        c0.3,0.1,0.5,0.2,0.7,0.4l22.8,22.8c0.4,0.4,0.6,0.9,0.6,1.5v4.8c0,0.7-0.2,1.5-0.6,2.1l-11.3,20.6c-0.5,0.9-1.6,1.3-2.5,0.9        l-5.2-2.3h-19c-1.2,0-2.2,1-2.2,2.2v8.5c0,1.2,0.5,2.3,1.3,3.1l19.7,19.9c20.8-9.2,35.2-30.1,35.2-54.2        C1769.8,97.5,1740.9,70.1,1706.3,72.4L1706.3,72.4L1706.3,72.4z"
+   id="path410" />
+					</g>
+				</g>
+			</g>
+		</g>
+	</g>
+</g>
+<g
+   id="g450">
+	<g
+   id="g428">
+		<path
+   id="line424"
+   class="st18"
+   style="fill:none;stroke:#1e2837;stroke-width:9.5;stroke-miterlimit:10"
+   d="m 1750.7,785 h 31.1" />
+		<path
+   id="polygon426"
+   class="st8"
+   style="fill:#1e2837"
+   d="m 1779,794.5 16.4,-9.5 -16.4,-9.4 z" />
+	</g>
+	<g
+   id="g434">
+		<path
+   id="line430"
+   class="st18"
+   style="fill:none;stroke:#1e2837;stroke-width:9.5;stroke-miterlimit:10"
+   d="m 1655.7,785 h 31" />
+		<path
+   id="polygon432"
+   class="st8"
+   style="fill:#1e2837"
+   d="m 1684,794.5 16.4,-9.5 -16.4,-9.4 z" />
+	</g>
+	<g
+   id="g440">
+		<path
+   id="line436"
+   class="st18"
+   style="fill:none;stroke:#1e2837;stroke-width:9.5;stroke-miterlimit:10"
+   d="m 1750.7,803.5 21.9,22" />
+		<path
+   id="polygon438"
+   class="st8"
+   style="fill:#1e2837"
+   d="m 1764,830.3 18.3,4.9 -4.9,-18.3 z" />
+	</g>
+	<g
+   id="g446">
+		<path
+   id="line442"
+   class="st18"
+   style="fill:none;stroke:#1e2837;stroke-width:9.5;stroke-miterlimit:10"
+   d="m 1750.7,766.59998 21.9,-22" />
+		<path
+   id="polygon444"
+   class="st8"
+   style="fill:#1e2837"
+   d="m 1777.4,753.2 4.9,-18.3 -18.3,4.9 z" />
+	</g>
+	<path
+   id="circle448"
+   class="st8"
+   style="fill:#1e2837"
+   d="m 1745,787.40002 a 20.200001,20.200001 0 0 1 -20.2,20.20001 20.200001,20.200001 0 0 1 -20.2,-20.20001 20.200001,20.200001 0 0 1 20.2,-20.2 20.200001,20.200001 0 0 1 20.2,20.2 z" />
+</g>
+<g
+   id="g486">
+	<path
+   class="st8"
+   d="M1686.5,1539.3v17.8c0,2.5-0.7,4.4-2.1,5.8s-3.3,2.1-5.7,2.1s-4.4-0.7-5.9-2.1s-2.2-3.4-2.2-5.9h5.1   c0,1.1,0.3,1.9,0.8,2.5s1.2,0.9,2.2,0.9s1.6-0.3,2.1-0.9s0.7-1.4,0.7-2.4v-17.8H1686.5L1686.5,1539.3z"
+   id="path452" />
+	<path
+   class="st8"
+   d="M1691.9,1549.1c0.8-1.6,1.9-2.8,3.3-3.6s2.9-1.3,4.7-1.3c1.5,0,2.8,0.3,3.9,0.9s2,1.4,2.7,2.3v-2.9h5.1v20.1   h-5.1v-2.9c-0.7,0.9-1.6,1.7-2.7,2.3c-1.2,0.6-2.5,0.9-4,0.9c-1.7,0-3.2-0.4-4.6-1.3s-2.5-2.1-3.3-3.7s-1.2-3.4-1.2-5.5   S1691.1,1550.7,1691.9,1549.1L1691.9,1549.1z M1705.8,1551.4c-0.5-0.9-1.1-1.6-2-2s-1.7-0.7-2.7-0.7s-1.8,0.2-2.6,0.7   c-0.8,0.5-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.7,3.2c0.5,0.9,1.2,1.6,2,2.1s1.7,0.7,2.6,0.7s1.8-0.2,2.7-0.7   c0.8-0.5,1.5-1.2,2-2c0.5-0.9,0.7-1.9,0.7-3.2S1706.3,1552.3,1705.8,1551.4L1705.8,1551.4z"
+   id="path454" />
+	<path
+   class="st8"
+   d="M1734.8,1556.1h-14.7c0.1,1.4,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5   c-0.6,1.9-1.7,3.5-3.3,4.8s-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4s0.4-3.9,1.3-5.5   c0.8-1.6,2-2.8,3.6-3.6s3.3-1.3,5.3-1.3s3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.2,5.2C1734.9,1554.9,1734.9,1555.5,1734.8,1556.1   L1734.8,1556.1z M1729.7,1552.7c0-1.3-0.5-2.3-1.4-3.1c-0.9-0.8-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2   H1729.7L1729.7,1552.7z"
+   id="path456" />
+	<path
+   class="st8"
+   d="M1750.1,1545.1c1.1,0.6,2,1.4,2.7,2.3v-2.9h5.1v20.2c0,1.9-0.4,3.5-1.1,5c-0.8,1.5-1.9,2.6-3.4,3.5   s-3.3,1.3-5.4,1.3c-2.8,0-5.2-0.7-7-2s-2.9-3.1-3.1-5.4h5c0.3,0.9,0.8,1.7,1.7,2.2s1.9,0.8,3.2,0.8c1.5,0,2.7-0.4,3.6-1.3   s1.4-2.2,1.4-4v-3.1c-0.7,0.9-1.6,1.7-2.7,2.4c-1.2,0.6-2.5,0.9-3.9,0.9c-1.7,0-3.2-0.4-4.6-1.3s-2.5-2.1-3.3-3.7s-1.2-3.4-1.2-5.5   s0.4-3.8,1.2-5.4c0.8-1.6,1.9-2.8,3.3-3.6s2.9-1.3,4.7-1.3C1747.6,1544.2,1748.9,1544.5,1750.1,1545.1L1750.1,1545.1z M1752,1551.4   c-0.5-0.9-1.1-1.6-2-2s-1.7-0.7-2.7-0.7s-1.8,0.2-2.6,0.7c-0.8,0.5-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.7,3.2   c0.5,0.9,1.2,1.6,2,2.1s1.7,0.7,2.6,0.7s1.8-0.2,2.7-0.7c0.8-0.5,1.5-1.2,2-2s0.7-1.9,0.7-3.2S1752.5,1552.3,1752,1551.4   L1752,1551.4z"
+   id="path458" />
+	<path
+   class="st8"
+   d="M1781,1556.1h-14.7c0.1,1.4,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5c-0.6,1.9-1.7,3.5-3.3,4.8   c-1.6,1.2-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4s0.4-3.9,1.3-5.5   c0.8-1.6,2-2.8,3.6-3.6s3.3-1.3,5.3-1.3s3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.2,5.2C1781.1,1554.9,1781.1,1555.5,1781,1556.1   L1781,1556.1z M1775.9,1552.7c0-1.3-0.5-2.3-1.4-3.1s-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2H1775.9   L1775.9,1552.7z"
+   id="path460" />
+	<path
+   class="st8"
+   d="M1792.1,1545.2c1.1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1   v-20.1h5.1v3.1C1790.2,1546.6,1791.1,1545.8,1792.1,1545.2L1792.1,1545.2z"
+   id="path462" />
+	<path
+   class="st8"
+   d="M1797.2,1539.1h9.6v3h-2.9v9.8h-3.8v-9.8h-2.9L1797.2,1539.1L1797.2,1539.1z M1825,1539.1v12.8h-3.5l-0.1-8   l-3.3,8h-2.6l-3.3-8.3v8.3h-3.4v-12.8h5l3.1,8.2l3.3-8.2H1825L1825,1539.1z"
+   id="path464" />
+	<path
+   class="st8"
+   d="M1841,1539.8l1.8,3.3l-4.7,1.7l4.7,1.7l-1.9,3.4l-3.9-3.2l0.8,5h-3.8l0.8-5l-3.9,3.3l-2-3.5l4.7-1.7l-4.7-1.6   l1.8-3.3l4,3.2l-0.8-5h3.8l-0.9,5L1841,1539.8L1841,1539.8z"
+   id="path466" />
+	<path
+   class="st8"
+   d="M1673.7,1605.8c-1.3-3.5-1.9-7.3-1.9-11.3s0.7-8,2-11.7s3.3-6.6,5.9-8.9h5.1v0.5c-2.7,2.5-4.7,5.6-6.1,9.1   c-1.4,3.6-2.1,7.2-2.1,11s0.7,7.2,2,10.6s3.2,6.4,5.6,8.9v0.5h-5.1C1676.9,1612.2,1675,1609.3,1673.7,1605.8L1673.7,1605.8z"
+   id="path468" />
+	<path
+   class="st8"
+   d="M1695.4,1587.8c1.2-0.6,2.5-0.9,3.9-0.9c1.7,0,3.3,0.4,4.7,1.3s2.5,2.1,3.3,3.6c0.8,1.6,1.2,3.4,1.2,5.4   s-0.4,3.9-1.2,5.5c-0.8,1.6-1.9,2.8-3.3,3.7s-2.9,1.3-4.7,1.3c-1.5,0-2.8-0.3-3.9-0.9s-2-1.4-2.7-2.3v12.4h-5.1v-29.7h5.1v2.9   C1693.4,1589.2,1694.3,1588.4,1695.4,1587.8L1695.4,1587.8z M1702.6,1594.1c-0.5-0.9-1.2-1.6-2-2c-0.8-0.5-1.7-0.7-2.6-0.7   s-1.8,0.2-2.6,0.7c-0.8,0.5-1.5,1.2-2,2.1s-0.7,1.9-0.7,3.2s0.2,2.3,0.7,3.2c0.5,0.9,1.2,1.6,2,2.1s1.7,0.7,2.6,0.7   s1.8-0.2,2.6-0.7s1.5-1.2,2-2.1s0.7-2,0.7-3.2S1703.1,1595,1702.6,1594.1L1702.6,1594.1z"
+   id="path470" />
+	<path
+   class="st8"
+   d="M1719.5,1587.8c1.1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1   v-20.1h5.1v3.1C1717.6,1589.3,1718.5,1588.4,1719.5,1587.8L1719.5,1587.8z"
+   id="path472" />
+	<path
+   class="st8"
+   d="M1744.7,1598.8H1730c0.1,1.4,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5c-0.6,1.9-1.7,3.5-3.3,4.8   c-1.6,1.2-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4s0.4-3.9,1.3-5.5   c0.8-1.6,2-2.8,3.6-3.6s3.3-1.3,5.3-1.3s3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.2,5.2C1744.8,1597.6,1744.8,1598.2,1744.7,1598.8   L1744.7,1598.8z M1739.6,1595.4c0-1.3-0.5-2.3-1.4-3.1s-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.1s-1.4,1.8-1.6,3.2H1739.6   L1739.6,1595.4z"
+   id="path474" />
+	<path
+   class="st8"
+   d="M1756.5,1602.6l5.1-15.4h5.4l-7.4,20.1h-6.2l-7.4-20.1h5.4L1756.5,1602.6L1756.5,1602.6z"
+   id="path476" />
+	<path
+   class="st8"
+   d="M1769.9,1584c-0.6-0.6-0.9-1.3-0.9-2.1s0.3-1.6,0.9-2.1s1.3-0.8,2.2-0.8s1.6,0.3,2.2,0.8s0.9,1.3,0.9,2.1   s-0.3,1.6-0.9,2.1s-1.3,0.8-2.2,0.8S1770.5,1584.5,1769.9,1584z M1774.6,1587.2v20.1h-5.1v-20.1H1774.6z"
+   id="path478" />
+	<path
+   class="st8"
+   d="M1797.8,1598.8h-14.7c0.1,1.4,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5   c-0.6,1.9-1.7,3.5-3.3,4.8c-1.6,1.2-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6s-1.3-3.4-1.3-5.4s0.4-3.9,1.3-5.5   c0.8-1.6,2-2.8,3.6-3.6s3.3-1.3,5.3-1.3s3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.2,5.2C1797.9,1597.6,1797.9,1598.2,1797.8,1598.8   L1797.8,1598.8z M1792.7,1595.4c0-1.3-0.5-2.3-1.4-3.1c-0.9-0.8-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2   H1792.7L1792.7,1595.4z"
+   id="path480" />
+	<path
+   class="st8"
+   d="M1829.1,1587.2l-5.9,20.1h-5.5l-3.7-14l-3.7,14h-5.5l-5.9-20.1h5.2l3.6,15.3l3.8-15.3h5.4l3.8,15.3l3.6-15.3   H1829.1L1829.1,1587.2z"
+   id="path482" />
+	<path
+   class="st8"
+   d="M1830.2,1614.5v-0.5c2.4-2.5,4.3-5.5,5.6-8.9s2-7,2-10.6s-0.7-7.4-2.1-11s-3.4-6.6-6.1-9.1v-0.5h5.1   c2.6,2.3,4.6,5.3,5.9,8.9s2,7.5,2,11.7s-0.7,7.8-1.9,11.3c-1.3,3.5-3.1,6.4-5.5,8.7H1830.2L1830.2,1614.5z"
+   id="path484" />
+</g>
+<g
+   id="g522">
+	<path
+   class="st8"
+   d="M283.8,234.5h-10.1l-1.7,4.8h-5.3l9.1-25.4h5.9l9.1,25.3h-5.4L283.8,234.5L283.8,234.5z M282.4,230.4   l-3.7-10.6l-3.6,10.6H282.4L282.4,230.4z"
+   id="path488" />
+	<path
+   class="st8"
+   d="M301.5,219.8c1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1s-1.2,2.1-1.2,3.9v10h-5.1v-20.1h5.1v3.1   C299.6,221.2,300.5,220.4,301.5,219.8z"
+   id="path490" />
+	<path
+   class="st8"
+   d="M320,219.7c1.1,0.6,2,1.4,2.7,2.3v-2.9h5.1v20.2c0,1.9-0.4,3.5-1.1,5c-0.8,1.5-1.9,2.6-3.4,3.5   s-3.3,1.3-5.4,1.3c-2.9,0-5.2-0.7-7-2s-2.9-3.1-3.1-5.4h5c0.3,0.9,0.8,1.6,1.7,2.2c0.9,0.5,2,0.8,3.2,0.8c1.5,0,2.7-0.4,3.6-1.3   s1.4-2.2,1.4-4v-3.1c-0.7,0.9-1.6,1.7-2.7,2.4c-1.1,0.6-2.5,0.9-3.9,0.9c-1.7,0-3.2-0.4-4.6-1.3c-1.4-0.9-2.5-2.1-3.3-3.7   c-0.8-1.6-1.2-3.4-1.2-5.5c0-2,0.4-3.8,1.2-5.4c0.8-1.6,1.9-2.8,3.3-3.6c1.4-0.9,2.9-1.3,4.7-1.3   C317.6,218.8,318.9,219.1,320,219.7L320,219.7z M322,226c-0.5-0.9-1.1-1.6-2-2c-0.8-0.5-1.7-0.7-2.6-0.7s-1.8,0.2-2.6,0.7   s-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.8,3.2c0.5,0.9,1.1,1.6,2,2.1s1.7,0.7,2.6,0.7s1.8-0.2,2.6-0.7s1.5-1.1,2-2   s0.7-1.9,0.7-3.2S322.5,226.9,322,226L322,226z"
+   id="path492" />
+	<path
+   class="st8"
+   d="M336.1,238.2c-1.5-0.9-2.8-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4c0-2.1,0.5-3.9,1.4-5.4s2.1-2.8,3.7-3.6   c1.6-0.9,3.3-1.3,5.3-1.3c1.9,0,3.7,0.4,5.3,1.3s2.8,2.1,3.7,3.6c0.9,1.6,1.4,3.4,1.4,5.4c0,2.1-0.5,3.9-1.4,5.4s-2.2,2.8-3.8,3.6   s-3.4,1.3-5.3,1.3C339.4,239.5,337.7,239.1,336.1,238.2L336.1,238.2z M343.9,234.4c0.8-0.4,1.5-1.1,1.9-2c0.5-0.9,0.7-2,0.7-3.3   c0-1.9-0.5-3.4-1.5-4.4s-2.2-1.5-3.7-1.5s-2.7,0.5-3.6,1.5c-1,1-1.5,2.5-1.5,4.4s0.5,3.4,1.4,4.4c1,1,2.2,1.5,3.6,1.5   C342.3,235.1,343.1,234.9,343.9,234.4L343.9,234.4z"
+   id="path494" />
+	<path
+   class="st8"
+   d="M353.6,213.6h9.6v3h-2.9v9.8h-3.8v-9.8h-2.9L353.6,213.6L353.6,213.6z M381.4,213.6v12.8h-3.5l-0.1-8l-3.3,8   h-2.6l-3.3-8.3v8.3h-3.4v-12.8h5l3.1,8.2l3.3-8.2H381.4L381.4,213.6z"
+   id="path496" />
+	<path
+   class="st8"
+   d="M385.9,219.8c1.1-2,2.7-3.5,4.6-4.6s4.1-1.7,6.5-1.7c2.8,0,5.3,0.7,7.4,2.2s3.6,3.4,4.5,6h-5.8   c-0.6-1.2-1.4-2.1-2.5-2.7c-1-0.6-2.3-0.9-3.6-0.9c-1.5,0-2.8,0.4-3.9,1c-1.1,0.7-2,1.7-2.7,2.9c-0.6,1.3-1,2.7-1,4.4   s0.3,3.1,1,4.4s1.5,2.2,2.7,2.9c1.1,0.7,2.5,1,3.9,1s2.6-0.3,3.6-0.9c1-0.6,1.9-1.5,2.4-2.7h5.8c-0.8,2.6-2.3,4.6-4.4,6   s-4.6,2.2-7.5,2.2c-2.4,0-4.6-0.5-6.5-1.6c-2-1.1-3.5-2.6-4.6-4.6s-1.7-4.2-1.7-6.7S384.8,221.8,385.9,219.8L385.9,219.8z"
+   id="path498" />
+	<path
+   class="st8"
+   d="M428.8,215.3c2,1,3.6,2.5,4.7,4.4s1.7,4.1,1.7,6.7c0,2.5-0.5,4.8-1.6,6.7s-2.7,3.4-4.7,4.4s-4.4,1.6-7,1.6H413   v-25.3h8.9C424.4,213.8,426.8,214.3,428.8,215.3L428.8,215.3z M427.8,232.6c1.5-1.4,2.2-3.5,2.2-6.1s-0.7-4.7-2.2-6.2   s-3.5-2.2-6.2-2.2H418v16.7h3.6C424.3,234.8,426.3,234.1,427.8,232.6z"
+   id="path500" />
+	<path
+   class="st8"
+   d="M450.5,214.2l1.8,3.3l-4.7,1.7l4.7,1.7l-1.9,3.4l-3.9-3.2l0.8,5h-3.8l0.8-5l-3.9,3.3l-2-3.5l4.7-1.7l-4.7-1.6   l1.9-3.3l4,3.2l-0.8-5h3.8l-0.9,5L450.5,214.2L450.5,214.2z"
+   id="path502" />
+	<path
+   class="st8"
+   d="M276.9,280.4c-1.3-3.5-2-7.3-2-11.4s0.7-8,2-11.7c1.4-3.6,3.3-6.6,5.9-8.9h5.1v0.5c-2.7,2.5-4.7,5.6-6.1,9.1   s-2.1,7.2-2.1,11c0,3.7,0.7,7.2,2,10.6s3.2,6.4,5.6,8.9v0.5h-5.1C280,286.8,278.2,283.9,276.9,280.4L276.9,280.4z"
+   id="path504" />
+	<path
+   class="st8"
+   d="M298.5,262.4c1.1-0.6,2.5-0.9,3.9-0.9c1.7,0,3.3,0.4,4.7,1.3s2.5,2,3.3,3.6s1.2,3.4,1.2,5.4s-0.4,3.9-1.2,5.5   s-1.9,2.8-3.3,3.7c-1.4,0.9-2.9,1.3-4.7,1.3c-1.5,0-2.8-0.3-3.9-0.9s-2-1.4-2.7-2.3v12.4h-5.1v-29.7h5.1v2.9   C296.5,263.8,297.4,263,298.5,262.4L298.5,262.4z M305.7,268.7c-0.5-0.9-1.1-1.5-2-2c-0.8-0.5-1.7-0.7-2.6-0.7s-1.8,0.2-2.6,0.7   s-1.5,1.2-2,2c-0.5,0.9-0.7,2-0.7,3.2s0.2,2.3,0.8,3.1s1.1,1.6,2,2s1.7,0.7,2.6,0.7s1.8-0.2,2.6-0.7c0.8-0.5,1.5-1.2,2-2.1   s0.7-2,0.7-3.2C306.5,270.6,306.2,269.5,305.7,268.7L305.7,268.7z"
+   id="path506" />
+	<path
+   class="st8"
+   d="M322.6,262.4c1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1s-1.2,2.1-1.2,3.9v10H315v-20.1h5.1v3.1   C320.7,263.9,321.6,263,322.6,262.4L322.6,262.4z"
+   id="path508" />
+	<path
+   class="st8"
+   d="M347.8,273.3h-14.7c0.1,1.5,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5c-0.6,1.9-1.7,3.5-3.3,4.8   s-3.7,1.9-6,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4c0-2.1,0.4-3.9,1.3-5.5s2-2.8,3.5-3.6   s3.3-1.3,5.3-1.3c1.9,0,3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.3,3.2,1.3,5.2C348,272.1,347.9,272.8,347.8,273.3L347.8,273.3z    M342.7,269.9c0-1.3-0.5-2.4-1.4-3.1c-0.9-0.8-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2H342.7L342.7,269.9z"
+   id="path510" />
+	<path
+   class="st8"
+   d="M359.7,277.2l5.1-15.4h5.4l-7.4,20.1h-6.2l-7.4-20.1h5.4L359.7,277.2L359.7,277.2z"
+   id="path512" />
+	<path
+   class="st8"
+   d="M373,258.5c-0.6-0.6-0.9-1.3-0.9-2.1c0-0.8,0.3-1.5,0.9-2.1s1.3-0.9,2.2-0.9s1.6,0.3,2.2,0.9s0.9,1.3,0.9,2.1   c0,0.9-0.3,1.5-0.9,2.1s-1.3,0.9-2.2,0.9S373.6,259.1,373,258.5L373,258.5z M377.7,261.7v20.1h-5.1v-20.1H377.7z"
+   id="path514" />
+	<path
+   class="st8"
+   d="M400.9,273.3h-14.7c0.1,1.5,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5c-0.6,1.9-1.7,3.5-3.3,4.8   c-1.6,1.2-3.7,1.9-6,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6s-1.3-3.4-1.3-5.4c0-2.1,0.4-3.9,1.3-5.5s2-2.8,3.5-3.6   s3.3-1.3,5.3-1.3c1.9,0,3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.3,3.2,1.3,5.2C401.1,272.1,401,272.7,400.9,273.3L400.9,273.3z    M395.8,269.9c0-1.3-0.5-2.4-1.4-3.1c-0.9-0.8-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2H395.8L395.8,269.9z"
+   id="path516" />
+	<path
+   class="st8"
+   d="M432.2,261.7l-5.9,20.1h-5.5l-3.7-14l-3.6,14H408l-5.9-20.1h5.1l3.6,15.3l3.8-15.3h5.4l3.8,15.3l3.5-15.3   H432.2L432.2,261.7z"
+   id="path518" />
+	<path
+   class="st8"
+   d="M433.4,288.9v-0.5c2.4-2.5,4.3-5.5,5.6-8.9c1.3-3.4,2-7,2-10.6c0-3.8-0.7-7.4-2.1-11c-1.4-3.5-3.4-6.6-6.1-9.1   v-0.5h5.1c2.6,2.3,4.6,5.3,5.9,8.9c1.4,3.6,2,7.5,2,11.7c0,4-0.6,7.8-1.9,11.4c-1.3,3.5-3.1,6.4-5.5,8.7L433.4,288.9L433.4,288.9z"
+   id="path520" />
+</g>
+<g
+   id="g548">
+	<path
+   class="st8"
+   d="M1296.6,243.4c-0.6,1.2-1.6,2.1-3,2.9s-3.1,1.1-5.2,1.1h-4.2v9.7h-5.1v-25.3h9.3c2,0,3.6,0.3,5,1   s2.4,1.6,3.1,2.8s1,2.5,1,4C1297.5,240.9,1297.2,242.2,1296.6,243.4L1296.6,243.4z M1291.3,242.3c0.7-0.6,1-1.5,1-2.7   c0-2.5-1.4-3.7-4.1-3.7h-4v7.4h4C1289.6,243.2,1290.6,242.9,1291.3,242.3L1291.3,242.3z"
+   id="path524" />
+	<path
+   class="st8"
+   d="M1304.5,256.1c-1.6-0.9-2.8-2.1-3.7-3.6c-0.9-1.6-1.3-3.4-1.3-5.4c0-2.1,0.4-3.9,1.3-5.4s2.1-2.8,3.7-3.6   s3.3-1.3,5.3-1.3c1.9,0,3.7,0.4,5.3,1.3c1.6,0.9,2.8,2.1,3.7,3.6c0.9,1.6,1.4,3.4,1.4,5.4c0,2.1-0.5,3.9-1.4,5.4s-2.2,2.8-3.8,3.6   c-1.6,0.9-3.3,1.3-5.3,1.3C1307.8,257.3,1306,256.9,1304.5,256.1L1304.5,256.1z M1312.3,252.2c0.8-0.4,1.5-1.1,1.9-2   c0.5-0.9,0.7-2,0.7-3.3c0-1.9-0.5-3.4-1.5-4.4s-2.2-1.5-3.7-1.5c-1.4,0-2.7,0.5-3.6,1.6c-1,1-1.5,2.5-1.5,4.4s0.5,3.4,1.4,4.4   c1,1,2.2,1.5,3.6,1.5C1310.6,252.9,1311.5,252.7,1312.3,252.2L1312.3,252.2z"
+   id="path526" />
+	<path
+   class="st8"
+   d="M1326.8,256.4c-1.3-0.6-2.3-1.4-3.1-2.4s-1.2-2.1-1.3-3.4h5.1c0.1,0.8,0.5,1.4,1.2,1.9s1.5,0.8,2.5,0.8   s1.7-0.2,2.3-0.6c0.5-0.4,0.8-0.9,0.8-1.5s-0.3-1.1-1-1.5s-1.7-0.7-3.2-1.1c-1.5-0.4-2.7-0.7-3.7-1.1c-1-0.4-1.8-1-2.5-1.8   s-1-1.9-1-3.2c0-1.1,0.3-2.1,1-3.1s1.6-1.6,2.8-2.2c1.2-0.5,2.6-0.8,4.2-0.8c2.4,0,4.3,0.6,5.7,1.8c1.4,1.2,2.2,2.8,2.4,4.8h-4.9   c-0.1-0.8-0.4-1.4-1-1.9s-1.4-0.7-2.4-0.7c-0.9,0-1.6,0.2-2.1,0.5s-0.7,0.8-0.7,1.4c0,0.7,0.3,1.2,1,1.5c0.7,0.4,1.7,0.7,3.2,1.1   c1.4,0.4,2.7,0.7,3.6,1.1s1.8,1,2.4,1.8s1.1,1.9,1.1,3.2c0,1.2-0.3,2.2-1,3.1s-1.6,1.6-2.8,2.2c-1.2,0.5-2.6,0.8-4.2,0.8   C1329.6,257.3,1328.1,257,1326.8,256.4L1326.8,256.4z"
+   id="path528" />
+	<path
+   class="st8"
+   d="M1348.8,241v9.7c0,0.7,0.2,1.2,0.5,1.5s0.9,0.4,1.7,0.4h2.4v4.3h-3.2c-4.3,0-6.4-2.1-6.4-6.2V241h-2.4v-4.2   h2.4v-5h5.1v5h4.5v4.2H1348.8L1348.8,241z"
+   id="path530" />
+	<path
+   class="st8"
+   d="M1368.5,237.4c1.1,0.6,2,1.4,2.7,2.3v-2.9h5.1V257c0,1.9-0.4,3.5-1.1,5c-0.8,1.5-1.9,2.6-3.4,3.5   s-3.3,1.3-5.4,1.3c-2.8,0-5.2-0.7-7-2s-2.9-3.1-3.1-5.4h5c0.3,0.9,0.8,1.6,1.7,2.2c0.9,0.5,1.9,0.8,3.2,0.8c1.5,0,2.7-0.4,3.6-1.3   s1.4-2.2,1.4-4V254c-0.7,0.9-1.6,1.7-2.7,2.4c-1.2,0.6-2.5,1-3.9,1c-1.7,0-3.2-0.4-4.6-1.3s-2.5-2.1-3.3-3.7   c-0.8-1.6-1.2-3.4-1.2-5.5c0-2,0.4-3.8,1.2-5.4c0.8-1.6,1.9-2.8,3.3-3.6s2.9-1.3,4.7-1.3C1366,236.5,1367.3,236.8,1368.5,237.4   L1368.5,237.4z M1370.4,243.7c-0.5-0.9-1.1-1.6-2-2s-1.7-0.7-2.7-0.7c-0.9,0-1.8,0.2-2.6,0.7c-0.8,0.5-1.4,1.1-1.9,2   s-0.7,1.9-0.7,3.1s0.2,2.3,0.8,3.2c0.5,0.9,1.2,1.6,2,2.1s1.7,0.7,2.6,0.7s1.8-0.2,2.7-0.7s1.5-1.1,2-2s0.7-1.9,0.7-3.2   S1370.9,244.6,1370.4,243.7L1370.4,243.7z"
+   id="path532" />
+	<path
+   class="st8"
+   d="M1388.5,237.4c1.1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1   v-20.1h5.1v3.1C1386.6,238.9,1387.4,238,1388.5,237.4z"
+   id="path534" />
+	<path
+   class="st8"
+   d="M1413.7,248.4H1399c0.1,1.4,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5c-0.6,1.9-1.7,3.5-3.3,4.8   c-1.6,1.2-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3c-1.5-0.9-2.7-2.1-3.6-3.6s-1.3-3.4-1.3-5.4c0-2.1,0.4-3.9,1.3-5.5   c0.8-1.6,2-2.8,3.6-3.6s3.3-1.3,5.3-1.3c1.9,0,3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.3,5.2   C1413.9,247.2,1413.8,247.8,1413.7,248.4L1413.7,248.4z M1408.6,245c0-1.3-0.5-2.4-1.4-3.1c-0.9-0.8-2-1.2-3.4-1.2   c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2H1408.6L1408.6,245z"
+   id="path536" />
+	<path
+   class="st8"
+   d="M1421.2,256.2c-1.4-0.6-2.5-1.5-3.4-2.6s-1.2-2.5-1.3-4h5.4c0.1,1,0.4,1.9,1.1,2.5s1.6,0.9,2.7,0.9   c1.2,0,2.1-0.3,2.8-0.9c0.7-0.6,1-1.3,1-2.2c0-0.8-0.2-1.4-0.7-1.9s-1-0.9-1.7-1.1s-1.6-0.6-2.8-0.9c-1.7-0.5-3-1-4-1.4   s-1.9-1.2-2.7-2.1c-0.7-0.9-1.1-2.2-1.1-3.8c0-1.5,0.4-2.8,1.1-3.9s1.8-2,3.2-2.6s2.9-0.9,4.6-0.9c2.6,0,4.7,0.6,6.4,1.9   c1.6,1.3,2.5,3,2.7,5.3h-5.6c-0.1-0.9-0.4-1.6-1.1-2.1c-0.7-0.6-1.6-0.9-2.7-0.9c-1,0-1.8,0.3-2.4,0.8s-0.9,1.2-0.9,2.2   c0,0.7,0.2,1.2,0.7,1.7c0.4,0.4,1,0.8,1.7,1.1s1.6,0.6,2.8,1c1.6,0.5,3,1,4,1.4c1,0.5,1.9,1.2,2.7,2.2c0.8,1,1.1,2.2,1.1,3.8   c0,1.4-0.3,2.6-1.1,3.8c-0.7,1.2-1.7,2.1-3.1,2.8c-1.4,0.7-3,1-4.8,1C1424.2,257.1,1422.6,256.8,1421.2,256.2L1421.2,256.2z"
+   id="path538" />
+	<path
+   class="st8"
+   d="M1457.8,261.3l-3.8-4.6c-1.1,0.3-2.2,0.4-3.3,0.4c-2.4,0-4.6-0.5-6.5-1.7s-3.6-2.6-4.7-4.6s-1.8-4.2-1.8-6.7   s0.6-4.7,1.7-6.7c1.2-2,2.7-3.5,4.7-4.6s4.2-1.7,6.5-1.7c2.4,0,4.6,0.6,6.6,1.7c2,1.1,3.5,2.6,4.7,4.6s1.7,4.2,1.7,6.6   c0,2.2-0.5,4.3-1.4,6.1c-0.9,1.9-2.2,3.4-3.9,4.5l5.8,6.5L1457.8,261.3L1457.8,261.3z M1443.9,248.6c0.7,1.3,1.6,2.3,2.7,2.9   s2.5,1,4,1s2.9-0.4,4-1s2.1-1.7,2.7-3s1-2.8,1-4.5s-0.3-3.2-1-4.4s-1.6-2.2-2.7-2.9c-1.2-0.7-2.5-1-4-1s-2.9,0.3-4,1   c-1.2,0.7-2.1,1.6-2.7,2.9s-1,2.8-1,4.4C1442.9,245.8,1443.2,247.3,1443.9,248.6L1443.9,248.6z"
+   id="path540" />
+	<path
+   class="st8"
+   d="M1472.2,252.8h8.3v4h-13.4v-25.3h5.1V252.8L1472.2,252.8z"
+   id="path542" />
+	<path
+   class="st8"
+   d="M1494.2,232.1c1.2,0.6,2.1,1.6,2.7,2.7c0.7,1.2,1,2.5,1,4s-0.3,2.8-1,4s-1.6,2.1-2.7,2.7c-1.2,0.7-2.5,1-4,1   s-2.8-0.3-4-1s-2.1-1.6-2.8-2.7s-1-2.5-1-3.9c0-1.5,0.3-2.8,1-4s1.6-2.1,2.8-2.7c1.2-0.7,2.5-1,4-1S1493,231.4,1494.2,232.1   L1494.2,232.1z M1494.4,243c1.1-1.1,1.6-2.5,1.6-4.2c0-1.8-0.5-3.2-1.6-4.3s-2.4-1.6-4.2-1.6s-3.1,0.5-4.2,1.6s-1.6,2.5-1.6,4.3   s0.5,3.2,1.6,4.2c1,1.1,2.4,1.6,4.2,1.6S1493.4,244.1,1494.4,243L1494.4,243z M1493.2,238.7c-0.2,0.4-0.6,0.7-1.1,0.9l1.9,3h-2.8   l-1.6-2.7h-0.2v2.7h-2.4v-7.8h3.8c0.8,0,1.5,0.2,2,0.7s0.8,1.1,0.8,1.8C1493.6,237.9,1493.5,238.3,1493.2,238.7L1493.2,238.7z    M1489.4,238h1.2c0.2,0,0.3-0.1,0.4-0.1s0.2-0.2,0.2-0.4c0-0.4-0.2-0.5-0.6-0.5h-1.2V238L1489.4,238z"
+   id="path544" />
+	<path
+   class="st8"
+   d="M1513.7,231.9l1.8,3.3l-4.7,1.7l4.7,1.7l-1.9,3.4l-3.9-3.2l0.8,5h-3.8l0.8-5l-3.9,3.3l-2-3.5l4.7-1.7l-4.7-1.6   l1.8-3.3l4,3.2l-0.8-5h3.8l-0.9,5L1513.7,231.9L1513.7,231.9z"
+   id="path546" />
+</g>
+<g
+   id="g576">
+	<path
+   class="st8"
+   d="M1583.8,231.8v4.1h-6.7v21.2h-5.1v-21.2h-6.8v-4.1H1583.8z"
+   id="path550" />
+	<path
+   class="st8"
+   d="M1587.5,233.7c-0.6-0.6-0.9-1.3-0.9-2.1c0-0.9,0.3-1.6,0.9-2.1c0.6-0.6,1.3-0.9,2.2-0.9c0.9,0,1.6,0.3,2.2,0.9   s0.9,1.3,0.9,2.1c0,0.9-0.3,1.6-0.9,2.1c-0.6,0.6-1.3,0.9-2.2,0.9C1588.9,234.6,1588.1,234.3,1587.5,233.7L1587.5,233.7z    M1592.3,237v20.1h-5.1V237H1592.3L1592.3,237z"
+   id="path552" />
+	<path
+   class="st8"
+   d="M1627.8,238.9c1.5,1.5,2.3,3.6,2.3,6.3V257h-5.1v-11.1c0-1.6-0.4-2.8-1.2-3.6s-1.9-1.2-3.3-1.2   s-2.5,0.4-3.3,1.2s-1.2,2-1.2,3.6V257h-5.1v-11.1c0-1.6-0.4-2.8-1.2-3.6s-1.9-1.2-3.3-1.2s-2.5,0.4-3.3,1.3c-0.8,0.8-1.2,2-1.2,3.6   v11h-5.1v-20.1h5.1v2.4c0.7-0.9,1.5-1.5,2.5-2s2.2-0.7,3.4-0.7c1.6,0,3,0.3,4.2,1s2.2,1.6,2.9,2.8c0.7-1.2,1.6-2.1,2.8-2.8   c1.2-0.7,2.6-1.1,4-1.1C1624.4,236.6,1626.3,237.3,1627.8,238.9L1627.8,238.9z"
+   id="path554" />
+	<path
+   class="st8"
+   d="M1653.1,248.5h-14.7c0.1,1.4,0.6,2.6,1.5,3.4c0.9,0.8,2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5   c-0.6,1.9-1.7,3.5-3.3,4.8c-1.6,1.2-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4   c0-2.1,0.4-3.9,1.3-5.5c0.8-1.6,2-2.8,3.6-3.6s3.3-1.3,5.3-1.3c1.9,0,3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.3,3.2,1.3,5.2   C1653.3,247.2,1653.2,247.9,1653.1,248.5L1653.1,248.5z M1648,245.1c0-1.3-0.5-2.4-1.4-3.1c-0.9-0.8-2-1.2-3.4-1.2   c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2H1648L1648,245.1z"
+   id="path556" />
+	<path
+   class="st8"
+   d="M1659.8,256.4c-1.3-0.6-2.3-1.4-3.1-2.4s-1.2-2.1-1.3-3.4h5.1c0.1,0.8,0.5,1.4,1.1,1.9   c0.7,0.5,1.5,0.8,2.5,0.8s1.7-0.2,2.3-0.6s0.8-0.9,0.8-1.5s-0.3-1.1-1-1.5s-1.7-0.7-3.2-1.1c-1.5-0.4-2.7-0.7-3.7-1.1   c-1-0.4-1.8-1-2.5-1.8s-1-1.9-1-3.2c0-1.1,0.3-2.1,1-3.1s1.6-1.6,2.8-2.2s2.6-0.8,4.2-0.8c2.4,0,4.3,0.6,5.7,1.8   c1.4,1.2,2.2,2.8,2.4,4.8h-4.9c-0.1-0.8-0.4-1.4-1-1.9s-1.4-0.7-2.4-0.7c-0.9,0-1.6,0.2-2.1,0.5s-0.7,0.8-0.7,1.4   c0,0.7,0.3,1.2,1,1.5s1.7,0.7,3.2,1.1c1.4,0.4,2.7,0.7,3.6,1.1s1.8,1,2.4,1.8s1.1,1.9,1.1,3.2c0,1.2-0.3,2.2-1,3.1   s-1.6,1.6-2.8,2.2c-1.2,0.5-2.6,0.8-4.2,0.8C1662.6,257.3,1661.1,257,1659.8,256.4L1659.8,256.4z"
+   id="path558" />
+	<path
+   class="st8"
+   d="M1675.9,241.4c0.8-1.6,2-2.8,3.5-3.6s3.2-1.3,5.2-1.3c2.5,0,4.6,0.6,6.2,1.9c1.6,1.2,2.7,3,3.3,5.2h-5.5   c-0.3-0.9-0.8-1.6-1.5-2c-0.7-0.5-1.5-0.7-2.6-0.7c-1.4,0-2.6,0.5-3.4,1.6s-1.3,2.6-1.3,4.5s0.4,3.4,1.3,4.4s2,1.6,3.4,1.6   c2.1,0,3.4-0.9,4-2.8h5.5c-0.6,2.2-1.7,3.9-3.3,5.2s-3.7,1.9-6.2,1.9c-1.9,0-3.7-0.4-5.2-1.3c-1.5-0.9-2.7-2.1-3.5-3.6   s-1.3-3.4-1.3-5.5C1674.7,244.8,1675.1,243,1675.9,241.4L1675.9,241.4z"
+   id="path560" />
+	<path
+   class="st8"
+   d="M1697.3,241.4c0.8-1.6,1.9-2.8,3.3-3.6c1.4-0.9,2.9-1.3,4.7-1.3c1.5,0,2.8,0.3,3.9,0.9c1.1,0.6,2,1.4,2.7,2.3   v-2.9h5.1v20.1h-5.1V254c-0.7,0.9-1.6,1.7-2.7,2.3c-1.2,0.6-2.5,0.9-4,0.9c-1.7,0-3.2-0.4-4.6-1.3s-2.5-2.1-3.3-3.7   c-0.8-1.6-1.2-3.4-1.2-5.5C1696.1,244.8,1696.5,243,1697.3,241.4L1697.3,241.4z M1711.2,243.7c-0.5-0.9-1.1-1.6-2-2   s-1.7-0.7-2.7-0.7c-0.9,0-1.8,0.2-2.6,0.7c-0.8,0.5-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.8,3.2c0.5,0.9,1.2,1.6,2,2.1   s1.7,0.7,2.6,0.7s1.8-0.2,2.7-0.7c0.8-0.5,1.5-1.1,2-2s0.7-1.9,0.7-3.2S1711.7,244.6,1711.2,243.7L1711.2,243.7z"
+   id="path562" />
+	<path
+   class="st8"
+   d="M1726.7,230.1v26.8h-5.1v-26.8L1726.7,230.1L1726.7,230.1z"
+   id="path564" />
+	<path
+   class="st8"
+   d="M1749.9,248.3h-14.7c0.1,1.4,0.6,2.6,1.5,3.4c0.9,0.8,2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5   c-0.6,1.9-1.7,3.5-3.3,4.8s-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3c-1.5-0.9-2.7-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4   c0-2.1,0.4-3.9,1.3-5.5c0.8-1.6,2-2.8,3.6-3.6s3.3-1.3,5.3-1.3c1.9,0,3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.3,3.2,1.3,5.2   C1750.1,247.1,1750,247.8,1749.9,248.3L1749.9,248.3z M1744.8,244.9c0-1.3-0.5-2.4-1.4-3.1c-0.9-0.8-2-1.2-3.4-1.2   c-1.3,0-2.3,0.4-3.2,1.1c-0.9,0.8-1.4,1.8-1.6,3.2H1744.8L1744.8,244.9z"
+   id="path566" />
+	<path
+   class="st8"
+   d="M1777.5,233.1c2,1,3.6,2.5,4.7,4.4s1.7,4.1,1.7,6.7c0,2.5-0.5,4.8-1.6,6.7s-2.7,3.4-4.7,4.4s-4.4,1.6-7,1.6   h-8.8v-25.3h8.8C1773.2,231.5,1775.5,232,1777.5,233.1L1777.5,233.1z M1776.5,250.3c1.4-1.4,2.2-3.5,2.2-6.1s-0.7-4.7-2.2-6.2   c-1.4-1.5-3.5-2.2-6.2-2.2h-3.6v16.7h3.6C1773,252.5,1775.1,251.8,1776.5,250.3z"
+   id="path568" />
+	<path
+   class="st8"
+   d="M1805.2,245.9c0.9,1.2,1.4,2.5,1.4,4c0,1.4-0.3,2.5-1,3.6c-0.7,1-1.6,1.8-2.9,2.4c-1.3,0.6-2.7,0.9-4.5,0.9   h-10.9v-25.3h10.4c1.7,0,3.2,0.3,4.4,0.8c1.2,0.6,2.2,1.3,2.8,2.3s1,2.1,1,3.4c0,1.5-0.4,2.7-1.2,3.7c-0.8,1-1.8,1.7-3.1,2.1   C1803.1,244.1,1804.3,244.8,1805.2,245.9L1805.2,245.9z M1792.4,241.9h4.6c1.2,0,2.1-0.3,2.8-0.8c0.7-0.5,1-1.3,1-2.3   s-0.3-1.8-1-2.4c-0.7-0.6-1.6-0.8-2.8-0.8h-4.6V241.9L1792.4,241.9z M1800.4,251.8c0.7-0.6,1-1.4,1-2.5s-0.4-1.9-1.1-2.6   c-0.7-0.6-1.7-0.9-2.9-0.9h-5v6.8h5.1C1798.7,252.7,1799.7,252.4,1800.4,251.8L1800.4,251.8z"
+   id="path570" />
+	<path
+   class="st8"
+   d="M1808.7,231.2h9.6v3h-2.9v9.8h-3.8v-9.8h-2.9L1808.7,231.2L1808.7,231.2z M1836.4,231.2V244h-3.5l-0.1-8   l-3.3,8h-2.6l-3.3-8.3v8.3h-3.4v-12.8h5l3.1,8.2l3.3-8.2H1836.4L1836.4,231.2z"
+   id="path572" />
+	<path
+   class="st8"
+   d="M1852.5,231.9l1.8,3.3l-4.7,1.7l4.7,1.7l-1.9,3.4l-3.9-3.2l0.8,5h-3.8l0.8-5l-3.9,3.3l-2-3.5l4.7-1.7l-4.7-1.6   l1.8-3.3l4,3.2l-0.8-5h3.8l-0.9,5L1852.5,231.9L1852.5,231.9z"
+   id="path574" />
+</g>
+<g
+   id="g600">
+	<path
+   class="st8"
+   d="M266.7,569.5c-0.6-1.1-1.4-1.9-2.4-2.4s-2.2-0.8-3.6-0.8c-1.5,0-2.8,0.3-4,1c-1.2,0.7-2.1,1.7-2.7,2.9   c-0.6,1.3-1,2.7-1,4.3c0,1.7,0.3,3.2,1,4.4c0.7,1.3,1.6,2.2,2.8,2.9c1.2,0.7,2.6,1,4.1,1c1.9,0,3.5-0.5,4.8-1.5   c1.2-1,2-2.5,2.4-4.3h-8.7v-3.9h13.7v4.4c-0.3,1.8-1,3.4-2.2,4.9c-1.1,1.5-2.5,2.7-4.3,3.6c-1.8,0.9-3.7,1.4-5.9,1.4   c-2.4,0-4.6-0.5-6.6-1.6s-3.5-2.6-4.6-4.6s-1.7-4.2-1.7-6.7s0.6-4.7,1.7-6.7c1.1-2,2.7-3.5,4.6-4.6c1.9-1.1,4.2-1.7,6.6-1.7   c2.9,0,5.3,0.7,7.4,2.1c2.1,1.4,3.6,3.3,4.4,5.8L266.7,569.5L266.7,569.5z"
+   id="path578" />
+	<path
+   class="st8"
+   d="M276.5,571.7c0.8-1.6,1.9-2.8,3.3-3.6s2.9-1.3,4.7-1.3c1.5,0,2.8,0.3,3.9,0.9c1.1,0.6,2,1.4,2.7,2.3v-2.9h5.1   v20.1h-5.1v-2.9c-0.6,0.9-1.5,1.7-2.7,2.3c-1.1,0.6-2.5,0.9-4,0.9c-1.7,0-3.2-0.4-4.6-1.3c-1.4-0.9-2.5-2.1-3.3-3.7   c-0.8-1.6-1.2-3.4-1.2-5.5C275.3,575.1,275.7,573.3,276.5,571.7L276.5,571.7z M290.4,574c-0.5-0.9-1.1-1.6-2-2   c-0.8-0.5-1.7-0.7-2.6-0.7s-1.8,0.2-2.6,0.7s-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.8,3.2c0.5,0.9,1.1,1.6,2,2.1   c0.8,0.5,1.7,0.7,2.6,0.7s1.8-0.2,2.6-0.7s1.5-1.2,2-2c0.5-0.9,0.7-1.9,0.7-3.2S290.9,574.9,290.4,574L290.4,574z"
+   id="path580" />
+	<path
+   class="st8"
+   d="M306.7,571.3v9.7c0,0.7,0.2,1.2,0.5,1.5s0.9,0.5,1.6,0.5h2.4v4.3H308c-4.3,0-6.4-2.1-6.4-6.2v-9.7h-2.4v-4.2   h2.4v-5h5.1v5h4.5v4.2L306.7,571.3L306.7,571.3z"
+   id="path582" />
+	<path
+   class="st8"
+   d="M333.1,578.6h-14.7c0.1,1.5,0.6,2.6,1.5,3.4c0.9,0.8,2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5   c-0.6,1.9-1.7,3.5-3.3,4.8c-1.6,1.2-3.7,1.9-6,1.9c-1.9,0-3.7-0.4-5.2-1.3c-1.5-0.9-2.7-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4   c0-2.1,0.4-3.9,1.3-5.5s2-2.8,3.5-3.6s3.3-1.3,5.3-1.3c1.9,0,3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.3,3.2,1.3,5.2   C333.2,577.4,333.2,578.1,333.1,578.6L333.1,578.6z M328,575.2c0-1.3-0.5-2.3-1.4-3.1s-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.2   c-0.9,0.8-1.4,1.8-1.6,3.2L328,575.2L328,575.2z"
+   id="path584" />
+	<path
+   class="st8"
+   d="M348.5,587.1l-6.8-8.5v8.6h-5.1v-26.8h5.1v15.3l6.7-8.5h6.6l-8.8,10.1l8.9,10L348.5,587.1L348.5,587.1z"
+   id="path586" />
+	<path
+   class="st8"
+   d="M375.9,578.6h-14.7c0.1,1.5,0.6,2.6,1.5,3.4c0.9,0.8,2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5   c-0.6,1.9-1.7,3.5-3.3,4.8s-3.7,1.9-6,1.9c-1.9,0-3.7-0.4-5.2-1.3c-1.5-0.9-2.7-2.1-3.6-3.6c-0.9-1.6-1.3-3.4-1.3-5.4   c0-2.1,0.4-3.9,1.3-5.5s2-2.8,3.5-3.6s3.3-1.3,5.3-1.3c1.9,0,3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.3,3.2,1.3,5.2   C376.1,577.4,376,578,375.9,578.6L375.9,578.6z M370.8,575.2c0-1.3-0.5-2.3-1.4-3.1s-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.2   c-0.9,0.8-1.4,1.8-1.6,3.2L370.8,575.2L370.8,575.2z"
+   id="path588" />
+	<path
+   class="st8"
+   d="M397.9,578.6h-14.7c0.1,1.5,0.6,2.6,1.5,3.4c0.9,0.8,2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5   c-0.6,1.9-1.7,3.5-3.3,4.8c-1.6,1.2-3.7,1.9-6,1.9c-1.9,0-3.7-0.4-5.2-1.3c-1.5-0.9-2.7-2.1-3.6-3.6s-1.3-3.4-1.3-5.4   c0-2.1,0.4-3.9,1.3-5.5s2-2.8,3.5-3.6s3.3-1.3,5.3-1.3c1.9,0,3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.3,3.2,1.3,5.2   C398.1,577.3,398,578,397.9,578.6L397.9,578.6z M392.8,575.2c0-1.3-0.5-2.3-1.4-3.1s-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.2   c-0.9,0.8-1.4,1.8-1.6,3.2L392.8,575.2L392.8,575.2z"
+   id="path590" />
+	<path
+   class="st8"
+   d="M409.2,567.6c1.1-0.6,2.5-0.9,3.9-0.9c1.7,0,3.3,0.4,4.7,1.3s2.5,2,3.3,3.6s1.2,3.4,1.2,5.4s-0.4,3.9-1.2,5.5   s-1.9,2.8-3.3,3.7s-2.9,1.3-4.7,1.3c-1.5,0-2.8-0.3-3.9-0.9c-1.1-0.6-2-1.4-2.7-2.3v12.4h-5.1V567h5.1v2.9   C407.1,568.9,408,568.2,409.2,567.6L409.2,567.6z M416.4,573.8c-0.5-0.9-1.1-1.5-2-2s-1.7-0.7-2.6-0.7s-1.8,0.2-2.6,0.7   c-0.8,0.5-1.5,1.2-2,2c-0.5,0.9-0.7,2-0.7,3.2s0.2,2.3,0.8,3.2s1.1,1.6,2,2s1.7,0.7,2.6,0.7s1.8-0.2,2.6-0.7c0.8-0.5,1.5-1.2,2-2.1   c0.5-0.9,0.7-2,0.7-3.2C417.1,575.7,416.9,574.7,416.4,573.8z"
+   id="path592" />
+	<path
+   class="st8"
+   d="M444.2,578.5h-14.7c0.1,1.5,0.6,2.6,1.5,3.4c0.9,0.8,2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5   c-0.6,1.9-1.7,3.5-3.3,4.8c-1.6,1.2-3.7,1.9-6,1.9c-1.9,0-3.7-0.4-5.2-1.3c-1.5-0.9-2.7-2.1-3.6-3.6s-1.3-3.4-1.3-5.4   c0-2.1,0.4-3.9,1.3-5.5s2-2.8,3.5-3.6s3.3-1.3,5.3-1.3c1.9,0,3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.3,5.2   C444.3,577.3,444.3,577.9,444.2,578.5L444.2,578.5z M439,575.1c0-1.3-0.5-2.3-1.4-3.1s-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.2   c-0.9,0.8-1.4,1.8-1.6,3.2L439,575.1L439,575.1z"
+   id="path594" />
+	<path
+   class="st8"
+   d="M455.3,567.5c1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1s-1.2,2.1-1.2,3.9v10h-5.1v-20.1h5.1v3.1   C453.4,569,454.2,568.1,455.3,567.5L455.3,567.5z"
+   id="path596" />
+	<path
+   class="st8"
+   d="M460.3,561.4h9.6v3H467v9.8h-3.8v-9.8h-2.9L460.3,561.4L460.3,561.4z M488.1,561.4v12.8h-3.5l-0.1-8l-3.3,8   h-2.6l-3.3-8.3v8.3H472v-12.8h5l3.1,8.2l3.3-8.2H488.1L488.1,561.4z"
+   id="path598" />
+</g>
+<path
+   class="st8"
+   d="M1836.3,412.1v11.4c0,10.5-23.7,18.9-53,18.9s-53-8.5-53-18.9v-11.4c0-10.5,23.7-18.9,53-18.9  S1836.3,401.7,1836.3,412.1z M1823.3,444c4.9-1.8,9.4-4,13-6.8v24.1c0,10.5-23.7,18.9-53,18.9s-53-8.5-53-18.9v-24.1  c3.5,2.8,8,5,13,6.8c10.6,3.8,24.8,6,40,6S1812.7,447.8,1823.3,444L1823.3,444z M1730.3,475.1c3.5,2.8,8,5,13,6.8  c10.6,3.8,24.8,6,40,6s29.4-2.2,40-6c4.9-1.8,9.4-4,13-6.8v20.3c0,10.5-23.7,18.9-53,18.9s-53-8.5-53-18.9V475.1L1730.3,475.1z"
+   id="path602" />
+<g
+   id="g618">
+	<path
+   class="st8"
+   d="M1728.6,588.8l-5.9-10.4h-2.5v10.5h-5.4v-26.8h10.1c2.1,0,3.8,0.3,5.3,1.1c1.5,0.7,2.6,1.7,3.3,3   s1.1,2.6,1.1,4.2c0,1.8-0.5,3.4-1.5,4.8c-1,1.4-2.5,2.4-4.6,2.9l6.4,10.9L1728.6,588.8L1728.6,588.8z M1720.2,574.3h4.5   c1.5,0,2.6-0.4,3.3-1.1c0.7-0.7,1.1-1.7,1.1-2.9s-0.4-2.2-1.1-2.9s-1.8-1-3.3-1h-4.5V574.3L1720.2,574.3z"
+   id="path604" />
+	<path
+   class="st8"
+   d="M1758.7,579.7h-15.6c0.1,1.5,0.7,2.7,1.6,3.6s2.1,1.3,3.5,1.3c2,0,3.4-0.9,4.3-2.6h5.8c-0.6,2-1.8,3.7-3.5,5   s-3.9,2-6.4,2c-2.1,0-3.9-0.5-5.5-1.4s-2.9-2.2-3.8-3.8s-1.4-3.6-1.4-5.8s0.4-4.1,1.3-5.8s2.2-3,3.8-3.8c1.6-0.9,3.5-1.3,5.6-1.3   c2,0,3.8,0.4,5.4,1.3c1.6,0.9,2.8,2.1,3.7,3.7c0.9,1.6,1.3,3.4,1.3,5.5C1758.8,578.4,1758.8,579.1,1758.7,579.7L1758.7,579.7z    M1753.2,576.1c0-1.4-0.5-2.5-1.5-3.3s-2.2-1.2-3.6-1.2c-1.3,0-2.4,0.4-3.4,1.2c-0.9,0.8-1.5,1.9-1.7,3.4L1753.2,576.1   L1753.2,576.1z"
+   id="path606" />
+	<path
+   class="st8"
+   d="M1762.2,572.3c0.9-1.7,2-3,3.5-3.8c1.5-0.9,3.1-1.3,4.9-1.3c1.4,0,2.7,0.3,4,0.9c1.2,0.6,2.2,1.4,3,2.4v-10.1   h5.4v28.4h-5.4v-3.1c-0.7,1-1.6,1.9-2.8,2.5c-1.2,0.6-2.6,1-4.2,1c-1.8,0-3.4-0.5-4.9-1.4s-2.7-2.2-3.5-3.9   c-0.9-1.7-1.3-3.6-1.3-5.8C1761,575.9,1761.4,574,1762.2,572.3L1762.2,572.3z M1776.9,574.7c-0.5-0.9-1.2-1.7-2.1-2.2   s-1.8-0.8-2.8-0.7c-1,0-1.9,0.2-2.8,0.7s-1.5,1.2-2.1,2.1s-0.8,2-0.8,3.3s0.3,2.4,0.8,3.4s1.2,1.7,2.1,2.2s1.8,0.8,2.8,0.8   s1.9-0.2,2.8-0.8s1.6-1.2,2.1-2.2c0.5-0.9,0.8-2.1,0.8-3.4C1777.7,576.8,1777.4,575.6,1776.9,574.7L1776.9,574.7z"
+   id="path608" />
+	<path
+   class="st8"
+   d="M1788.3,564c-0.6-0.6-0.9-1.3-0.9-2.2s0.3-1.6,0.9-2.2c0.6-0.6,1.4-0.9,2.4-0.9s1.7,0.3,2.4,0.9   c0.6,0.6,0.9,1.3,0.9,2.2s-0.3,1.7-0.9,2.2s-1.4,0.9-2.4,0.9S1789,564.6,1788.3,564z M1793.4,567.4v21.3h-5.4v-21.3H1793.4z"
+   id="path610" />
+	<path
+   class="st8"
+   d="M1801.8,588.1c-1.4-0.6-2.5-1.5-3.3-2.5s-1.2-2.3-1.3-3.6h5.4c0.1,0.8,0.5,1.5,1.2,2s1.6,0.8,2.6,0.8   s1.8-0.2,2.4-0.6c0.6-0.4,0.9-0.9,0.9-1.6c0-0.7-0.3-1.2-1.1-1.5c-0.7-0.3-1.8-0.7-3.4-1.1c-1.6-0.4-2.9-0.8-3.9-1.2   s-1.9-1-2.6-1.9s-1.1-2-1.1-3.4c0-1.2,0.3-2.2,1-3.2s1.7-1.7,2.9-2.3c1.3-0.6,2.8-0.8,4.5-0.8c2.5,0,4.6,0.6,6.1,1.9   c1.5,1.3,2.3,3,2.5,5.1h-5.2c-0.1-0.8-0.4-1.5-1.1-2s-1.5-0.8-2.5-0.8s-1.7,0.2-2.2,0.5c-0.5,0.4-0.8,0.9-0.8,1.5   c0,0.7,0.4,1.3,1.1,1.6s1.8,0.8,3.3,1.1c1.5,0.4,2.8,0.8,3.8,1.2s1.9,1,2.6,1.9s1.1,2,1.1,3.4c0,1.2-0.3,2.3-1,3.3   s-1.7,1.7-2.9,2.3s-2.8,0.8-4.4,0.8C1804.7,589,1803.1,588.7,1801.8,588.1L1801.8,588.1z"
+   id="path612" />
+	<path
+   class="st8"
+   d="M1830.3,562.5c1.2,0.7,2.2,1.7,2.9,2.9c0.7,1.2,1,2.7,1,4.2c0,1.6-0.3,3-1,4.2s-1.7,2.2-2.9,2.9   c-1.2,0.7-2.6,1.1-4.2,1.1s-3-0.3-4.2-1s-2.2-1.7-2.9-2.9s-1.1-2.6-1.1-4.2c0-1.6,0.3-3,1.1-4.2c0.7-1.2,1.7-2.2,2.9-2.9   c1.2-0.7,2.6-1,4.2-1C1827.6,561.4,1829,561.8,1830.3,562.5L1830.3,562.5z M1830.5,574.1c1.1-1.1,1.7-2.6,1.7-4.5s-0.6-3.4-1.7-4.5   s-2.6-1.7-4.4-1.7s-3.3,0.6-4.4,1.7s-1.7,2.7-1.6,4.5c0,1.9,0.6,3.4,1.7,4.5s2.6,1.7,4.4,1.7   C1827.9,575.8,1829.4,575.2,1830.5,574.1L1830.5,574.1z M1829.3,569.5c-0.3,0.4-0.7,0.7-1.1,0.9l2,3.2h-3l-1.7-2.9h-0.2v2.9h-2.6   v-8.2h4c0.9,0,1.6,0.2,2.2,0.8s0.8,1.2,0.8,1.9C1829.7,568.6,1829.6,569.1,1829.3,569.5L1829.3,569.5z M1825.2,568.8h1.2   c0.2,0,0.3,0,0.5-0.2c0.1-0.1,0.2-0.3,0.2-0.5c0-0.4-0.2-0.6-0.7-0.6h-1.2V568.8L1825.2,568.8z"
+   id="path614" />
+	<path
+   class="st8"
+   d="M1850.1,563.7l1.8,3.3l-4.7,1.7l4.7,1.7l-1.9,3.4l-3.9-3.2l0.8,5h-3.8l0.8-5l-3.9,3.3l-2-3.5l4.7-1.7l-4.7-1.6   l1.8-3.3l4,3.2l-0.8-5h3.8l-0.9,5L1850.1,563.7L1850.1,563.7z"
+   id="path616" />
+</g>
+<g
+   id="g644">
+	<path
+   class="st8"
+   d="M1058.8,898.7c1.1-2,2.7-3.5,4.6-4.6s4.1-1.7,6.5-1.7c2.8,0,5.3,0.7,7.4,2.2s3.6,3.5,4.5,6h-5.8   c-0.6-1.2-1.4-2.1-2.4-2.7c-1.1-0.6-2.3-0.9-3.7-0.9c-1.5,0-2.8,0.3-3.9,1c-1.2,0.7-2,1.7-2.7,2.9c-0.6,1.3-1,2.7-1,4.4   s0.3,3.1,1,4.4c0.6,1.3,1.5,2.2,2.7,2.9s2.5,1,3.9,1s2.6-0.3,3.6-0.9s1.9-1.5,2.4-2.7h5.8c-0.8,2.6-2.3,4.6-4.4,6s-4.6,2.2-7.4,2.2   c-2.4,0-4.6-0.5-6.6-1.6c-1.9-1.1-3.5-2.6-4.6-4.6s-1.7-4.2-1.7-6.7S1057.7,900.7,1058.8,898.7L1058.8,898.7z"
+   id="path620" />
+	<path
+   class="st8"
+   d="M1104.4,909.5h-14.7c0.1,1.5,0.6,2.6,1.5,3.4c0.9,0.8,2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5   c-0.6,1.9-1.7,3.5-3.3,4.8s-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3c-1.5-0.9-2.7-2.1-3.6-3.6s-1.3-3.4-1.3-5.4   c0-2.1,0.4-3.9,1.3-5.5s2-2.8,3.6-3.6s3.3-1.3,5.3-1.3c1.9,0,3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.3,3.2,1.3,5.2   C1104.6,908.3,1104.5,909,1104.4,909.5L1104.4,909.5z M1099.3,906.1c0-1.3-0.5-2.3-1.4-3.1s-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.2   c-0.9,0.8-1.4,1.8-1.6,3.2L1099.3,906.1L1099.3,906.1z"
+   id="path622" />
+	<path
+   class="st8"
+   d="M1115.5,898.6c1.1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1   v-20.1h5.1v3.1C1113.6,900,1114.5,899.2,1115.5,898.6L1115.5,898.6z"
+   id="path624" />
+	<path
+   class="st8"
+   d="M1128.1,902.1v9.7c0,0.7,0.2,1.2,0.5,1.5s0.9,0.5,1.7,0.5h2.4v4.3h-3.2c-4.3,0-6.4-2.1-6.4-6.2v-9.7h-2.4V898   h2.4v-5h5.1v5h4.5v4.2L1128.1,902.1L1128.1,902.1z"
+   id="path626" />
+	<path
+   class="st8"
+   d="M1151.3,902.9v4.3h-15.4v-4.3H1151.3z"
+   id="path628" />
+	<path
+   class="st8"
+   d="M1184.3,892.7V918h-5.1v-16.5l-6.8,16.5h-3.8l-6.8-16.5V918h-5.1v-25.3h5.8l8.1,18.8l8-18.8H1184.3   L1184.3,892.7z"
+   id="path630" />
+	<path
+   class="st8"
+   d="M1188.8,902.4c0.8-1.6,1.9-2.8,3.3-3.6s2.9-1.3,4.7-1.3c1.5,0,2.8,0.3,3.9,0.9c1.1,0.6,2,1.4,2.7,2.3v-2.9h5.1   v20.1h-5.1V915c-0.7,0.9-1.6,1.7-2.7,2.3c-1.2,0.6-2.5,0.9-4,0.9c-1.7,0-3.2-0.4-4.6-1.3c-1.4-0.9-2.5-2.1-3.3-3.7   c-0.8-1.6-1.2-3.4-1.2-5.5C1187.6,905.8,1188,904,1188.8,902.4L1188.8,902.4z M1202.7,904.7c-0.5-0.9-1.1-1.6-2-2   c-0.8-0.5-1.7-0.7-2.7-0.7c-0.9,0-1.8,0.2-2.6,0.7c-0.8,0.5-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.8,3.2c0.5,0.9,1.2,1.6,2,2.1   s1.7,0.7,2.6,0.7s1.8-0.2,2.7-0.7c0.8-0.5,1.5-1.2,2-2c0.5-0.9,0.7-1.9,0.7-3.2S1203.2,905.6,1202.7,904.7L1202.7,904.7z"
+   id="path632" />
+	<path
+   class="st8"
+   d="M1230.1,899.8c1.5,1.5,2.2,3.6,2.2,6.3v11.8h-5.1v-11.1c0-1.6-0.4-2.8-1.2-3.7c-0.8-0.9-1.9-1.3-3.3-1.3   s-2.5,0.4-3.3,1.3c-0.8,0.9-1.2,2.1-1.2,3.7v11.1h-5.1v-20.1h5.1v2.5c0.7-0.9,1.5-1.6,2.6-2c1.1-0.5,2.2-0.8,3.5-0.8   C1226.7,897.5,1228.6,898.3,1230.1,899.8L1230.1,899.8z"
+   id="path634" />
+	<path
+   class="st8"
+   d="M1236.7,902.4c0.8-1.6,1.9-2.8,3.3-3.6s2.9-1.3,4.7-1.3c1.5,0,2.8,0.3,3.9,0.9c1.1,0.6,2,1.4,2.7,2.3v-2.9h5.1   v20.1h-5.1V915c-0.7,0.9-1.6,1.7-2.7,2.3c-1.2,0.6-2.5,0.9-4,0.9c-1.7,0-3.2-0.4-4.6-1.3c-1.4-0.9-2.5-2.1-3.3-3.7   c-0.8-1.6-1.2-3.4-1.2-5.5C1235.5,905.8,1235.9,904,1236.7,902.4L1236.7,902.4z M1250.5,904.7c-0.5-0.9-1.1-1.6-2-2   c-0.8-0.5-1.7-0.7-2.7-0.7c-0.9,0-1.8,0.2-2.6,0.7c-0.8,0.5-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.8,3.2c0.5,0.9,1.2,1.6,2,2.1   s1.7,0.7,2.6,0.7s1.8-0.2,2.7-0.7c0.8-0.5,1.5-1.2,2-2c0.5-0.9,0.7-1.9,0.7-3.2S1251,905.6,1250.5,904.7L1250.5,904.7z"
+   id="path636" />
+	<path
+   class="st8"
+   d="M1272.8,898.3c1.1,0.6,2,1.4,2.7,2.3v-2.9h5.1v20.2c0,1.9-0.4,3.5-1.1,5c-0.8,1.5-1.9,2.6-3.4,3.5   s-3.3,1.3-5.4,1.3c-2.8,0-5.2-0.7-7-2s-2.9-3.1-3.1-5.4h5c0.3,0.9,0.8,1.6,1.7,2.2c0.9,0.5,1.9,0.8,3.2,0.8c1.5,0,2.7-0.4,3.6-1.3   c0.9-0.9,1.4-2.2,1.4-4v-3.1c-0.7,0.9-1.6,1.7-2.7,2.4c-1.2,0.6-2.5,1-3.9,1c-1.7,0-3.2-0.4-4.6-1.3s-2.5-2.1-3.3-3.7   c-0.8-1.6-1.2-3.4-1.2-5.5c0-2,0.4-3.8,1.2-5.4c0.8-1.6,1.9-2.8,3.3-3.6s2.9-1.3,4.7-1.3C1270.4,897.4,1271.7,897.7,1272.8,898.3   L1272.8,898.3z M1274.8,904.6c-0.5-0.9-1.1-1.6-2-2c-0.8-0.5-1.7-0.7-2.7-0.7c-0.9,0-1.8,0.2-2.6,0.7c-0.8,0.5-1.4,1.1-1.9,2   s-0.7,1.9-0.7,3.1s0.2,2.3,0.8,3.2c0.5,0.9,1.2,1.6,2,2.1s1.7,0.7,2.6,0.7s1.8-0.2,2.7-0.7s1.5-1.2,2-2c0.5-0.9,0.7-1.9,0.7-3.2   S1275.2,905.5,1274.8,904.6L1274.8,904.6z"
+   id="path638" />
+	<path
+   class="st8"
+   d="M1303.7,909.3H1289c0.1,1.5,0.6,2.6,1.5,3.4c0.9,0.8,2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5   c-0.6,1.9-1.7,3.5-3.3,4.8s-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3c-1.5-0.9-2.7-2.1-3.6-3.6s-1.3-3.4-1.3-5.4   c0-2.1,0.4-3.9,1.3-5.5s2-2.8,3.6-3.6s3.3-1.3,5.3-1.3c1.9,0,3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.3,3.2,1.3,5.2   C1303.9,908.1,1303.8,908.7,1303.7,909.3L1303.7,909.3z M1298.6,905.9c0-1.3-0.5-2.3-1.4-3.1s-2-1.2-3.4-1.2   c-1.3,0-2.3,0.4-3.2,1.2c-0.9,0.8-1.4,1.8-1.6,3.2L1298.6,905.9L1298.6,905.9z"
+   id="path640" />
+	<path
+   class="st8"
+   d="M1314.8,898.3c1.1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1   v-20.1h5.1v3.1C1312.9,899.8,1313.8,898.9,1314.8,898.3L1314.8,898.3z"
+   id="path642" />
+</g>
+<g
+   id="g692">
+	<path
+   class="st8"
+   d="M1612.7,901.2h-5.1l-11.5-17.3v17.4h-5.1V876h5.1l11.5,17.4V876h5.1V901.2L1612.7,901.2z"
+   id="path646" />
+	<path
+   class="st8"
+   d="M1634.9,883.4c-0.6-1.1-1.4-1.9-2.4-2.4s-2.2-0.8-3.6-0.8c-1.5,0-2.8,0.3-4,1s-2.1,1.7-2.7,2.9   c-0.7,1.3-1,2.7-1,4.3c0,1.7,0.3,3.2,1,4.4c0.7,1.3,1.6,2.2,2.8,2.9c1.2,0.7,2.6,1,4.1,1c1.9,0,3.5-0.5,4.8-1.5   c1.2-1,2-2.5,2.4-4.3h-8.7V887h13.7v4.4c-0.3,1.8-1.1,3.4-2.2,4.9s-2.5,2.7-4.3,3.6c-1.8,0.9-3.7,1.4-5.9,1.4   c-2.4,0-4.7-0.5-6.6-1.6c-2-1.1-3.5-2.6-4.7-4.6s-1.7-4.2-1.7-6.7s0.6-4.7,1.7-6.7s2.7-3.5,4.6-4.6s4.2-1.7,6.6-1.7   c2.8,0,5.3,0.7,7.4,2.1s3.6,3.3,4.4,5.8L1634.9,883.4L1634.9,883.4z"
+   id="path648" />
+	<path
+   class="st8"
+   d="M1649.8,875.8v25.3h-5.1v-25.3H1649.8z"
+   id="path650" />
+	<path
+   class="st8"
+   d="M1676.2,901.1h-5.1l-11.5-17.3v17.4h-5.1v-25.3h5.1l11.5,17.4v-17.4h5.1V901.1L1676.2,901.1z"
+   id="path652" />
+	<path
+   class="st8"
+   d="M1696,901.1l-5.5-8.5l-5,8.5h-5.7l8-12.8l-8.1-12.5h5.8l5.5,8.5l4.9-8.5h5.7l-7.9,12.7l8.1,12.6H1696   L1696,901.1z"
+   id="path654" />
+	<path
+   class="st8"
+   d="M1716.1,876.3c1.2,0.7,2.1,1.6,2.7,2.7s1,2.5,1,4s-0.3,2.8-1,4s-1.6,2.1-2.7,2.7c-1.2,0.7-2.5,1-4,1   s-2.8-0.3-4-1s-2.1-1.6-2.8-2.7s-1-2.5-1-4s0.3-2.8,1-4s1.6-2.1,2.8-2.7s2.5-1,4-1S1715,875.7,1716.1,876.3L1716.1,876.3z    M1716.4,887.3c1.1-1.1,1.6-2.5,1.6-4.2c0-1.8-0.5-3.2-1.6-4.3s-2.4-1.6-4.2-1.6s-3.1,0.5-4.2,1.6s-1.6,2.5-1.6,4.3   s0.5,3.2,1.6,4.2s2.4,1.6,4.2,1.6S1715.3,888.3,1716.4,887.3L1716.4,887.3z M1715.2,883c-0.2,0.4-0.6,0.7-1.1,0.9l1.9,3h-2.8   l-1.6-2.7h-0.2v2.7h-2.4v-7.8h3.8c0.8,0,1.5,0.2,2,0.7s0.8,1.1,0.8,1.8C1715.6,882.1,1715.4,882.6,1715.2,883L1715.2,883z    M1711.4,882.3h1.2c0.2,0,0.3,0,0.4-0.2c0.1-0.1,0.2-0.2,0.2-0.4c0-0.4-0.2-0.5-0.6-0.5h-1.2V882.3L1711.4,882.3z"
+   id="path656" />
+	<path
+   class="st8"
+   d="M1737,875.7V901h-5.1v-25.3H1737z"
+   id="path658" />
+	<path
+   class="st8"
+   d="M1758.6,882.9c1.5,1.5,2.2,3.6,2.2,6.3V901h-5.1v-11.1c0-1.6-0.4-2.8-1.2-3.7s-1.9-1.3-3.3-1.3   s-2.5,0.4-3.3,1.3c-0.8,0.9-1.2,2.1-1.2,3.7V901h-5.1v-20.1h5.1v2.5c0.7-0.9,1.5-1.6,2.6-2s2.2-0.8,3.5-0.8   C1755.2,880.6,1757.1,881.4,1758.6,882.9L1758.6,882.9z"
+   id="path660" />
+	<path
+   class="st8"
+   d="M1777.1,881.4c1.1,0.6,2,1.4,2.7,2.3v-2.9h5.1V901c0,1.9-0.4,3.5-1.1,5s-1.9,2.6-3.4,3.5s-3.3,1.3-5.4,1.3   c-2.8,0-5.2-0.7-7-2s-2.9-3.1-3.1-5.4h5c0.3,0.9,0.8,1.6,1.7,2.2c0.9,0.5,1.9,0.8,3.2,0.8c1.5,0,2.7-0.5,3.6-1.3   c0.9-0.9,1.4-2.2,1.4-4V898c-0.7,0.9-1.6,1.7-2.7,2.4c-1.2,0.6-2.5,1-3.9,1c-1.7,0-3.2-0.4-4.6-1.3s-2.5-2.1-3.3-3.7   c-0.8-1.6-1.2-3.4-1.2-5.5c0-2,0.4-3.8,1.2-5.4c0.8-1.6,1.9-2.8,3.3-3.6s2.9-1.3,4.7-1.3C1774.6,880.5,1775.9,880.8,1777.1,881.4   L1777.1,881.4z M1779,887.7c-0.5-0.9-1.1-1.6-2-2c-0.8-0.5-1.7-0.7-2.7-0.7c-0.9,0-1.8,0.2-2.6,0.7c-0.8,0.5-1.4,1.1-1.9,2   s-0.7,1.9-0.7,3.1s0.2,2.3,0.8,3.2s1.2,1.6,2,2.1s1.7,0.7,2.6,0.7s1.8-0.2,2.7-0.7s1.5-1.2,2-2c0.5-0.9,0.7-1.9,0.7-3.2   S1779.5,888.6,1779,887.7L1779,887.7z"
+   id="path662" />
+	<path
+   class="st8"
+   d="M1797.1,881.5c1.1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1   v-20.1h5.1v3.1C1795.2,882.9,1796.1,882.1,1797.1,881.5L1797.1,881.5z"
+   id="path664" />
+	<path
+   class="st8"
+   d="M1822.3,892.4h-14.7c0.1,1.5,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5c-0.6,1.9-1.7,3.5-3.3,4.8   s-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3c-1.5-0.9-2.7-2.1-3.6-3.6s-1.3-3.4-1.3-5.4c0-2.1,0.4-3.9,1.3-5.5s2-2.8,3.6-3.6   s3.3-1.3,5.3-1.3c1.9,0,3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.3,5.2C1822.5,891.2,1822.4,891.8,1822.3,892.4L1822.3,892.4z    M1817.2,889c0-1.3-0.5-2.3-1.4-3.1s-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.2c-0.9,0.8-1.4,1.8-1.6,3.2L1817.2,889L1817.2,889z"
+   id="path666" />
+	<path
+   class="st8"
+   d="M1829.1,900.3c-1.3-0.6-2.3-1.4-3.1-2.4c-0.8-1-1.2-2.1-1.3-3.4h5.1c0.1,0.8,0.5,1.4,1.2,1.9s1.5,0.8,2.5,0.8   s1.7-0.2,2.3-0.6c0.5-0.4,0.8-0.9,0.8-1.5c0-0.7-0.3-1.1-1-1.5c-0.7-0.3-1.7-0.7-3.2-1.1c-1.5-0.4-2.7-0.7-3.7-1.1   c-1-0.4-1.8-1-2.5-1.8s-1-1.9-1-3.2c0-1.1,0.3-2.1,1-3s1.6-1.7,2.8-2.2c1.2-0.5,2.6-0.8,4.2-0.8c2.4,0,4.3,0.6,5.7,1.8   c1.4,1.2,2.2,2.8,2.4,4.8h-4.9c-0.1-0.8-0.4-1.4-1-1.9s-1.4-0.7-2.4-0.7c-0.9,0-1.6,0.2-2.1,0.5s-0.7,0.8-0.7,1.4   c0,0.7,0.3,1.2,1,1.5s1.7,0.7,3.2,1.1c1.4,0.4,2.7,0.7,3.6,1.1s1.8,1,2.4,1.8s1.1,1.9,1.1,3.2c0,1.2-0.3,2.2-1,3.1   s-1.6,1.6-2.8,2.2c-1.2,0.5-2.6,0.8-4.2,0.8C1831.8,901.2,1830.4,900.9,1829.1,900.3L1829.1,900.3z"
+   id="path668" />
+	<path
+   class="st8"
+   d="M1848.5,900.3c-1.3-0.6-2.3-1.4-3.1-2.4s-1.2-2.1-1.3-3.4h5.1c0.1,0.8,0.5,1.4,1.2,1.9s1.5,0.8,2.5,0.8   s1.7-0.2,2.3-0.6c0.5-0.4,0.8-0.9,0.8-1.5c0-0.7-0.3-1.1-1-1.5c-0.7-0.3-1.7-0.7-3.2-1.1c-1.5-0.4-2.7-0.7-3.7-1.1   c-1-0.4-1.8-1-2.5-1.8s-1-1.9-1-3.2c0-1.1,0.3-2.1,1-3s1.6-1.7,2.8-2.2s2.6-0.8,4.2-0.8c2.4,0,4.3,0.6,5.7,1.8   c1.4,1.2,2.2,2.8,2.4,4.8h-4.9c-0.1-0.8-0.4-1.4-1-1.9s-1.4-0.7-2.4-0.7c-0.9,0-1.6,0.2-2.1,0.5s-0.7,0.8-0.7,1.4   c0,0.7,0.3,1.2,1,1.5s1.7,0.7,3.2,1.1c1.4,0.4,2.7,0.7,3.6,1.1s1.8,1,2.4,1.8s1.1,1.9,1.1,3.2c0,1.2-0.3,2.2-1,3.1   s-1.6,1.6-2.8,2.2c-1.2,0.5-2.6,0.8-4.2,0.8C1851.2,901.2,1849.8,900.9,1848.5,900.3L1848.5,900.3z"
+   id="path670" />
+	<path
+   class="st8"
+   d="M1638.1,924.4c1.1-2,2.7-3.5,4.6-4.6s4.1-1.7,6.5-1.7c2.8,0,5.3,0.7,7.4,2.2s3.6,3.5,4.5,6h-5.8   c-0.6-1.2-1.4-2.1-2.4-2.7s-2.3-0.9-3.7-0.9c-1.5,0-2.8,0.3-3.9,1c-1.2,0.7-2,1.7-2.7,2.9s-1,2.7-1,4.4s0.3,3.1,1,4.4   c0.6,1.3,1.5,2.2,2.7,2.9s2.5,1,3.9,1s2.6-0.3,3.6-0.9s1.9-1.5,2.4-2.7h5.8c-0.8,2.6-2.3,4.6-4.4,6s-4.6,2.2-7.4,2.2   c-2.4,0-4.6-0.5-6.6-1.6c-1.9-1.1-3.5-2.6-4.6-4.6s-1.7-4.2-1.7-6.7S1637,926.4,1638.1,924.4L1638.1,924.4z"
+   id="path672" />
+	<path
+   class="st8"
+   d="M1668.9,942.8c-1.6-0.9-2.8-2.1-3.7-3.6s-1.3-3.4-1.3-5.4s0.4-3.9,1.3-5.4c0.9-1.6,2.1-2.8,3.7-3.7   s3.3-1.3,5.3-1.3c1.9,0,3.7,0.4,5.3,1.3c1.6,0.9,2.8,2.1,3.7,3.6s1.4,3.4,1.4,5.4c0,2.1-0.5,3.9-1.4,5.4s-2.2,2.8-3.8,3.7   c-1.6,0.9-3.3,1.3-5.3,1.3C1672.2,944.1,1670.4,943.7,1668.9,942.8L1668.9,942.8z M1676.7,939c0.8-0.5,1.5-1.1,1.9-2   c0.5-0.9,0.7-2,0.7-3.3c0-1.9-0.5-3.4-1.5-4.4s-2.2-1.5-3.7-1.5c-1.4,0-2.7,0.5-3.6,1.5c-1,1-1.5,2.5-1.5,4.4s0.5,3.4,1.4,4.4   c1,1,2.2,1.5,3.6,1.5C1675,939.7,1675.9,939.4,1676.7,939L1676.7,939z"
+   id="path674" />
+	<path
+   class="st8"
+   d="M1704.9,925.6c1.5,1.5,2.2,3.6,2.2,6.3v11.8h-5.1v-11.1c0-1.6-0.4-2.8-1.2-3.7s-1.9-1.3-3.3-1.3   s-2.5,0.4-3.3,1.3c-0.8,0.9-1.2,2.1-1.2,3.7v11.1h-5.1v-20.1h5.1v2.5c0.7-0.9,1.5-1.6,2.6-2c1.1-0.5,2.2-0.8,3.5-0.8   C1701.4,923.3,1703.4,924.1,1704.9,925.6L1704.9,925.6z"
+   id="path676" />
+	<path
+   class="st8"
+   d="M1717.4,927.8v9.7c0,0.7,0.2,1.2,0.5,1.5s0.9,0.5,1.7,0.5h2.4v4.3h-3.2c-4.3,0-6.4-2.1-6.4-6.2v-9.7h-2.4v-4.2   h2.4v-5h5.1v5h4.5v4.2L1717.4,927.8L1717.4,927.8z"
+   id="path678" />
+	<path
+   class="st8"
+   d="M1732.9,924.2c1.1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1   v-20.1h5.1v3.1C1731,925.6,1731.8,924.8,1732.9,924.2L1732.9,924.2z"
+   id="path680" />
+	<path
+   class="st8"
+   d="M1743.2,942.7c-1.6-0.9-2.8-2.1-3.7-3.6s-1.3-3.4-1.3-5.4s0.4-3.9,1.3-5.4c0.9-1.6,2.1-2.8,3.7-3.7   s3.3-1.3,5.3-1.3c1.9,0,3.7,0.4,5.3,1.3c1.6,0.9,2.8,2.1,3.7,3.6s1.4,3.4,1.4,5.4c0,2.1-0.5,3.9-1.4,5.4s-2.2,2.8-3.8,3.7   c-1.6,0.9-3.3,1.3-5.3,1.3C1746.5,944,1744.8,943.6,1743.2,942.7L1743.2,942.7z M1751.1,938.9c0.8-0.5,1.5-1.1,1.9-2   c0.5-0.9,0.7-2,0.7-3.3c0-1.9-0.5-3.4-1.5-4.4s-2.2-1.5-3.7-1.5c-1.4,0-2.7,0.5-3.6,1.5c-1,1-1.5,2.5-1.5,4.4s0.5,3.4,1.4,4.4   c1,1,2.2,1.5,3.6,1.5C1749.4,939.6,1750.3,939.3,1751.1,938.9L1751.1,938.9z"
+   id="path682" />
+	<path
+   class="st8"
+   d="M1767.4,916.8v26.8h-5.1v-26.8H1767.4L1767.4,916.8z"
+   id="path684" />
+	<path
+   class="st8"
+   d="M1777.1,916.8v26.8h-5.1v-26.8H1777.1L1777.1,916.8z"
+   id="path686" />
+	<path
+   class="st8"
+   d="M1800.3,935.1h-14.7c0.1,1.5,0.6,2.6,1.5,3.4s2,1.2,3.3,1.2c1.9,0,3.2-0.8,4-2.4h5.5c-0.6,1.9-1.7,3.5-3.3,4.8   s-3.7,1.9-6.1,1.9c-1.9,0-3.7-0.4-5.2-1.3s-2.7-2.1-3.6-3.6s-1.3-3.4-1.3-5.4c0-2.1,0.4-3.9,1.3-5.5c0.8-1.6,2-2.8,3.6-3.6   s3.3-1.3,5.3-1.3c1.9,0,3.6,0.4,5.1,1.2s2.7,2,3.5,3.5s1.2,3.2,1.3,5.2C1800.4,933.9,1800.4,934.5,1800.3,935.1L1800.3,935.1z    M1795.2,931.7c0-1.3-0.5-2.3-1.4-3.1s-2-1.2-3.4-1.2c-1.3,0-2.3,0.4-3.2,1.2c-0.9,0.8-1.4,1.8-1.6,3.2L1795.2,931.7L1795.2,931.7z   "
+   id="path688" />
+	<path
+   class="st8"
+   d="M1811.4,924.1c1.1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1   v-20.1h5.1v3.1C1809.5,925.6,1810.3,924.7,1811.4,924.1L1811.4,924.1z"
+   id="path690" />
+</g>
+<g
+   id="g708">
+	<path
+   class="st8"
+   d="M1398.7,1225v25.3h-5.1v-10.8h-10.8v10.8h-5.1V1225h5.1v10.4h10.8V1225H1398.7z"
+   id="path694" />
+	<path
+   class="st8"
+   d="M1403.3,1234.8c0.8-1.6,1.9-2.8,3.3-3.6s2.9-1.3,4.7-1.3c1.5,0,2.8,0.3,3.9,0.9s2,1.4,2.7,2.3v-2.9h5.1v20.1   h-5.1v-2.9c-0.7,0.9-1.6,1.7-2.7,2.3c-1.2,0.6-2.5,0.9-4,0.9c-1.7,0-3.2-0.4-4.6-1.3s-2.5-2.1-3.3-3.7s-1.2-3.4-1.2-5.5   C1402.1,1238.1,1402.5,1236.3,1403.3,1234.8L1403.3,1234.8z M1417.1,1237.1c-0.5-0.9-1.1-1.6-2-2s-1.7-0.7-2.7-0.7   c-0.9,0-1.8,0.2-2.6,0.7c-0.8,0.5-1.4,1.1-1.9,2s-0.7,1.9-0.7,3.1s0.2,2.3,0.8,3.2c0.5,0.9,1.2,1.6,2,2.1s1.7,0.7,2.6,0.7   s1.8-0.2,2.7-0.7s1.5-1.2,2-2c0.5-0.9,0.7-1.9,0.7-3.2C1417.9,1239,1417.6,1237.9,1417.1,1237.1L1417.1,1237.1z"
+   id="path696" />
+	<path
+   class="st8"
+   d="M1435.2,1230.8c1.1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1   v-20.1h5.1v3.1C1433.3,1232.2,1434.2,1231.4,1435.2,1230.8z"
+   id="path698" />
+	<path
+   class="st8"
+   d="M1449.6,1230.7c1.2-0.6,2.5-0.9,3.9-0.9c1.7,0,3.3,0.4,4.7,1.3s2.5,2.1,3.3,3.6c0.8,1.6,1.2,3.4,1.2,5.4   s-0.4,3.9-1.2,5.5c-0.8,1.6-1.9,2.8-3.3,3.7s-2.9,1.3-4.7,1.3c-1.5,0-2.8-0.3-3.9-0.9s-2-1.4-2.7-2.3v2.9h-5.1v-26.8h5.1v9.7   C1447.6,1232.1,1448.5,1231.3,1449.6,1230.7L1449.6,1230.7z M1456.8,1237c-0.5-0.9-1.2-1.6-2-2c-0.8-0.5-1.7-0.7-2.6-0.7   s-1.8,0.2-2.6,0.7c-0.8,0.5-1.5,1.2-2,2.1s-0.7,1.9-0.7,3.2c0,1.2,0.2,2.3,0.8,3.2s1.2,1.6,2,2.1s1.7,0.7,2.6,0.7s1.8-0.2,2.6-0.7   c0.8-0.5,1.5-1.2,2-2.1s0.7-2,0.7-3.2C1457.6,1238.9,1457.3,1237.8,1456.8,1237L1456.8,1237z"
+   id="path700" />
+	<path
+   class="st8"
+   d="M1469.8,1249.2c-1.6-0.9-2.8-2.1-3.7-3.6c-0.9-1.6-1.3-3.4-1.3-5.4c0-2.1,0.4-3.9,1.3-5.4s2.1-2.8,3.7-3.7   s3.3-1.3,5.3-1.3c1.9,0,3.7,0.4,5.3,1.3c1.6,0.9,2.8,2.1,3.7,3.6c0.9,1.6,1.4,3.4,1.4,5.4c0,2.1-0.5,3.9-1.4,5.4s-2.2,2.8-3.8,3.7   c-1.6,0.9-3.3,1.3-5.3,1.3C1473.1,1250.5,1471.3,1250.1,1469.8,1249.2L1469.8,1249.2z M1477.6,1245.4c0.8-0.4,1.5-1.1,1.9-2   c0.5-0.9,0.7-2,0.7-3.3c0-1.9-0.5-3.4-1.5-4.4s-2.2-1.5-3.7-1.5c-1.4,0-2.7,0.5-3.6,1.5c-1,1-1.5,2.5-1.5,4.4s0.5,3.4,1.4,4.4   c1,1,2.2,1.5,3.6,1.5C1476,1246.1,1476.8,1245.9,1477.6,1245.4L1477.6,1245.4z"
+   id="path702" />
+	<path
+   class="st8"
+   d="M1496.5,1230.7c1.1-0.6,2.2-0.9,3.6-0.9v5.3h-1.3c-1.6,0-2.8,0.4-3.6,1.1c-0.8,0.8-1.2,2.1-1.2,3.9v10h-5.1   V1230h5.1v3.1C1494.6,1232.1,1495.4,1231.3,1496.5,1230.7z"
+   id="path704" />
+	<path
+   class="st8"
+   d="M1501.6,1224.6h9.6v3h-2.9v9.8h-3.8v-9.8h-2.9L1501.6,1224.6L1501.6,1224.6z M1529.3,1224.6v12.8h-3.5l-0.1-8   l-3.3,8h-2.6l-3.3-8.3v8.3h-3.4v-12.8h5l3.1,8.2l3.3-8.2H1529.3L1529.3,1224.6z"
+   id="path706" />
+</g>
+<g
+   id="g716">
+	<g
+   id="g714">
+		<path
+   class="st19"
+   d="M667.1,450.1c10.5-4.9,18-14.7,20-26.1c-8.6-19.4-25.4-33.9-45.8-39.8c6.9,10,10.3,22,9.5,34.1    C660.3,426.2,666.2,437.7,667.1,450.1z M580.9,431.7c-11.5-1.5-23,2.8-30.8,11.4c-3.1,21.2,3.5,42.7,17.9,58.6    c-0.8-12.3,2.7-24.4,9.6-34.5C573.9,455.3,575.1,442.6,580.9,431.7z M589,485.8c-4.3,11.5-2.4,24.4,5.1,34.2    c17.5,7.1,37.1,7.1,54.5,0c-11.4-3.7-21.2-11-28.1-20.8C608.8,499,597.4,494.2,589,485.8L589,485.8z M631.5,408.6    c-2.2-11.9-10.3-21.9-21.5-26.4c-20.5,3.3-38.5,15.2-49.6,32.7c11.3-3.5,23.5-3.1,34.6,0.9C605.6,408.3,618.9,405.7,631.5,408.6z     M663.6,471.1c-4.3,10.2-12.2,18.6-22.1,23.4c8.7,7.9,20.8,11,32.2,8.2c12.6-13.4,19.6-31,19.6-49.4    C685.6,462.3,675.2,468.5,663.6,471.1L663.6,471.1z"
+   id="path710" />
+		<path
+   id="circle712"
+   class="st20"
+   style="fill:#f04d5c"
+   d="m 644,453.29999 a 22.5,22.5 0 0 1 -22.5,22.5 22.5,22.5 0 0 1 -22.5,-22.5 22.5,22.5 0 0 1 22.5,-22.5 22.5,22.5 0 0 1 22.5,22.5 z" />
+	</g>
+</g>
+<g
+   id="g722">
+	<g
+   id="g720">
+		<path
+   class="st8"
+   d="M1192.3,1386.9c4.1,0,8,2.2,10.1,5.8l63,107.3c2.1,3.6,2.1,8.1,0.1,11.7s-5.9,5.9-10.1,5.9h-125.9    c-4.2,0-8.1-2.2-10.1-5.9s-2-8.1,0.1-11.7l63-107.3C1184.4,1389.1,1188.2,1386.9,1192.3,1386.9L1192.3,1386.9z M1192.3,1424.3    c-3.9,0-7,3.1-7,7v32.7c0,3.9,3.1,7,7,7s7-3.1,7-7v-32.7C1199.3,1427.4,1196.2,1424.3,1192.3,1424.3z M1201.7,1489.6    c0-5.2-4.2-9.3-9.3-9.3s-9.3,4.2-9.3,9.3s4.2,9.3,9.3,9.3S1201.7,1494.7,1201.7,1489.6z"
+   id="path718" />
+	</g>
+</g>
+<g
+   id="g730">
+	<path
+   class="st21"
+   d="M690.5,1101.6c-2.7,0-5,2.2-5,4.9c0,40.7-33,73.8-73.8,73.8c-2.7,0-5,2.2-5,4.9s2.2,4.9,5,4.9   c46.2,0,83.6-37.4,83.6-83.6C695.5,1103.8,693.3,1101.6,690.5,1101.6L690.5,1101.6z"
+   id="path724" />
+	<path
+   class="st22"
+   d="M660.7,1133.3c4.8-7.8,9.4-18.1,8.5-32.6c-1.9-30-29.1-52.8-54.8-50.3c-10,1-20.4,9.2-19.5,23.8   c0.4,6.4,3.5,10.1,8.6,13c4.8,2.8,11,4.5,18.1,6.5c8.5,2.4,18.3,5.1,25.9,10.7C656.6,1111.1,662.8,1118.8,660.7,1133.3   L660.7,1133.3z"
+   id="path726" />
+	<path
+   class="st21"
+   d="M564.1,1080.8c-4.8,7.8-9.4,18.1-8.5,32.6c1.9,30,29.1,52.8,54.8,50.3c10-1,20.4-9.2,19.5-23.8   c-0.4-6.4-3.5-10.1-8.6-13c-4.8-2.8-11-4.5-18.1-6.5c-8.5-2.4-18.3-5.1-25.9-10.7C568.2,1103.1,562,1095.3,564.1,1080.8   L564.1,1080.8z"
+   id="path728" />
+</g>
+<g
+   id="g773">
+	<g
+   id="g771">
+		<path
+   id="a"
+   class="st3"
+   d="M369.6,124.9c0,5.7-3.8,8.7-9.9,8.7s-9.4-3.6-9.4-8.7c0,0,3.4,4.7,9.4,4.7S369.6,124.9,369.6,124.9    L369.6,124.9z" />
+		<path
+   class="st23"
+   d="M360.4,147c29.7,0,53.8-24.1,53.8-53.8s-24.1-53.8-53.8-53.8s-53.8,24.1-53.8,53.8S330.6,147,360.4,147    L360.4,147z"
+   id="path733" />
+		<path
+   class="st24"
+   d="M360.4,138.2c24.3,0,44-19.7,44-44s-19.7-44-44-44s-44,19.7-44,44S336.1,138.2,360.4,138.2L360.4,138.2z"
+   id="path735" />
+		<path
+   class="st3"
+   d="M343.9,55.7c1.4,0,2.6-1.2,2.6-2.6c0-1.4-1.2-2.6-2.6-2.6l0,0c-1.4,0-2.6,1.2-2.6,2.6S342.5,55.7,343.9,55.7z     M324.6,120.9c0.3,0.4,0.9,0.5,1.3,0.2s0.5-0.8,0.2-1.3v-0.1c-17.6-22.5-7.4-51.5,12.5-63c0.4-0.3,0.5-0.8,0.3-1.2    s-0.8-0.5-1.2-0.3C316.9,67.1,306.3,97.4,324.6,120.9L324.6,120.9L324.6,120.9z"
+   id="path737" />
+		<path
+   class="st25"
+   d="M306.1,82.5c0-0.4-0.3-0.7-0.7-0.7s-0.7,0.3-0.7,0.7H306.1L306.1,82.5z M304.7,103.6c0,0.4,0.3,0.7,0.7,0.7    s0.7-0.3,0.7-0.7H304.7L304.7,103.6z M415.8,82.4c0-0.4-0.3-0.7-0.7-0.7s-0.7,0.3-0.7,0.7H415.8L415.8,82.4z M414.4,103.5    c0,0.4,0.3,0.7,0.7,0.7s0.7-0.3,0.7-0.7H414.4L414.4,103.5z M360.2,148.6c30.7,0,55.5-24.9,55.5-55.6h-1.4    c0,29.9-24.2,54.2-54.1,54.2V148.6L360.2,148.6z M415.8,93c0-30.7-24.9-55.6-55.5-55.6v1.4c29.9,0,54.1,24.2,54.1,54.2H415.8z     M360.2,37.5c-30.7,0-55.5,24.9-55.5,55.6h1.4c0-29.9,24.2-54.2,54.1-54.2V37.5z M304.7,93c0,30.7,24.9,55.6,55.5,55.6v-1.4    c-29.9,0-54.1-24.3-54.1-54.2C306.1,93,304.7,93,304.7,93z M304.7,82.5v21.1h1.4V82.5H304.7z M414.4,82.4v21.1h1.4V82.4H414.4z"
+   id="path739" />
+		<path
+   class="st25"
+   d="M306.6,82.5c0-1.2-0.9-2.2-2.1-2.3s-2.2,0.9-2.3,2.1c0,0.1,0,0.1,0,0.2v21.3c0,1.2,0.9,2.2,2.1,2.3    c1.2,0.1,2.2-0.9,2.3-2.1c0-0.1,0-0.1,0-0.2V82.5z M418.5,82.5c0-1.2-0.9-2.2-2.1-2.3c-1.2-0.1-2.2,0.9-2.3,2.1c0,0.1,0,0.1,0,0.2    v21.3c0,1.2,0.9,2.2,2.1,2.3c1.2,0.1,2.2-0.9,2.3-2.1c0-0.1,0-0.1,0-0.2V82.5z"
+   id="path741" />
+		<path
+   class="st26"
+   d="M336.5,175c2.5-1,2-2,2-2.6l-1.2-18.5l-1.1-9.3l-1.6-57.8c0-13.7,10.1-26.5,25.5-26.5s26.2,12.3,26.2,26.6    c-0.4,27.5-1.2,37.9-2.2,57.6c-0.1,2.7-0.5,6.8-0.6,9.3c-0.6,12.3-1.2,18.4-1.2,18.7c0,0.5-0.5,1.5,2,2.6s8.3,2.3,8.3,2.7    s-9.8,0-9.8,0c-5.6,0-5.6-4.2-5.6-5.2s-1.5-18.5-1.5-18.5l-0.5,22.6c0,1,0.5,2.6,4.1,3.6c0,0,7.8,1.2,7.8,1.6s-9.3,0-9.3,0    c-7.1,0-7.1-4.1-7.1-4.1L369,159c0,0-0.5,18.5-0.5,21.1c0,2,0.4,3.5,5.9,4.6c2.7,0.8,8.1,1.7,8.1,2s-12.4,0-12.4,0    c-6.6-0.5-7.2-5.1-7.2-5.1l-2.5-9.2l-2.5,9.2c0,0-1,4.6-7.6,5.1c0,0-11.2,0.4-11.2,0s4.5-1.2,7.4-2c3.9-1.1,5.9-2.6,5.9-4.6    c0-2.6-0.5-21.1-0.5-21.1l-1.5,18.5c0,0,0,4.6-7.1,4.6c0,0-10.1,0-10.1-0.4s8.5-1.6,8.5-1.6c3.6-1,4.1-2.6,4.1-3.6l-0.5-22.6    c0,0-1.5,17.5-1.5,18.5s0,5.6-5.6,5.6c0,0-9.4-0.5-9.4-0.8S334,176,336.5,175L336.5,175L336.5,175z"
+   id="path743" />
+		<path
+   class="st27"
+   d="M336.2,144.6c0,0-1,2.6-3.4,3.9c-2.4,1.4-5.1,1.8-7.7,2.2c0,0,3.5,1.8,7.9,1.4c2.7-0.2,3.9,0.5,4.3,1.8    L336.2,144.6L336.2,144.6L336.2,144.6z M384,144.4c0,0,1.5,2.6,3.9,3.9s5.1,1.8,7.7,2.2c0,0-3.5,1.8-7.9,1.4    c-2.7-0.2-3.9,0.5-4.3,1.8L384,144.4L384,144.4z"
+   id="path745" />
+		<path
+   class="st28"
+   d="M384,144l0.2-3.2c-12.5,5.9-24.1,5.3-24.1,5.3s-11.7,0.5-24-5.3l0.1,3.1c0,0,8.8,5.4,23.9,5.4    S384,144,384,144L384,144L384,144z"
+   id="path747" />
+		<path
+   class="st29"
+   d="M350,76.2c2,0.1,3.6-1.5,3.6-3.5s-1.5-3.6-3.5-3.7c-0.1,0-0.1,0-0.2,0c-2,0.1-3.5,1.7-3.5,3.7    C346.6,74.7,348.1,76.2,350,76.2L350,76.2z"
+   id="path749" />
+		<path
+   class="st30"
+   d="M386.2,87.2c0,0,0.4-4.5-1.6-9.8c-5.4-14.6-18.5-17.5-25.6-17.1c0,0,10.1,4.7,10.5,20c0.2,6.8,0.2,7,0.2,7    L386.2,87.2L386.2,87.2z"
+   id="path751" />
+		<path
+   id="a-2"
+   class="st3"
+   d="M369.6,124.9c0,5.7-3.8,8.7-9.9,8.7s-9.4-3.6-9.4-8.7c0,0,3.4,4.7,9.4,4.7S369.6,124.9,369.6,124.9    L369.6,124.9z" />
+		<path
+   id="a-3"
+   class="st3"
+   d="M369.6,124.9c0,5.7-3.8,8.7-9.9,8.7s-9.4-3.6-9.4-8.7c0,0,3.4,4.7,9.4,4.7S369.6,124.9,369.6,124.9    L369.6,124.9z" />
+		<path
+   class="st3"
+   d="M369.6,124.9c0,5.7-2.3,14.6-9.9,14.6s-9.4-9.5-9.4-14.6c0,0,0,8.7,9.4,8.7    C370.1,133.6,369.6,124.9,369.6,124.9L369.6,124.9L369.6,124.9z"
+   id="path755" />
+		<path
+   class="st31"
+   d="M369.6,124.9c0,5.7-2.3,14.6-9.9,14.6s-9.4-9.5-9.4-14.6c0,0,0,8.7,9.4,8.7    C370.1,133.6,369.6,124.9,369.6,124.9L369.6,124.9L369.6,124.9z"
+   id="path757" />
+		<path
+   class="st27"
+   d="M341.8,116.3c8.6,0,15.6-7,15.6-15.6l0,0c0-8.6-7-15.6-15.6-15.6s-15.6,7-15.6,15.6l0,0    C326.3,109.3,333.2,116.3,341.8,116.3L341.8,116.3z"
+   id="path759" />
+		<path
+   class="st3"
+   d="M341.8,113.1c6.7,0,12.2-5.5,12.2-12.2l0,0c0-6.7-5.5-12.2-12.2-12.2l0,0c-6.7,0-12.2,5.5-12.2,12.2l0,0    C329.6,107.6,335.1,113.1,341.8,113.1L341.8,113.1z"
+   id="path761" />
+		<path
+   class="st32"
+   d="M341.5,102.5c2.1,0,3.8-1.7,3.7-3.8c0-2.1-1.7-3.8-3.8-3.7s-3.8,1.7-3.7,3.8S339.4,102.5,341.5,102.5z"
+   id="path763" />
+		<path
+   class="st27"
+   d="M378.5,116.3c8.6,0,15.6-7,15.6-15.6l0,0c0-8.6-7-15.6-15.6-15.6s-15.6,7-15.6,15.6l0,0    C362.9,109.3,369.9,116.3,378.5,116.3L378.5,116.3z"
+   id="path765" />
+		<path
+   class="st3"
+   d="M377.9,113c6.7,0,12.2-5.5,12.2-12.2l0,0c0-6.7-5.5-12.2-12.2-12.2l0,0c-6.7,0-12.2,5.5-12.2,12.2    C365.7,107.6,371.1,113,377.9,113z"
+   id="path767" />
+		<path
+   class="st32"
+   d="M378.1,102.5c2.1,0,3.7-1.7,3.7-3.8S380.1,95,378,95s-3.8,1.7-3.7,3.8C374.4,100.8,376,102.5,378.1,102.5    L378.1,102.5z"
+   id="path769" />
+	</g>
+</g>
+<g
+   id="g781">
+	<g
+   id="g779">
+		<g
+   id="g824">
+			<path
+   id="path7"
+   class="st33"
+   d="M690.9,787.3c-4.7-8.1-11.4-14.2-19.2-18c-1,5.3-2.9,10.6-5.7,15.5l-4.5,7.8     c3,1.7,5.6,4.1,7.5,7.3c5.4,9.4,2.2,21.4-7.2,26.8s-21.4,2.2-26.8-7.2l-9.1-15.7h-14.7l-7.3,12.7l9.1,15.7     c12.5,21.6,40,28.9,61.6,16.5C695.9,836.4,703.3,808.9,690.9,787.3" />
+			<path
+   id="path11"
+   class="st34"
+   d="M645.7,721.2c-21.6-12.4-49.1-5.1-61.6,16.5c-4.7,8.1-6.5,17-5.9,25.6     c5.1-1.8,10.6-2.8,16.3-2.8h9c-0.1-3.4,0.8-6.9,2.6-10.1c5.4-9.4,17.4-12.6,26.8-7.2c9.4,5.4,12.6,17.4,7.2,26.8l-9.1,15.8     l7.3,12.7H653l9.1-15.8C674.7,761.2,667.3,733.6,645.7,721.2" />
+			<path
+   id="path15"
+   class="st35"
+   d="M609.2,834.5l-4.5-7.8c-3,1.8-6.4,2.8-10.1,2.8c-10.8,0-19.6-8.8-19.6-19.6s8.8-19.6,19.6-19.6     h18.2l7.3-12.7l-7.3-12.7h-18.2c-24.9,0-45.1,20.2-45.1,45.1s20.2,45.1,45.1,45.1c9.3,0,18-2.8,25.2-7.7     C615.6,843.7,612,839.5,609.2,834.5" />
+		</g>
+	</g>
+</g>
+<g
+   id="g787">
+	<g
+   id="g785">
+		<path
+   class="st36"
+   d="M848,1384.8v135h95.6c21.8,0,39.4-17.6,39.4-39.4v-95.6H848z M953.2,1469.9h5v5h-5V1469.9z M951.6,1448.2    h8.2v8.2h-8.2V1448.2z M950.4,1426.8h10.7v10.7h-10.7V1426.8z M933.1,1490h5v5h-5V1490L933.1,1490z M931.5,1468h8.2v8.2h-8.2V1468    z M930.2,1446.9H941v10.7h-10.7L930.2,1446.9L930.2,1446.9z M931.5,1436.2v-8.2h8.2v8.2H931.5z M892.8,1490h5v5h-5V1490z     M891.3,1468.3h8.2v8.2h-8.2V1468.3z M892.8,1454.8v-5h5v5H892.8z M891.3,1428.1h8.2v8.2h-8.2V1428.1z M872.7,1490h5v5h-5V1490z     M872.7,1469.9h5v5h-5V1469.9z M871.2,1448.2h8.2v8.2h-8.2V1448.2z M869.9,1426.8h10.7v10.7h-10.7V1426.8z M865.2,1402h100.6v20.1    h-40.2v80.5h-20.1v-80.5h-40.2L865.2,1402L865.2,1402z"
+   id="path783" />
+	</g>
+</g>
+<g
+   id="g941">
+	<g
+   id="g939">
+		<path
+   class="st37"
+   d="M1715.9,1505.1c-1.7,0.4-3,1.1-2.9,1.6s1.6,0.6,3.2,0.2s3-1.1,2.9-1.6    C1719.1,1504.9,1717.6,1504.8,1715.9,1505.1z"
+   id="path789" />
+		<path
+   class="st37"
+   d="M1708.8,1504.7c-1.8,0.1-3.2,0.7-3.2,1.1s1.5,0.8,3.3,0.6c1.8-0.1,3.2-0.7,3.2-1.1    S1710.6,1504.6,1708.8,1504.7z"
+   id="path791" />
+		<path
+   class="st37"
+   d="M1703,1504.2c-1.2,0.2-2.1,0.6-2.1,1s1.1,0.6,2.3,0.4c1.2-0.2,2.1-0.6,2.1-1S1704.2,1504,1703,1504.2z"
+   id="path793" />
+		<path
+   class="st37"
+   d="M1698.8,1503.7c-1.2,0.2-2.1,0.6-2,0.9c0,0.3,1,0.4,2.2,0.2c1.2-0.2,2.1-0.6,2-0.9    C1700.9,1503.6,1699.9,1503.5,1698.8,1503.7z"
+   id="path795" />
+		<path
+   class="st37"
+   d="M1697.9,1503.6c1.2-0.2,2.1-0.6,2-0.9s-1-0.4-2.2-0.2c-1.2,0.2-2.1,0.6-2,0.9    C1695.8,1503.6,1696.8,1503.8,1697.9,1503.6z"
+   id="path797" />
+		<path
+   class="st37"
+   d="M1697.7,1502.1c1-0.2,1.8-0.5,1.8-0.8s-0.9-0.4-1.9-0.2s-1.8,0.5-1.8,0.8S1696.7,1502.3,1697.7,1502.1z"
+   id="path799" />
+		<path
+   class="st37"
+   d="M1748.3,1499.2c-1.7,0-3.1,0.4-3.1,1s1.4,1,3.1,1s3.1-0.4,3.1-1S1750,1499.2,1748.3,1499.2z"
+   id="path801" />
+		<path
+   class="st37"
+   d="M1756.3,1499.1c-1.1,0-2.1,0.4-2.1,0.9s0.9,0.9,2.1,0.9s2.1-0.4,2.1-0.9S1757.4,1499.1,1756.3,1499.1z"
+   id="path803" />
+		<path
+   id="ellipse805"
+   class="st37"
+   style="fill:#221f1f"
+   d="m 1765.1,1499.4 a 2.3,0.80000001 0 0 1 -2.3,0.8 2.3,0.80000001 0 0 1 -2.3,-0.8 2.3,0.80000001 0 0 1 2.3,-0.8 2.3,0.80000001 0 0 1 2.3,0.8 z" />
+		<path
+   class="st37"
+   d="M1767.8,1497.7c-0.9,0-1.7,0.4-1.7,0.8s0.7,0.8,1.7,0.8s1.7-0.4,1.7-0.8S1768.7,1497.7,1767.8,1497.7z"
+   id="path807" />
+		<path
+   id="ellipse809"
+   class="st37"
+   style="fill:#221f1f"
+   d="m 1773.8,1497.6 a 1.7,0.80000001 0 0 1 -1.7,0.8 1.7,0.80000001 0 0 1 -1.7,-0.8 1.7,0.80000001 0 0 1 1.7,-0.8 1.7,0.80000001 0 0 1 1.7,0.8 z" />
+		<path
+   class="st9"
+   d="M1778.2,1392.9L1778.2,1392.9L1778.2,1392.9L1778.2,1392.9z"
+   id="path811" />
+		<path
+   class="st9"
+   d="M1705.9,1407.5c0,0.5,0,1.1,0.2,1.6C1705.9,1408.6,1705.9,1408,1705.9,1407.5z"
+   id="path813" />
+		<path
+   class="st9"
+   d="M1778.1,1392.9L1778.1,1392.9L1778.1,1392.9L1778.1,1392.9L1778.1,1392.9    C1778.2,1392.9,1778.2,1392.9,1778.1,1392.9z"
+   id="path815" />
+		<path
+   class="st9"
+   d="M1711.5,1408.6c-0.2-0.5-0.5-0.9-0.8-1.3c-0.2-0.2-0.3-0.4-0.6-0.7c0.2,0.2,0.4,0.4,0.5,0.7    C1711,1407.8,1711.2,1408.2,1711.5,1408.6z"
+   id="path817" />
+		<path
+   class="st9"
+   d="M1708.1,1405.5L1708.1,1405.5c0.1,0,0.2,0,0.2,0C1708.3,1405.5,1708.2,1405.5,1708.1,1405.5L1708.1,1405.5    L1708.1,1405.5c-0.2,0-0.4,0-0.5,0C1707.7,1405.5,1707.9,1405.5,1708.1,1405.5L1708.1,1405.5L1708.1,1405.5z"
+   id="path819" />
+		<path
+   id="polygon821"
+   class="st9"
+   style="fill:none"
+   d="m 1707.6,1405.5 -0.1,0.1 h -0.1 0.1 z" />
+		<path
+   class="st9"
+   d="M1778.2,1392.9c0.1,0.2,0.1,0.3,0.1,0.5c0,0.3,0,0.7-0.1,1c0.1-0.3,0.1-0.7,0.1-1    C1778.3,1393.2,1778.3,1393.1,1778.2,1392.9z"
+   id="path823" />
+		<path
+   class="st9"
+   d="M1778.6,1391.1L1778.6,1391.1L1778.6,1391.1l-0.2-0.1c-0.2-0.1-0.3-0.1-0.5-0.1c0.2,0,0.3,0.1,0.5,0.1    L1778.6,1391.1z"
+   id="path825" />
+		<path
+   class="st9"
+   d="M1713.1,1413.2c0-0.1,0-0.2-0.1-0.3v-0.1v0.1C1713,1413,1713,1413.1,1713.1,1413.2z"
+   id="path827" />
+		<path
+   class="st9"
+   d="M1772.1,1398c0.1-0.7,0.2-1.4,0.4-2.1c0.2-1,0.7-1.9,1.2-2.8c0.2-0.3,0.3-0.5,0.5-0.7    c-0.2,0.2-0.4,0.5-0.5,0.7c-0.5,0.9-0.9,1.8-1.2,2.8C1772.3,1396.7,1772.2,1397.3,1772.1,1398c0,0.2,0,0.4,0,0.6    c0,0.1,0,0.1,0,0.2c0,0,0-0.1,0-0.2S1772.1,1398.3,1772.1,1398z"
+   id="path829" />
+		<path
+   class="st9"
+   d="M1775.7,1391.2c-0.3,0.2-0.6,0.3-0.9,0.6c-0.2,0.2-0.4,0.4-0.7,0.7c0.2-0.2,0.4-0.4,0.7-0.7    C1775.1,1391.6,1775.4,1391.4,1775.7,1391.2z"
+   id="path831" />
+		<path
+   class="st9"
+   d="M1777,1392.7c-0.4,0.1-0.8,0.2-1.1,0.5c-0.4,0.3-0.7,0.6-1,0.9c0.3-0.3,0.6-0.7,1-0.9    C1776.3,1393,1776.6,1392.8,1777,1392.7c0.1,0,0.2,0,0.3,0l0,0C1777.2,1392.7,1777.1,1392.7,1777,1392.7z"
+   id="path833" />
+		<path
+   class="st9"
+   d="M1779.9,1393.4c-0.1,0.5-0.2,1.1-0.4,1.6C1779.8,1394.5,1779.9,1394,1779.9,1393.4c0-0.3,0-0.5-0.1-0.8    C1779.9,1392.9,1780,1393.2,1779.9,1393.4L1779.9,1393.4z"
+   id="path835" />
+		<path
+   class="st9"
+   d="M1707.9,1407.3L1707.9,1407.3L1707.9,1407.3L1707.9,1407.3L1707.9,1407.3z"
+   id="path837" />
+		<path
+   class="st9"
+   d="M1778.2,1392.9L1778.2,1392.9L1778.2,1392.9z"
+   id="path839" />
+		<path
+   class="st9"
+   d="M1775.7,1391.2c0.3-0.2,0.7-0.3,1-0.3C1776.3,1391,1776,1391.1,1775.7,1391.2z"
+   id="path841" />
+		<path
+   class="st9"
+   d="M1778.2,1392.9L1778.2,1392.9L1778.2,1392.9L1778.2,1392.9z"
+   id="path843" />
+		<path
+   class="st9"
+   d="M1713.1,1413.6L1713.1,1413.6L1713.1,1413.6z"
+   id="path845" />
+		<path
+   class="st9"
+   d="M1778.2,1392.9L1778.2,1392.9L1778.2,1392.9z"
+   id="path847" />
+		<path
+   class="st9"
+   d="M1707.6,1411.9L1707.6,1411.9c0.1,0.1,0.2,0.2,0.2,0.2C1707.7,1412.1,1707.7,1412,1707.6,1411.9    L1707.6,1411.9z"
+   id="path849" />
+		<path
+   class="st9"
+   d="M1708.4,1407.6c-0.1-0.1-0.2-0.2-0.4-0.2C1708.1,1407.4,1708.2,1407.5,1708.4,1407.6z"
+   id="path851" />
+		<path
+   class="st9"
+   d="M1707.8,1412.2c0.1,0.1,0.1,0.1,0.1,0.2c0.1,0.1,0.1,0.1,0.1,0.1l0,0l-0.1-0.1    C1707.9,1412.3,1707.8,1412.2,1707.8,1412.2L1707.8,1412.2z"
+   id="path853" />
+		<path
+   class="st9"
+   d="M1706.6,1410.3L1706.6,1410.3C1706.6,1410.3,1706.6,1410.4,1706.6,1410.3    C1706.6,1410.4,1706.6,1410.3,1706.6,1410.3L1706.6,1410.3z"
+   id="path855" />
+		<path
+   class="st9"
+   d="M1707.6,1410c0.1,0.7,0.2,1.3,0.3,1.8C1707.8,1411.3,1707.7,1410.7,1707.6,1410z"
+   id="path857" />
+		<path
+   id="polygon859"
+   class="st9"
+   style="fill:none"
+   d="m 1779.6,1391.9 v -0.1 0 0 z" />
+		<path
+   class="st9"
+   d="M1746.9,1445.8c-0.2,0-0.3,0-0.5,0.1c-0.8,0.1-1.5,0.3-2.2,0.6c0.7-0.3,1.5-0.5,2.2-0.6    C1746.6,1445.8,1746.8,1445.8,1746.9,1445.8z"
+   id="path861" />
+		<path
+   class="st9"
+   d="M1749.2,1445.8c0,0-0.1,0-0.2,0c-0.3,0-0.7,0-1.1,0c0.3,0,0.7,0,1.1,0    C1749.1,1445.7,1749.1,1445.8,1749.2,1445.8z"
+   id="path863" />
+		<path
+   id="polygon865"
+   class="st9"
+   style="fill:none"
+   d="m 1778.1,1392.9 v 0 -0.1 z" />
+		<path
+   class="st9"
+   d="M1754.1,1460.3h-0.7l0,0c-0.8,0-1.6,0-2.2,0l0,0l0,0c-0.4,0-0.8,0-1.2,0c-0.3,0-0.6,0.1-0.9,0.2    c0.1,0.4,0.2,0.9,0.2,1.3v0.1c0.1,0.4,0.2,0.9,0.3,1.3c0.3,1.1,0.8,2.2,1.4,2.4l0,0c0.2,0.1,0.4,0.1,0.5,0.1    c1,0.1,2.6-0.2,2.6-2.5c0-0.1,0-0.2,0-0.3C1754.3,1461.6,1754.2,1460.9,1754.1,1460.3L1754.1,1460.3z"
+   id="path867" />
+		<path
+   class="st9"
+   d="M1748.2,1463.2C1748.2,1463.2,1748.2,1463.1,1748.2,1463.2c-0.1-0.4-0.2-0.7-0.2-1v-0.1    c-0.1-0.4-0.2-0.8-0.3-1c-1.4,0.6-2.8,1.3-4.1,2.2h-0.1c0.2,0.9,0.7,2.5,1.8,3.2c0.6,0.4,1.3,0.4,1.9,0.2c0.4-0.1,0.8-0.4,1-0.9    C1748.4,1465.1,1748.4,1464.1,1748.2,1463.2L1748.2,1463.2z"
+   id="path869" />
+		<path
+   class="st9"
+   d="M1777.3,1398.7L1777.3,1398.7c0,0,0.1-0.3,0.2-0.8C1777.3,1398.4,1777.3,1398.7,1777.3,1398.7z"
+   id="path871" />
+		<path
+   class="st9"
+   d="M1778.2,1392.9L1778.2,1392.9L1778.2,1392.9L1778.2,1392.9z"
+   id="path873" />
+		<path
+   class="st9"
+   d="M1765.5,1452.2c0-0.2-0.1-0.3-0.1-0.5c-0.1-0.3-0.3-0.6-0.5-0.9c-0.6-0.7-1.5-1.4-2.7-1.9    c-1.9-0.8-4.5-1.2-7.6-1.2h-1.4c0.2,0.3,0.3,0.7,0.3,1c0,1.8-2.3,3.6-5.4,4.2c-0.2,0-0.3,0.1-0.4,0.1c-2.3,0.4-4.4,0-5.7-0.8    c-0.6-0.3-1-0.8-1.2-1.4l0,0l-1.1,0.4c-0.4,0.2-3.1,1.1-5.1,2.9c-0.7,0.6-1.3,1.4-1.8,2.3c-0.2,0.5-0.4,1-0.4,1.5    c-0.1,0.7-0.1,1.4,0.1,2s0.5,1.2,1,1.7c1.1,1.2,2.9,2,4.8,2c1,0,1.9-0.2,2.8-0.7c0.5-0.3,1-0.6,1.6-0.9c1.4-0.9,3.1-1.9,5-2.6    c0.7-0.2,1.3-0.4,2-0.5c0.1,0,0.1,0,0.2,0c0.2,0,0.3,0,0.6,0c0.2,0,0.3,0,0.5,0l0,0c0.7,0,1.5,0,2.2,0c0.5,0,1,0,1.5,0s1,0,1.5,0    l0,0c1.1,0,2.1,0,2.9-0.1c1.1-0.1,2.1-0.3,3.1-0.7c2.3-1,3.5-2.9,3.5-5.1c0-0.3,0-0.5-0.1-0.8    C1765.5,1452.4,1765.5,1452.3,1765.5,1452.2L1765.5,1452.2z M1763.6,1454.2c-0.1,0.3-0.2,0.6-0.4,0.8c-0.1,0.2-0.3,0.4-0.4,0.6    c-0.2,0.2-0.4,0.4-0.6,0.5c-0.3,0.2-0.6,0.3-0.8,0.5c-1.1,0.5-3.2,0.6-5.3,0.6c-1.9,0-3.8-0.1-5.2-0.1c-0.5,0-1,0-1.5,0.1    c-1.4,0.2-2.9,0.6-4.2,1.3c-2.1,1-3.8,2.2-5.1,2.9c-0.6,0.3-1.2,0.4-1.9,0.4c-1.7,0-3.5-0.8-4-2.4c-0.1-0.3-0.1-0.5-0.1-0.8    c0-0.2,0-0.3,0-0.4c0.4-2.9,4.8-4.7,5.9-5.1c0.1,0,0.1-0.1,0.2-0.1s0.1,0,0.1,0c0.7,0.9,2,1.9,5.1,1.9c0.4,0,0.9,0,1.4-0.1    c0.1,0,0.1,0,0.2,0c0.4,0,0.9-0.1,1.3-0.2c1.8-0.3,3.2-0.9,4.1-1.6c0.9-0.6,1.5-1.5,1.9-2.5c0.1-0.2,0.1-0.3,0.1-0.4    c0.1-0.2,0.1-0.4,0.1-0.6l0,0c6.4,0.1,9,1.9,9.2,3c0,0.1,0,0.1,0,0.2c0,0.2,0,0.3,0,0.4    C1763.7,1453.6,1763.7,1453.9,1763.6,1454.2L1763.6,1454.2L1763.6,1454.2z"
+   id="path875" />
+		<path
+   class="st3"
+   d="M1768.9,1421.4c-1.1-0.5-2.3-0.8-3.4-0.9c-0.4,0-0.8-0.1-1.2-0.1l0,0c-6.6,0-12,5.4-12,12s5.4,12,12,12l0,0    c0.4,0,0.8,0,1.2-0.1c6.6-0.7,11.4-6.6,10.7-13.2C1775.8,1426.9,1773,1423.2,1768.9,1421.4L1768.9,1421.4L1768.9,1421.4z     M1762.6,1440.3c-2.1,0-3.8-1.7-3.8-3.8c0-2.1,1.7-3.8,3.8-3.8c2.1,0,3.8,1.7,3.8,3.8l0,0    C1766.4,1438.6,1764.7,1440.3,1762.6,1440.3L1762.6,1440.3z"
+   id="path877" />
+		<path
+   class="st3"
+   d="M1729,1453c0.4-0.1,0.8-0.2,1.2-0.2c0.2-0.1,0.4-0.1,0.6-0.2c0.3-0.1,0.6-0.2,0.9-0.3    c0.2-0.1,0.4-0.2,0.7-0.3c0.2-0.1,0.5-0.2,0.7-0.4c4.5-2.7,6.8-8,5.6-13.1c-0.1-0.3-0.1-0.6-0.2-0.9c-2-6.3-8.7-9.9-15.1-7.9    c-5,1.6-8.4,6.2-8.4,11.5l0,0c0,6.6,5.4,12,12,12c0.6,0,1.1,0,1.6-0.1C1728.8,1453.1,1728.9,1453,1729,1453L1729,1453z     M1725.9,1441.6c2.1,0,3.8,1.7,3.8,3.8c0,2.1-1.7,3.8-3.8,3.8l0,0c-2.1,0-3.8-1.7-3.8-3.8    C1722.1,1443.3,1723.8,1441.6,1725.9,1441.6L1725.9,1441.6z"
+   id="path879" />
+		<path
+   class="st37"
+   d="M1726.5,1493.4c-2.1,0.5-8.1,3.8-13.3,4.8c-5.2,1-9.8,1.5-11.3,2.1s-2.8,1.8,0.3,2.9    c3.1,1.2,18.2,1.6,19.6,0c1.3-1.6-0.9-2.3-4.2-2.2c-2.3,0-2.1-0.8-2.1-0.9c0,0,0.2-1,3.8-1.5s19.6-2,19.3-3.7    C1738.1,1493.2,1728.6,1493,1726.5,1493.4L1726.5,1493.4z"
+   id="path881" />
+		<path
+   class="st37"
+   d="M1757.9,1495.1L1757.9,1495.1c-3.6,0.2-11.7-0.2-12.8,1.7c-1.1,1.9,3.3,2.6,10.2,2s16.8-1.3,17.2-3.5    c0.4-2.1-1.8-1.7-2.1-3.1c-0.2-1.3,2.5-1.3,3-3.3s-3.6-1.8-7.3-1.8s-9.9,0.3-10.5,2.3c-0.6,1.9,2.8,1.9,5.2,2.4    c2.4,0.5,1.7,1.3,1.7,1.3C1762.4,1494.4,1761.5,1494.9,1757.9,1495.1L1757.9,1495.1z"
+   id="path883" />
+		<path
+   class="st37"
+   d="M1813.5,1473.3L1813.5,1473.3c-0.5,1.3-1.2,2.5-2.2,3.4c-1.8,1.7-3.3,2.7-4.7,3c7.6-1.1,12.1-2.4,12.1-3.8    C1818.7,1475,1816.9,1474.1,1813.5,1473.3L1813.5,1473.3z"
+   id="path885" />
+		<path
+   class="st37"
+   d="M1698.9,1475.9c0,1,2.2,1.9,6.1,2.8c-0.2-1.9-0.2-3.8,0.2-5.6C1701.2,1474,1698.9,1474.9,1698.9,1475.9z"
+   id="path887" />
+		<path
+   class="st38"
+   d="M1800.6,1471.2c-0.5-3.5-2-5.1-3.3-6.5c-1.2-1.3-2.4-2.5-2-4.8c0.3-2.1,2-3.4,4.7-3.7    c-1.7-11.2-4.1-25.2-7.2-37.2c-1.6-6-4-10.2-7.3-12.9c-3.8,1.9-8.3,4.1-13.4,6.2c-3.7,1.6-7.3,3.1-11,4.6c-2.9,3.1-6.1,6.2-8,7    c-1.2,0.6-2.4,0.8-3.7,0.9c-1.8,0.1-3.5-0.8-4.6-2.2c-0.7,0.2-1.3,0.3-2,0.4c-0.6,0.1-1.4,0.1-2.4,0.2c0.4,1.1,0.2,2.3-0.5,3.2    c-0.8,1-2.2,1.5-4.2,1.5c-2.8,0-6.8-1.1-12.1-3.2c-0.7-0.3-1.4-0.6-2.2-0.8c-0.4,0-0.8,0-1.2,0l0,0c-5.1,0-9-0.2-12.1-0.4    c-3.4,7-1.9,14.8-0.7,21.3c1.2,6.2,5.3,17.2,9.2,26.6c1.4,3.5,2.8,6.8,4,9.5c10.4,0.9,23.7,1.5,38.2,1.5c17.3,0,32.8-0.8,43.8-2    C1801.8,1477,1800.8,1472.5,1800.6,1471.2L1800.6,1471.2L1800.6,1471.2z M1769,1443.6c-1.1,0.5-2.3,0.8-3.4,0.9    c-0.4,0-0.8,0.1-1.2,0.1l0,0c-6.6,0-12-5.4-12-12s5.4-12,12-12l0,0l0,0c0.4,0,0.8,0,1.2,0.1c6.6,0.7,11.4,6.6,10.7,13.2    C1775.8,1438.1,1773,1441.9,1769,1443.6L1769,1443.6L1769,1443.6z M1715,1441.2L1715,1441.2c0-6.6,5.4-12,12-12    c5.3,0,9.9,3.4,11.5,8.4c0.1,0.3,0.2,0.6,0.2,0.9c1.2,5.1-1.1,10.4-5.6,13.1c-0.2,0.1-0.5,0.2-0.7,0.4c-0.2,0.1-0.4,0.2-0.7,0.3    c-0.3,0.1-0.6,0.2-0.9,0.3c-0.2,0.1-0.4,0.2-0.6,0.2c-0.4,0.1-0.8,0.2-1.2,0.2c-0.1,0-0.2,0.1-0.3,0.1    c-6.6,0.9-12.6-3.7-13.5-10.3C1715,1442.3,1715,1441.7,1715,1441.2L1715,1441.2L1715,1441.2z M1747.1,1466.6    c-0.6,0.2-1.3,0.2-1.9-0.2c-1.1-0.7-1.6-2.3-1.8-3.2h0.1c1.3-0.9,2.7-1.6,4.1-2.2c0.1,0.3,0.2,0.6,0.3,1v0.1    c0.1,0.3,0.2,0.6,0.2,1c0,0,0,0,0,0.1c0.2,0.9,0.2,1.9-0.1,2.6C1747.9,1466.2,1747.5,1466.5,1747.1,1466.6L1747.1,1466.6z     M1751.8,1465.7c-0.2,0-0.4-0.1-0.5-0.1l0,0c-0.6-0.2-1.1-1.3-1.4-2.4c-0.1-0.4-0.2-0.9-0.3-1.3v-0.1c-0.1-0.4-0.2-0.9-0.2-1.3    c0.3-0.1,0.6-0.1,0.9-0.2c0.4,0,0.8-0.1,1.2,0l0,0c0.6,0,1.4,0,2.2,0l0,0h0.7c0.1,0.6,0.1,1.3,0.2,2.5c0,0.1,0,0.2,0,0.3    C1754.4,1465.5,1752.7,1465.8,1751.8,1465.7L1751.8,1465.7L1751.8,1465.7z M1762,1458.3c-1,0.4-2.1,0.6-3.1,0.7    c-0.8,0.1-1.8,0.1-2.9,0.1l0,0c-0.5,0-1,0-1.5,0s-1,0-1.5,0c-0.7,0-1.5,0-2.2,0l0,0c-0.2,0-0.3,0-0.5,0s-0.4,0-0.6,0    c-0.1,0-0.2,0-0.2,0c-0.7,0.1-1.4,0.2-2,0.5c-1.9,0.6-3.6,1.7-5,2.6c-0.6,0.3-1.1,0.7-1.6,0.9c-0.8,0.4-1.8,0.7-2.8,0.7    c-1.9,0-3.7-0.8-4.8-2c-0.4-0.5-0.8-1.1-1-1.7c-0.2-0.7-0.2-1.3-0.1-2c0.1-0.5,0.2-1,0.4-1.5c0.4-0.9,1-1.6,1.8-2.3    c2-1.8,4.7-2.8,5.1-2.9l1.1-0.4c0-0.1-0.1-0.2-0.1-0.3c-0.2-1.5,1.2-3.1,3.5-4c0.7-0.3,1.5-0.5,2.2-0.6c0.2,0,0.3-0.1,0.5-0.1    c0.3,0,0.7-0.1,1.1-0.1c0.3,0,0.7,0,1.1,0c0.1,0,0.1,0,0.2,0c1.7,0.2,3.1,0.7,3.8,1.6c0.1,0.1,0.2,0.2,0.3,0.4h1.4    c3.1,0,5.6,0.4,7.6,1.2c1.2,0.5,2.1,1.1,2.7,1.9c0.2,0.3,0.4,0.6,0.5,0.9c0.1,0.2,0.1,0.3,0.1,0.5c0,0.1,0,0.1,0,0.2    c0,0.3,0.1,0.5,0.1,0.8C1765.6,1455.4,1764.4,1457.3,1762,1458.3L1762,1458.3L1762,1458.3z"
+   id="path889" />
+		<path
+   d="M1779.9,1392.6c0-0.1,0-0.2-0.1-0.3c0-0.1-0.1-0.2-0.1-0.3l-0.1-0.2l0,0l0,0l-0.1-0.1c-0.2-0.2-0.4-0.3-0.6-0.5h-0.1l0,0    l-0.1-0.1l0,0l0,0h-0.1l-0.2-0.1c-0.2-0.1-0.3-0.1-0.5-0.1s-0.4,0-0.6,0s-0.4,0-0.6,0c-0.7,0.1-1.3,0.4-1.9,0.9    c-0.5,0.4-0.9,0.9-1.2,1.4c-0.5,0.9-0.9,1.8-1.2,2.8c-0.2,0.7-0.3,1.4-0.4,2.1c0,0.2,0,0.4,0,0.6c0,0.1,0,0.1,0,0.2v0.1l0.4-0.7    c0.2-0.4,0.6-1,1-1.7c0.4-0.8,0.9-1.5,1.5-2.2c0.3-0.3,0.6-0.7,1-0.9c0.3-0.2,0.7-0.4,1.1-0.5c0.1,0,0.2,0,0.3,0l0,0l0,0    c0.1,0,0.2,0,0.3,0s0.2,0,0.3,0.1l0.2,0.1h0.1l0,0l0,0l0,0l0,0l0,0l0,0l0,0l0,0l0,0l0,0l0,0l0,0l0,0l0,0l0,0c0,0,0,0,0,0.1    c0.1,0.2,0.1,0.3,0.1,0.5c0,0.3,0,0.7-0.1,1c0,0.1,0,0.2,0,0.3c-0.1,0.4-0.2,0.9-0.3,1.3c-0.2,0.8-0.4,1.5-0.5,1.9    c-0.1,0.5-0.2,0.8-0.2,0.8c0.2-0.2,0.4-0.4,0.5-0.6c0.4-0.5,0.8-1.1,1.2-1.7c0.2-0.4,0.4-0.8,0.6-1.3v-0.1c0.2-0.5,0.3-1,0.4-1.6    C1779.9,1393.2,1779.9,1392.9,1779.9,1392.6L1779.9,1392.6z"
+   id="path891" />
+		<path
+   d="M1778.2,1392.9L1778.2,1392.9L1778.2,1392.9L1778.2,1392.9L1778.2,1392.9L1778.2,1392.9L1778.2,1392.9L1778.2,1392.9    L1778.2,1392.9L1778.2,1392.9L1778.2,1392.9L1778.2,1392.9z"
+   id="path893" />
+		<path
+   id="polygon895"
+   class="st37"
+   style="fill:#221f1f"
+   d="m 1705.1,1415 h 0.2 l -0.2,-0.3 z" />
+		<path
+   class="st37"
+   d="M1706.1,1409.1c0.1,0.4,0.3,0.8,0.5,1.2l0,0l0,0c0.1,0.2,0.3,0.5,0.4,0.7l0.1,0.1c0.2,0.2,0.3,0.5,0.5,0.7    l0,0c0.1,0.1,0.1,0.2,0.2,0.2l0,0c0.1,0.1,0.1,0.1,0.1,0.2c0.1,0.1,0.1,0.1,0.1,0.1s0-0.1-0.1-0.3c0-0.1-0.1-0.2-0.1-0.4    c-0.1-0.4-0.2-1.1-0.3-1.8c-0.1-0.4-0.1-0.8-0.1-1.1c0-0.2,0-0.4,0-0.5c0,0,0,0,0-0.1c0-0.2,0-0.3,0.1-0.5c0-0.1,0.1-0.2,0.2-0.3    c0.1-0.1,0.1-0.1,0.2-0.1h0.1h0.1l0,0l0,0l0,0l0,0l0,0l0,0l0,0l0,0c0,0,0,0,0.1,0l0,0c0.1,0.1,0.2,0.1,0.4,0.2    c0.3,0.3,0.6,0.6,0.9,0.9s0.6,0.7,0.8,1.1c0.5,0.7,1,1.4,1.5,2.1c0.3,0.5,0.7,1,1.1,1.5c0.3,0.4,0.4,0.6,0.4,0.6l0,0v-0.2    c0-0.1,0-0.1,0-0.2s0-0.2-0.1-0.3v-0.1c-0.1-0.3-0.1-0.6-0.2-0.9c0-0.1-0.1-0.2-0.1-0.2c-0.1-0.2-0.1-0.4-0.2-0.7    c-0.1-0.3-0.2-0.5-0.3-0.8c-0.1-0.1-0.1-0.2-0.2-0.4c-0.2-0.4-0.3-0.8-0.5-1.1c-0.2-0.5-0.5-0.9-0.8-1.3c-0.2-0.2-0.3-0.4-0.5-0.7    c-0.2-0.2-0.4-0.4-0.7-0.6c-0.1-0.1-0.3-0.2-0.4-0.3c-0.2-0.1-0.3-0.2-0.5-0.2c-0.1,0-0.1,0-0.2,0s-0.1,0-0.2,0h-0.1h-0.1    c-0.1,0-0.3,0-0.4,0h-0.1h-0.1h-0.1l0,0l-0.1,0.1c-0.4,0.2-0.7,0.4-0.9,0.8c-0.1,0.2-0.2,0.3-0.2,0.5c-0.1,0.2-0.1,0.3-0.1,0.5    C1705.9,1408,1706,1408.6,1706.1,1409.1L1706.1,1409.1z"
+   id="path897" />
+		<path
+   class="st39"
+   d="M1712.1,1484.2c2.8,0,4.8-1.5,6.2-3.5c-1.6-3.7-4.2-9.9-6.7-16.5c-0.9,0.8-1.7,1.7-2.3,2.7    c-2.1,3.2-3.8,10.8-1.7,14.8C1708.6,1483.4,1710,1484.2,1712.1,1484.2L1712.1,1484.2z"
+   id="path899" />
+		<path
+   class="st39"
+   d="M1811.6,1465.4c-1.7-4.3-5.2-7.3-8.5-7.4h-0.1c-0.5-0.1-1-0.1-1.5-0.1c-1.8,0-4.1,0.4-4.4,2.3    c-0.2,1.3,0.3,2,1.6,3.2c1.4,1.4,3.2,3.4,3.8,7.6c0.6,4.7,1.8,7.1,3.4,7.1c0.8,0,2.2-0.5,4.4-2.6    C1813.1,1472.8,1812.8,1468.6,1811.6,1465.4z"
+   id="path901" />
+		<path
+   class="st37"
+   d="M1722.2,1445.4c0,2.1,1.7,3.8,3.8,3.8l0,0c2.1,0,3.8-1.7,3.8-3.8c0-2.1-1.7-3.8-3.8-3.8l0,0    C1723.9,1441.6,1722.2,1443.3,1722.2,1445.4z"
+   id="path903" />
+		<path
+   class="st37"
+   d="M1762.7,1432.7c-2.1,0-3.8,1.7-3.8,3.8c0,2.1,1.7,3.8,3.8,3.8c2.1,0,3.8-1.7,3.8-3.8l0,0    C1766.4,1434.4,1764.7,1432.7,1762.7,1432.7z"
+   id="path905" />
+		<path
+   class="st40"
+   d="M1784.2,1398.2c-0.5,2.9-1.4,6-2,6.9l-0.6,0.8c2.6-1.3,4.9-2.5,6.9-3.6c6.9-3.9,7.7-5.5,7.8-6    c0.1-0.3,0-0.4,0-0.4c-0.1-0.1-0.6-0.6-2.7-0.6c-2.4,0-5.7,0.5-9.2,1.3C1784.4,1397.2,1784.3,1397.7,1784.2,1398.2L1784.2,1398.2z    "
+   id="path907" />
+		<path
+   class="st40"
+   d="M1781.5,1405.9l-1-0.1c-1.4-0.1-2.9-0.2-4.3-0.2c-2.6,0-5.9,0.2-8.7,0.8c0.6,1.1,0.4,2.5-0.4,3.5    c-0.7,0.8-1.8,2.2-3.2,3.8c2.5-1,5-2.1,7.5-3.1C1774.8,1409.1,1778.2,1407.6,1781.5,1405.9z"
+   id="path909" />
+		<path
+   class="st40"
+   d="M1715.7,1403.1L1715.7,1403.1c3.2,0.8,6.6,1.2,9.9,1.2c5.8,0,18.3-1.1,35.7-8.7l0.4-0.2    c-0.1-1,0-1.9,0.2-2.9c0.3-1.6,1-3,2.1-4.2c-0.1-0.5-0.3-0.9-0.4-1.4c-2-1.1-18.6-7.2-27.3-7.2c-0.8,0-1.5,0.1-2.2,0.2    c-7.7,1.6-19.3,14.9-19.7,16.8c-0.1,0.8-0.1,3.4,0,6.2L1715.7,1403.1L1715.7,1403.1z"
+   id="path911" />
+		<path
+   class="st40"
+   d="M1742.6,1421.1c0.5-0.1,1.1-0.2,1.6-0.3c-0.1-1.8,1.2-3.3,3-3.4c0.9-0.1,1.8,0.3,2.4,0.9    c0.3-0.1,0.6-0.2,0.8-0.3c1.6-0.8,7.3-6.9,11.7-12.1c0.2-0.2,0.3-0.3,0.5-0.5c-9.9,4.3-23.9,9-37.1,9c-2,0-4-0.1-6-0.4l0.3,0.8    l-1.7,0.6c0,0-0.3,0.1-0.8,0.3c2.1,0.5,5,1.5,8.6,2.9c6.6,2.7,9.2,2.8,9.8,2.7c0.9-0.5,2-0.5,2.9,0    C1740.4,1421.3,1741.8,1421.2,1742.6,1421.1L1742.6,1421.1z"
+   id="path913" />
+		<path
+   class="st40"
+   d="M1715.5,1422c-0.2-0.1-0.5-0.1-0.8-0.1c-1.8,0.1-3.3-1.2-3.4-3c0-0.1,0-0.1,0-0.2c-0.9,0.5-1.7,1-2.6,1.6    l-1.4,1l-1.1-1.4c-1.2-1.6-2.2-3.3-3.2-5.1c-2.6,1.2-4.6,2.5-5.1,3.8c-0.1,0.2-0.1,0.4,0,0.5    C1698.5,1419.8,1701,1421.7,1715.5,1422L1715.5,1422z"
+   id="path915" />
+		<path
+   class="st39"
+   d="M1762,1397.2c-7,3-22.2,8.9-36.4,8.9c-3.5,0-7-0.4-10.4-1.3c0.3,0.5,0.7,1.1,1,1.7c1,1.8,1.9,3.6,2.6,5.5    c2.2,0.3,4.5,0.5,6.7,0.5c8.2,0,20.9-1.9,38.4-9.7c0.3-0.9,0.6-1.9,1.1-3.1h-0.1c-0.2,0-0.4,0-0.6-0.1    C1763.2,1399.3,1762.4,1398.5,1762,1397.2L1762,1397.2z"
+   id="path917" />
+		<path
+   class="st38"
+   d="M1705.3,1415c0.7,1.3,1.6,2.6,2.5,3.8c4.2-2.9,9.8-5,9.8-5s-0.1-0.4-0.4-1.1c-0.2-0.6-0.5-1.2-0.8-1.8    c-0.2-0.4-0.4-0.9-0.6-1.3c-0.1-0.2-0.2-0.4-0.3-0.5l-0.1-0.1c-0.1-0.2-0.2-0.4-0.3-0.6v-0.1c-0.4-0.8-0.9-1.6-1.4-2.4    c-1.7-2.5-3.8-4.7-6.2-4.7c-0.8,0-1.6,0.2-2.3,0.7c-4.4,2.7-2.1,8.8,0.1,12.9L1705.3,1415L1705.3,1415z M1705.9,1407.5    c0-0.2,0.1-0.3,0.1-0.5c0.1-0.2,0.1-0.3,0.2-0.5c0.2-0.4,0.6-0.7,0.9-0.8h0.1l0,0l0.1-0.1h0.1h0.1c0.1,0,0.3,0,0.4,0h0.1h0.1    c0.1,0,0.1,0,0.2,0s0.1,0,0.2,0c0.2,0.1,0.3,0.1,0.5,0.2s0.3,0.2,0.4,0.3c0.2,0.2,0.4,0.4,0.7,0.6c0.2,0.2,0.4,0.4,0.6,0.7    c0.3,0.4,0.6,0.8,0.8,1.3c0.2,0.4,0.4,0.7,0.5,1.1c0.1,0.1,0.1,0.2,0.2,0.4c0.1,0.3,0.2,0.5,0.3,0.8c0.1,0.2,0.2,0.4,0.2,0.7    c0,0.1,0.1,0.2,0.1,0.2c0.1,0.3,0.2,0.6,0.2,0.9v0.1c0,0.1,0,0.2,0.1,0.3c0,0.1,0,0.2,0,0.2v0.2l0,0l0,0c0,0-0.2-0.2-0.4-0.6    c-0.4-0.5-0.7-1-1.1-1.5c-0.4-0.6-0.9-1.3-1.5-2.1c-0.3-0.4-0.6-0.7-0.8-1.1c-0.3-0.3-0.6-0.6-0.9-0.9c-0.1-0.1-0.2-0.2-0.4-0.2    l0,0c0,0,0,0-0.1,0l0,0l0,0l0,0l0,0l0,0l0,0l0,0h-0.1h-0.1c-0.1,0-0.1,0.1-0.2,0.1c-0.1,0.1-0.1,0.2-0.2,0.3    c0,0.2-0.1,0.3-0.1,0.5c0,0,0,0,0,0.1c0,0.2,0,0.4,0,0.5c0,0.4,0.1,0.8,0.1,1.1c0.1,0.7,0.2,1.3,0.3,1.8c0,0.2,0.1,0.3,0.1,0.4    c0,0.2,0.1,0.3,0.1,0.3l0,0l-0.1-0.1c0-0.1-0.1-0.1-0.1-0.2l0,0c-0.1-0.1-0.1-0.2-0.2-0.2l0,0c-0.2-0.2-0.3-0.5-0.5-0.7l-0.1-0.1    c-0.1-0.2-0.3-0.5-0.4-0.7l0,0l0,0c-0.2-0.4-0.3-0.8-0.5-1.2C1705.9,1408.6,1705.9,1408.1,1705.9,1407.5L1705.9,1407.5z"
+   id="path919" />
+		<path
+   class="st39"
+   d="M1766.6,1386.9L1766.6,1386.9c0.2,0,0.4,0,0.6,0.1c1.3,0.3,2.3,1.6,2.6,3.4c2.6-3.6,5.4-5.4,8.4-5.4    c1.2,0,2.3,0.3,3.3,0.9c1.6-1.9,2.6-3.3,2.6-3.3c-1.2,0.2-3.7,0.5-3.7,0.5c9.4-3.5,8.7-12.9,8.7-12.9c0,1.6-4.9,5.5-4.9,5.5    c0.2-1.4-0.5-3.2-0.5-3.2c0.2,1.8-5.6,6.6-5.6,6.6c0.4-0.9,0.1-2.4,0.1-2.4c-0.3,1.7-2.9,2.4-2.9,2.4c1.6-1.9,4.7-12.2,2.4-12.9    s-5.4,6.7-5.4,6.7c-0.1-1.7-1.1-1.7-1.1-1.7c0.4,5.4-3.9,9.8-3.9,9.8c-0.3-1.1-2.1-1.6-2.1-1.6c0.6,1.2-0.1,6.7-0.3,8.2    C1765.3,1387.2,1765.9,1387,1766.6,1386.9L1766.6,1386.9z"
+   id="path921" />
+		<path
+   d="M1764.3,1397.5L1764.3,1397.5c0.1,0.1,0.1,0.1,0.2,0.1c0.1,0.1,0.2,0.1,0.3,0.1c0.1,0,0.2,0,0.3,0    c0.3-0.1,0.7-0.3,0.9-0.5c0.3-0.7,0.6-1.4,0.9-2s0.6-1.2,0.9-1.8c0.5-2.4-0.2-4.5-1.1-4.7c-0.1,0-0.1,0-0.2,0    c-0.9,0-2.3,1.6-2.8,4.1c-0.4,1.8-0.2,3.3,0.2,4.2C1764,1397.2,1764.1,1397.4,1764.3,1397.5L1764.3,1397.5L1764.3,1397.5    L1764.3,1397.5z"
+   id="path923" />
+		<path
+   class="st38"
+   d="M1778.2,1392.9L1778.2,1392.9L1778.2,1392.9L1778.2,1392.9L1778.2,1392.9L1778.2,1392.9L1778.2,1392.9    L1778.2,1392.9L1778.2,1392.9L1778.2,1392.9L1778.2,1392.9z"
+   id="path925" />
+		<path
+   class="st38"
+   d="M1778.1,1386.8c-5.4,0-9.3,8.1-11.4,13.6c-0.5,1.4-1,2.9-1.5,4.4c0.3,0.1,0.5,0.1,0.8,0.3    c3.1-0.9,7.2-1.2,10.2-1.2c2.6,0,4.5,0.2,4.5,0.2C1781.5,1402.9,1786.2,1386.8,1778.1,1386.8L1778.1,1386.8z M1779.6,1395    C1779.6,1395,1779.5,1395.1,1779.6,1395c-0.2,0.5-0.4,0.9-0.6,1.3c-0.3,0.6-0.7,1.2-1.2,1.7c-0.2,0.2-0.3,0.4-0.5,0.6l0,0    c0,0,0.1-0.3,0.2-0.8s0.3-1.2,0.5-1.9c0.1-0.4,0.2-0.8,0.3-1.3c0-0.1,0-0.2,0-0.3c0.1-0.3,0.1-0.7,0.1-1c0-0.2,0-0.3-0.1-0.5    c0,0,0,0,0-0.1l0,0l0,0l0,0l0,0l0,0l0,0l0,0l0,0l0,0l0,0l0,0l0,0l0,0h-0.1l-0.2-0.1c-0.1,0-0.2,0-0.3-0.1c-0.1,0-0.2,0-0.3,0l0,0    c-0.1,0-0.2,0-0.3,0c-0.4,0.1-0.8,0.2-1.1,0.5c-0.4,0.3-0.7,0.6-1,0.9c-0.6,0.7-1.1,1.4-1.5,2.2c-0.4,0.7-0.8,1.3-1,1.7l-0.4,0.7    c0,0,0,0,0-0.1s0-0.1,0-0.2s0-0.3,0-0.6c0.1-0.7,0.2-1.4,0.4-2.1c0.2-1,0.7-1.9,1.2-2.8c0.3-0.5,0.7-1,1.2-1.4    c0.5-0.5,1.2-0.8,1.9-0.9c0.2,0,0.4,0,0.6,0s0.4,0,0.6,0s0.3,0.1,0.5,0.1l0.2,0.1h0.1l0,0l0,0h0.1l0,0h0.1    c0.2,0.1,0.4,0.3,0.6,0.5l0.1,0.1l0,0l0,0l0.1,0.2c0.1,0.1,0.1,0.2,0.1,0.3c0,0.1,0.1,0.2,0.1,0.3c0.1,0.3,0.1,0.5,0.1,0.8    C1779.9,1393.9,1779.8,1394.5,1779.6,1395L1779.6,1395z"
+   id="path927" />
+		<path
+   d="M1749.4,1422.8c1,0,2-0.3,2.9-0.7c2.1-1,7.3-6.2,13.3-13.3c0.4-0.5,0.4-1.3-0.2-1.8c-0.5-0.4-1.3-0.4-1.8,0.2l0,0    c-2.6,3.1-9.8,11.4-12.3,12.6l0,0c-0.4,0.2-0.9,0.3-1.3,0.4l-0.9,0.2l-0.7-0.7c-0.2-0.2-0.6-0.3-0.9-0.3c-0.7,0-1.3,0.6-1.3,1.3    c0,0.2,0.1,0.5,0.2,0.7C1746.4,1421.5,1747.3,1422.8,1749.4,1422.8L1749.4,1422.8z"
+   id="path929" />
+		<path
+   d="M1736.7,1423.2l-0.4,0.2h-0.4c-0.1,0-0.2,0-0.3,0c-1.2,0-4.1-0.4-10.3-2.9c-6.9-2.8-9.6-3.2-10.6-3.2c-0.1,0-0.2,0-0.4,0    c-0.7,0.1-1.2,0.8-1,1.5l0,0c0.1,0.6,0.7,1.1,1.3,1.1h0.1h0.1c0.8,0.1,3.2,0.5,9.4,3c5,2,8.8,3.1,11.3,3.1c1.3,0,2.2-0.3,2.7-0.8    c0.4-0.5,0.4-1.3-0.2-1.8c-0.2-0.2-0.5-0.3-0.8-0.3C1737.1,1423.1,1736.9,1423.1,1736.7,1423.2L1736.7,1423.2z"
+   id="path931" />
+		<path
+   class="st39"
+   d="M1763.7,1452.6c-0.2-1.1-2.8-2.9-9.2-3l0,0c0,0.2-0.1,0.4-0.1,0.6c0,0.1-0.1,0.3-0.1,0.4    c-0.4,1-1.1,1.9-1.9,2.5c-0.9,0.7-2.2,1.3-4.1,1.6c-0.5,0.1-0.9,0.1-1.3,0.2c-0.1,0-0.1,0-0.2,0c-0.5,0-1,0.1-1.4,0.1    c-3.2,0-4.4-1-5.1-1.9c0,0,0,0-0.1,0c0,0-0.1,0-0.2,0.1c-1.1,0.4-5.5,2.2-5.9,5.1c0,0.2,0,0.3,0,0.4c0,0.3,0,0.5,0.1,0.8    c0.5,1.6,2.3,2.4,4,2.4c0.7,0,1.3-0.1,1.9-0.4c1.3-0.7,3-1.9,5.1-2.9c1.3-0.6,2.7-1.1,4.2-1.3c0.5-0.1,1-0.1,1.5-0.1    c1.4,0,3.3,0.1,5.2,0.1c2.1,0,4.2-0.1,5.3-0.6c0.3-0.1,0.6-0.3,0.8-0.5c0.2-0.2,0.4-0.3,0.6-0.5s0.3-0.3,0.4-0.6    c0.2-0.3,0.3-0.6,0.4-0.8c0.1-0.3,0.1-0.7,0.1-1.1c0-0.2,0-0.3,0-0.4C1763.7,1452.6,1763.7,1452.6,1763.7,1452.6L1763.7,1452.6z"
+   id="path933" />
+		<path
+   class="st9"
+   d="M1754.5,1449.6c0,0.2-0.1,0.4-0.1,0.6"
+   id="path935" />
+		<path
+   class="st37"
+   d="M1742,1452.2c1.3,0.8,3.4,1.2,5.7,0.8c0.2,0,0.3-0.1,0.4-0.1c3.1-0.6,5.3-2.4,5.4-4.2c0-0.4-0.1-0.7-0.3-1    c-0.1-0.1-0.2-0.3-0.3-0.4c-0.7-0.9-2.1-1.4-3.8-1.6c-0.1,0-0.1,0-0.2,0c-0.3,0-0.7,0-1.1,0c-0.3,0-0.7,0-1.1,0.1    c-0.2,0-0.3,0-0.5,0.1c-0.8,0.1-1.5,0.3-2.2,0.6c-2.3,0.9-3.8,2.5-3.5,4c0,0.1,0.1,0.2,0.1,0.3l0,0    C1741,1451.4,1741.4,1451.9,1742,1452.2L1742,1452.2z"
+   id="path937" />
+	</g>
+</g>
+<g
+   id="g1152">
+	<g
+   id="g1150">
+		<g
+   id="g12">
+			<path
+   id="path943"
+   class="st3"
+   d="M1390.1,1121.7c0-34.6,28.1-62.7,62.7-62.7s62.7,28.1,62.7,62.7s-28.1,62.7-62.7,62.7l0,0     C1418.2,1184.4,1390.1,1156.3,1390.1,1121.7" />
+			<g
+   id="g968">
+				<g
+   id="g966">
+					<g
+   id="g964">
+						<defs
+   id="defs946">
+							<polygon
+   id="SVGID_00000087397673825608628110000014088707974821386916_"
+   points="1450.5,1173.7 1421.6,1161 1420,1179.2          1451.8,1189.3        " />
+						</defs>
+						<clipPath
+   id="SVGID_00000129901781963488700080000004494674542875899296_">
+							<use
+   xlink:href="#SVGID_00000087397673825608628110000014088707974821386916_"
+   style="overflow:visible;"
+   id="use948" />
+						</clipPath>
+						<g
+   style="clip-path:url(#SVGID_00000129901781963488700080000004494674542875899296_);"
+   clip-path="url(#SVGID_00000129901781963488700080000004494674542875899296_)"
+   id="g962">
+							<g
+   id="g30">
+								<g
+   id="g32">
+
+										<linearGradient
+   id="path46_00000017498145880322647670000015042790713764617647_"
+   gradientUnits="userSpaceOnUse"
+   x1="-1334.0927"
+   y1="1466.636"
+   x2="-1333.0426"
+   y2="1466.636"
+   gradientTransform="matrix(30.43 0 0 -30.43 42016.5312 45804.8828)">
+										<stop
+   offset="0"
+   style="stop-color:#60B932"
+   id="stop951" />
+										<stop
+   offset="0.28"
+   style="stop-color:#60B932"
+   id="stop953" />
+										<stop
+   offset="1"
+   style="stop-color:#367C34"
+   id="stop955" />
+									</linearGradient>
+									<path
+   id="path958"
+   style="fill:url(#path46_00000017498145880322647670000015042790713764617647_);"
+   d="M1450.5,1173.7           l-28.9-12.7l-1.6,18.2l31.8,10.1L1450.5,1173.7" />
+								</g>
+							</g>
+						</g>
+					</g>
+				</g>
+			</g>
+			<g
+   id="g993">
+				<g
+   id="g991">
+					<g
+   id="g989">
+						<defs
+   id="defs971">
+							<path
+   id="SVGID_00000095328567770303831910000000899055023590851201_"
+   d="M1427.3,1103.4h16.2v13.8h-3.8v-5.9         c0-2.4-1.9-4.3-4.3-4.3s-4.3,1.9-4.3,4.3l0,0v5.9h-3.8L1427.3,1103.4L1427.3,1103.4z M1424,1133.7l24.1,10.6l-1.7-20.3h3.2         v-6.8h-2.3v-13.8h2.3v-4l-13-12.7v-0.9c0-0.7-0.6-1.2-1.2-1.2s-1.2,0.6-1.2,1.2v0.9l-13,12.7v4h2.3v13.8h-2.3v6.8h3.7         L1424,1133.7L1424,1133.7z" />
+						</defs>
+						<clipPath
+   id="SVGID_00000039850736858859901780000010548777329597472896_">
+							<use
+   xlink:href="#SVGID_00000095328567770303831910000000899055023590851201_"
+   style="overflow:visible;"
+   id="use973" />
+						</clipPath>
+						<g
+   style="clip-path:url(#SVGID_00000039850736858859901780000010548777329597472896_);"
+   clip-path="url(#SVGID_00000039850736858859901780000010548777329597472896_)"
+   id="g987">
+							<g
+   id="g48">
+								<g
+   id="g50">
+
+										<linearGradient
+   id="path64_00000048494459876183170980000018362635505638317234_"
+   gradientUnits="userSpaceOnUse"
+   x1="-1321.8586"
+   y1="1485.1105"
+   x2="-1320.8187"
+   y2="1485.1105"
+   gradientTransform="matrix(27.21 0 0 -27.21 37388.4766 41524.3047)">
+										<stop
+   offset="0"
+   style="stop-color:#60B932"
+   id="stop976" />
+										<stop
+   offset="0.28"
+   style="stop-color:#60B932"
+   id="stop978" />
+										<stop
+   offset="1"
+   style="stop-color:#367C34"
+   id="stop980" />
+									</linearGradient>
+									<path
+   id="path983"
+   style="fill:url(#path64_00000048494459876183170980000018362635505638317234_);"
+   d="M1427.3,1103.4h16.2           v13.8h-3.8v-5.9c0-2.4-1.9-4.3-4.3-4.3s-4.3,1.9-4.3,4.3l0,0v5.9h-3.8L1427.3,1103.4L1427.3,1103.4z M1424,1133.7           l24.1,10.6l-1.7-20.3h3.2v-6.8h-2.3v-13.8h2.3v-4l-13-12.7v-0.9c0-0.7-0.6-1.2-1.2-1.2s-1.2,0.6-1.2,1.2v0.9l-13,12.7v4           h2.3v13.8h-2.3v6.8h3.7L1424,1133.7" />
+								</g>
+							</g>
+						</g>
+					</g>
+				</g>
+			</g>
+			<g
+   id="g1018">
+				<g
+   id="g1016">
+					<g
+   id="g1014">
+						<defs
+   id="defs996">
+							<polygon
+   id="SVGID_00000054251076119018809420000008931239462571946426_"
+   points="1422.6,1149.6 1449.5,1161.5          1449.1,1156.6 1423,1145.1        " />
+						</defs>
+						<clipPath
+   id="SVGID_00000119097023542842266100000002233422779262003332_">
+							<use
+   xlink:href="#SVGID_00000054251076119018809420000008931239462571946426_"
+   style="overflow:visible;"
+   id="use998" />
+						</clipPath>
+						<g
+   style="clip-path:url(#SVGID_00000119097023542842266100000002233422779262003332_);"
+   clip-path="url(#SVGID_00000119097023542842266100000002233422779262003332_)"
+   id="g1012">
+							<g
+   id="g66">
+								<g
+   id="g68">
+
+										<linearGradient
+   id="path82_00000093864474510243601780000006733216764569346967_"
+   gradientUnits="userSpaceOnUse"
+   x1="-1315.3534"
+   y1="1494.5994"
+   x2="-1314.3134"
+   y2="1494.5994"
+   gradientTransform="matrix(25.75 0 0 -25.75 35293.1406 39639.2344)">
+										<stop
+   offset="0"
+   style="stop-color:#60B932"
+   id="stop1001" />
+										<stop
+   offset="0.28"
+   style="stop-color:#60B932"
+   id="stop1003" />
+										<stop
+   offset="1"
+   style="stop-color:#367C34"
+   id="stop1005" />
+									</linearGradient>
+									<path
+   id="path1008"
+   style="fill:url(#path82_00000093864474510243601780000006733216764569346967_);"
+   d="M1422.6,1149.6           l26.9,11.9l-0.4-4.9l-26.1-11.5L1422.6,1149.6" />
+								</g>
+							</g>
+						</g>
+					</g>
+				</g>
+			</g>
+			<g
+   id="g1043">
+				<g
+   id="g1041">
+					<g
+   id="g1039">
+						<defs
+   id="defs1021">
+							<polygon
+   id="SVGID_00000124841580987800601930000001158039670789792432_"
+   points="1421.9,1157.6 1450.2,1170.1          1449.8,1165.1 1422.3,1153        " />
+						</defs>
+						<clipPath
+   id="SVGID_00000039834433141302221920000011146649494845704605_">
+							<use
+   xlink:href="#SVGID_00000124841580987800601930000001158039670789792432_"
+   style="overflow:visible;"
+   id="use1023" />
+						</clipPath>
+						<g
+   style="clip-path:url(#SVGID_00000039834433141302221920000011146649494845704605_);"
+   clip-path="url(#SVGID_00000039834433141302221920000011146649494845704605_)"
+   id="g1037">
+							<g
+   id="g84">
+								<g
+   id="g86">
+
+										<linearGradient
+   id="path100_00000003105454600206803550000006370044937769740719_"
+   gradientUnits="userSpaceOnUse"
+   x1="-1321.4335"
+   y1="1485.4615"
+   x2="-1320.3934"
+   y2="1485.4615"
+   gradientTransform="matrix(27.1 0 0 -27.1 37233.2227 41417.6094)">
+										<stop
+   offset="0"
+   style="stop-color:#60B932"
+   id="stop1026" />
+										<stop
+   offset="0.28"
+   style="stop-color:#60B932"
+   id="stop1028" />
+										<stop
+   offset="1"
+   style="stop-color:#367C34"
+   id="stop1030" />
+									</linearGradient>
+									<path
+   id="path1033"
+   style="fill:url(#path100_00000003105454600206803550000006370044937769740719_);"
+   d="M1421.9,1157.6           l28.3,12.5l-0.4-4.9l-27.5-12.1L1421.9,1157.6" />
+								</g>
+							</g>
+						</g>
+					</g>
+				</g>
+			</g>
+			<g
+   id="g1067">
+				<g
+   id="g1065">
+					<g
+   id="g1063">
+						<defs
+   id="defs1046">
+							<polygon
+   id="SVGID_00000168820533334741191070000018209296112031605155_"
+   points="1423.7,1137.1 1423.3,1141.7          1448.8,1152.9 1448.4,1148        " />
+						</defs>
+						<clipPath
+   id="SVGID_00000167367538517693814720000018124936068125037230_">
+							<use
+   xlink:href="#SVGID_00000168820533334741191070000018209296112031605155_"
+   style="overflow:visible;"
+   id="use1048" />
+						</clipPath>
+						<g
+   style="clip-path:url(#SVGID_00000167367538517693814720000018124936068125037230_);"
+   clip-path="url(#SVGID_00000167367538517693814720000018124936068125037230_)"
+   id="g1061">
+							<g
+   id="g102">
+								<g
+   id="g104">
+
+										<linearGradient
+   id="path118_00000035492919820086048550000006409214471163179167_"
+   gradientUnits="userSpaceOnUse"
+   x1="-1308.6071"
+   y1="1504.7484"
+   x2="-1307.557"
+   y2="1504.7484"
+   gradientTransform="matrix(24.4 0 0 -24.4 33353.0586 37860.8594)">
+										<stop
+   offset="0"
+   style="stop-color:#60B932"
+   id="stop1051" />
+										<stop
+   offset="0.28"
+   style="stop-color:#60B932"
+   id="stop1053" />
+										<stop
+   offset="1"
+   style="stop-color:#367C34"
+   id="stop1055" />
+									</linearGradient>
+									<path
+   id="path118"
+   style="fill:url(#path118_00000035492919820086048550000006409214471163179167_);"
+   d="M1423.7,1137.1           l-0.4,4.6l25.5,11.2l-0.4-4.9L1423.7,1137.1" />
+								</g>
+							</g>
+						</g>
+					</g>
+				</g>
+			</g>
+			<path
+   id="path1069"
+   class="st51"
+   d="M1505.1,1093l13-4.2c-0.1-0.1-0.1-0.2-0.1-0.3c-2.2-4.3-4.8-8.4-7.8-12.1l-12.2,6.3     c2.7,3.1,5,6.5,7,10.1C1505,1092.9,1505.1,1092.9,1505.1,1093" />
+			<path
+   id="path1071"
+   class="st51"
+   d="M1512.3,1117.7l13.6,1c-0.2-3.6-0.6-7.2-1.3-10.8l-13.7,0.5     C1511.6,1111.4,1512.1,1114.5,1512.3,1117.7" />
+			<path
+   id="path1073"
+   class="st51"
+   d="M1453.7,1181.4c-32.9,0-59.7-26.8-59.7-59.7s26.8-59.7,59.7-59.7c11.4,0,22.5,3.2,32.1,9.4     l9.5-9.9c-12.2-8.5-26.7-13-41.6-13c-40.3,0-73.2,32.8-73.2,73.2s32.8,73.2,73.2,73.2c34.5,0,63.4-24,71.2-56.1l-12.8-4.4     C1506.2,1161.2,1482.3,1181.4,1453.7,1181.4" />
+			<g
+   id="g1098">
+				<g
+   id="g1096">
+					<g
+   id="g1094">
+						<defs
+   id="defs1076">
+							<path
+   id="SVGID_00000160174208940108839400000010220353791722414234_"
+   d="M1508.9,1074.8c-3.7-4.4-7.9-8.4-12.5-11.8         c-0.7-0.5-1.3-1-2-1.4l-9.5,9.9l-34.7,36.1l47.8-24.7l12.2-6.3C1509.7,1075.9,1509.3,1075.3,1508.9,1074.8L1508.9,1074.8z" />
+						</defs>
+						<clipPath
+   id="SVGID_00000143598246816816800900000002179034859363660172_">
+							<use
+   xlink:href="#SVGID_00000160174208940108839400000010220353791722414234_"
+   style="overflow:visible;"
+   id="use1078" />
+						</clipPath>
+						<g
+   style="clip-path:url(#SVGID_00000143598246816816800900000002179034859363660172_);"
+   clip-path="url(#SVGID_00000143598246816816800900000002179034859363660172_)"
+   id="g1092">
+							<g
+   id="g126">
+								<g
+   id="g128">
+
+										<linearGradient
+   id="path142_00000060736282408283149900000005045030824478742953_"
+   gradientUnits="userSpaceOnUse"
+   x1="-1356.8926"
+   y1="1341.7611"
+   x2="-1355.8525"
+   y2="1341.7611"
+   gradientTransform="matrix(53.1132 -39.3304 -39.3304 -53.1132 126292.6484 19004.6367)">
+										<stop
+   offset="0"
+   style="stop-color:#4596D8"
+   id="stop1081" />
+										<stop
+   offset="0.2"
+   style="stop-color:#4596D8"
+   id="stop1083" />
+										<stop
+   offset="1"
+   style="stop-color:#FFFFFF"
+   id="stop1085" />
+									</linearGradient>
+									<path
+   id="path1088"
+   style="fill:url(#path142_00000060736282408283149900000005045030824478742953_);"
+   d="M1508.9,1074.8           c-3.7-4.4-7.9-8.4-12.5-11.8c-0.7-0.5-1.3-1-2-1.4l-9.5,9.9l-34.7,36.1l47.8-24.7l12.2-6.3           C1509.8,1075.9,1509.3,1075.4,1508.9,1074.8" />
+								</g>
+							</g>
+						</g>
+					</g>
+				</g>
+			</g>
+			<g
+   id="g1122">
+				<g
+   id="g1120">
+					<g
+   id="g1118">
+						<defs
+   id="defs1101">
+							<path
+   id="SVGID_00000161615399572690421340000004143536593183571115_"
+   d="M1525.9,1121.1c0-0.8-0.1-1.7-0.1-2.5l-13.6-1         l-62.1-4.4l60.9,21.1l12.8,4.4c0-0.2,0.1-0.3,0.1-0.4c1.3-5.4,1.9-11,1.9-16.6L1525.9,1121.1L1525.9,1121.1L1525.9,1121.1z" />
+						</defs>
+						<clipPath
+   id="SVGID_00000084497795545825265180000002078913860547847355_">
+							<use
+   xlink:href="#SVGID_00000161615399572690421340000004143536593183571115_"
+   style="overflow:visible;"
+   id="use1103" />
+						</clipPath>
+						<g
+   style="clip-path:url(#SVGID_00000084497795545825265180000002078913860547847355_);"
+   clip-path="url(#SVGID_00000084497795545825265180000002078913860547847355_)"
+   id="g1116">
+							<g
+   id="g144">
+								<g
+   id="g146">
+
+										<linearGradient
+   id="path160_00000175313603018217718320000003920914298315059359_"
+   gradientUnits="userSpaceOnUse"
+   x1="-1409.645"
+   y1="1380.2673"
+   x2="-1408.6051"
+   y2="1380.2673"
+   gradientTransform="matrix(76.2273 15.564 15.564 -76.2273 87422.1797 128267.3984)">
+										<stop
+   offset="0"
+   style="stop-color:#4194D7"
+   id="stop1106" />
+										<stop
+   offset="0.2"
+   style="stop-color:#4194D7"
+   id="stop1108" />
+										<stop
+   offset="1"
+   style="stop-color:#FFFFFF"
+   id="stop1110" />
+									</linearGradient>
+									<path
+   id="path160"
+   style="fill:url(#path160_00000175313603018217718320000003920914298315059359_);"
+   d="M1525.9,1121.1           c0-0.8-0.1-1.7-0.1-2.5l-13.6-1l-62.1-4.4l60.9,21.1l12.8,4.4c0-0.2,0.1-0.3,0.1-0.4c1.3-5.4,1.9-11,1.9-16.6           L1525.9,1121.1" />
+								</g>
+							</g>
+						</g>
+					</g>
+				</g>
+			</g>
+			<g
+   id="g1147">
+				<g
+   id="g1145">
+					<g
+   id="g1143">
+						<defs
+   id="defs1125">
+							<path
+   id="SVGID_00000025442485407522031580000013511136474749453742_"
+   d="M1523.9,1104.7c-1.3-5.5-3.3-10.8-5.8-15.9l-13,4.2         l-53.9,17.3l59.8-2l13.7-0.5C1524.4,1106.8,1524.2,1105.8,1523.9,1104.7L1523.9,1104.7z" />
+						</defs>
+						<clipPath
+   id="SVGID_00000119822009097313768620000012705009158048941448_">
+							<use
+   xlink:href="#SVGID_00000025442485407522031580000013511136474749453742_"
+   style="overflow:visible;"
+   id="use1127" />
+						</clipPath>
+						<g
+   style="clip-path:url(#SVGID_00000119822009097313768620000012705009158048941448_);"
+   clip-path="url(#SVGID_00000119822009097313768620000012705009158048941448_)"
+   id="g1141">
+							<g
+   id="g162">
+								<g
+   id="g164">
+
+										<linearGradient
+   id="path178_00000000923461309940430990000006568761399965490363_"
+   gradientUnits="userSpaceOnUse"
+   x1="-1382.14"
+   y1="1370.002"
+   x2="-1381.1"
+   y2="1370.002"
+   gradientTransform="matrix(70.2157 -12.6718 -12.6718 -70.2157 115856.125 79793.0234)">
+										<stop
+   offset="0"
+   style="stop-color:#4194D7"
+   id="stop1130" />
+										<stop
+   offset="0.33"
+   style="stop-color:#4496D8"
+   id="stop1132" />
+										<stop
+   offset="1"
+   style="stop-color:#FFFFFF"
+   id="stop1134" />
+									</linearGradient>
+									<path
+   id="path1137"
+   style="fill:url(#path178_00000000923461309940430990000006568761399965490363_);"
+   d="M1523.9,1104.7           c-1.3-5.5-3.3-10.8-5.8-15.9l-13,4.2l-53.9,17.3l59.8-2l13.7-0.5C1524.4,1106.8,1524.2,1105.7,1523.9,1104.7" />
+								</g>
+							</g>
+						</g>
+					</g>
+				</g>
+			</g>
+		</g>
+	</g>
+</g>
+<g
+   id="g1228">
+	<g
+   id="g1226">
+
+			<linearGradient
+   id="SVGID_00000119798366210899755310000004953006299790301059_"
+   gradientUnits="userSpaceOnUse"
+   x1="668.78"
+   y1="-5275.8643"
+   x2="814.5645"
+   y2="-5275.8643"
+   gradientTransform="matrix(1 0 0 1 -378.48 6397.6089)">
+			<stop
+   offset="0"
+   style="stop-color:#2A59A2"
+   id="stop1154" />
+			<stop
+   offset="1"
+   style="stop-color:#2A59A2"
+   id="stop1156" />
+		</linearGradient>
+		<path
+   style="fill:url(#SVGID_00000119798366210899755310000004953006299790301059_);"
+   d="M435.3,1112.9h-2.6    c-4.7-0.1-13.8,0.4-22,7.6c-19.6,17-24.1,42.1-57.8,55.6c-28,11.3-62.6,0.6-62.6,0.6s30.8-2.1,34.9-25.7c3.2-18.4-13.5-31.4-24-48    c-10.7-16.9-13.4-30.9-8.3-37c14.6-17.2,54.8,29.3,74.7,35.6c19.5,6.1,32.7-8.1,48.9-6c5.2,0.7,7.7,2.9,9.3,5.7    c0.5,1,2,4.2,3.2,5.4c1.2,1.2,2.8,2,4.3,2.9C435.3,1110.8,437.2,1112.9,435.3,1112.9L435.3,1112.9z"
+   id="path1159" />
+
+			<linearGradient
+   id="SVGID_00000088814885656828779990000001158491541440105629_"
+   gradientUnits="userSpaceOnUse"
+   x1="662.95"
+   y1="-5300.7344"
+   x2="817.09"
+   y2="-5300.7344"
+   gradientTransform="matrix(1 0 0 1 -378.48 6397.6089)">
+			<stop
+   offset="0"
+   style="stop-color:#91D3F2"
+   id="stop1161" />
+			<stop
+   offset="0.27"
+   style="stop-color:#6FB2DE"
+   id="stop1163" />
+			<stop
+   offset="0.52"
+   style="stop-color:#5598CE"
+   id="stop1165" />
+			<stop
+   offset="0.67"
+   style="stop-color:#4B8FC8"
+   id="stop1167" />
+		</linearGradient>
+		<path
+   style="fill:url(#SVGID_00000088814885656828779990000001158491541440105629_);"
+   d="M343,1086c-4.8-3.7-9.8-7.5-14.7-11    c-1.1-0.8-2.2-1.6-3.3-2.3c-13.1-9-25.3-14.6-32-6.7c-5.1,6.1-2.4,20.1,8.3,37c0.1,0.2,0.2,0.3,0.3,0.5c5.6,8.6,21.7,28.8,60,28    c2.5-2.7,6.3-7.7,11.3-13.2C364.8,1105.3,352.7,1094,343,1086L343,1086L343,1086z"
+   id="path1170" />
+
+			<linearGradient
+   id="SVGID_00000121994742269144180110000017276817011946744243_"
+   gradientUnits="userSpaceOnUse"
+   x1="668.88"
+   y1="-5241.9678"
+   x2="815.67"
+   y2="-5241.9678"
+   gradientTransform="matrix(1 0 0 1 -378.48 6397.6089)">
+			<stop
+   offset="0"
+   style="stop-color:#2C9EC7"
+   id="stop1172" />
+			<stop
+   offset="0.4"
+   style="stop-color:#2C63A5"
+   id="stop1174" />
+			<stop
+   offset="1"
+   style="stop-color:#395DA1"
+   id="stop1176" />
+		</linearGradient>
+		<path
+   style="fill:url(#SVGID_00000121994742269144180110000017276817011946744243_);"
+   d="M381.6,1146.9c0.1-5.8-0.9-11.4-2.9-16.9    c-5,0.8-10.7,1.3-17.1,1.4c-4.7,5-15.4,18.3-33.1,30.3c-23.6,16-38.1,15-38.1,15s34.5,10.7,62.5-0.6c10-4,17.5-9.1,23.5-14.7    C377.4,1160.4,381.4,1155.5,381.6,1146.9L381.6,1146.9L381.6,1146.9z"
+   id="path1179" />
+
+			<linearGradient
+   id="SVGID_00000098907531341648511230000010665178158809117594_"
+   gradientUnits="userSpaceOnUse"
+   x1="668.85"
+   y1="-5272.8091"
+   x2="815.64"
+   y2="-5272.8091"
+   gradientTransform="matrix(1 0 0 1 -378.48 6397.6089)">
+			<stop
+   offset="0"
+   style="stop-color:#4FAAC4"
+   id="stop1181" />
+			<stop
+   offset="0"
+   style="stop-color:#2F75B1"
+   id="stop1183" />
+			<stop
+   offset="1"
+   style="stop-color:#356EAC"
+   id="stop1185" />
+		</linearGradient>
+		<path
+   style="fill:url(#SVGID_00000098907531341648511230000010665178158809117594_);"
+   d="M372.9,1118.2    c-4.9,5.5-8.8,10.6-11.3,13.2c6.5-0.1,12.1-0.7,17.1-1.4c-0.6-1.6-1.3-3.2-2-4.8C375.5,1122.8,374.3,1120.5,372.9,1118.2    L372.9,1118.2z"
+   id="path1188" />
+
+			<linearGradient
+   id="SVGID_00000020362440269823779060000011663757752894870144_"
+   gradientUnits="userSpaceOnUse"
+   x1="721.48"
+   y1="-5295.5088"
+   x2="816.5"
+   y2="-5295.5088"
+   gradientTransform="matrix(1 0 0 1 -378.48 6397.6089)">
+			<stop
+   offset="0"
+   style="stop-color:#4FAAC4"
+   id="stop1190" />
+			<stop
+   offset="0"
+   style="stop-color:#2F81B6"
+   id="stop1192" />
+			<stop
+   offset="1"
+   style="stop-color:#3B5EA9"
+   id="stop1194" />
+		</linearGradient>
+		<path
+   style="fill:url(#SVGID_00000020362440269823779060000011663757752894870144_);"
+   d="M401.6,1097.4    c-10.3,3.1-20.6,8.4-33.9,4.2c-6.6-2.1-15.3-8.5-24.6-15.6c9.8,8,21.9,19.2,29.9,32.2C380.2,1110.1,390,1101.1,401.6,1097.4    L401.6,1097.4z"
+   id="path1197" />
+
+			<linearGradient
+   id="SVGID_00000157990824233147759680000011448003325793772448_"
+   gradientUnits="userSpaceOnUse"
+   x1="721.46"
+   y1="-5259.1089"
+   x2="816.48"
+   y2="-5259.1089"
+   gradientTransform="matrix(1 0 0 1 -378.48 6397.6089)">
+			<stop
+   offset="0"
+   style="stop-color:#4FAAC4"
+   id="stop1199" />
+			<stop
+   offset="0"
+   style="stop-color:#1E3773"
+   id="stop1201" />
+			<stop
+   offset="1"
+   style="stop-color:#203370"
+   id="stop1203" />
+		</linearGradient>
+		<path
+   style="fill:url(#SVGID_00000157990824233147759680000011448003325793772448_);"
+   d="M378.7,1130c2,5.5,3,11.1,2.9,16.9    c-0.2,8.6-4.2,13.5-5.2,14.5c14.1-13.1,20.5-29,34.2-40.9c2.5-2.2,5.2-3.8,7.8-4.9C409.4,1119.4,399.6,1126.9,378.7,1130    L378.7,1130z"
+   id="path1206" />
+
+			<linearGradient
+   id="SVGID_00000169533450373387631460000003169798735553612417_"
+   gradientUnits="userSpaceOnUse"
+   x1="783.0235"
+   y1="-5251.1787"
+   x2="783.0235"
+   y2="-5303.2788"
+   gradientTransform="matrix(1 0 0 1 -378.48 6397.6089)">
+			<stop
+   offset="0"
+   style="stop-color:#4FAAC4"
+   id="stop1208" />
+			<stop
+   offset="0"
+   style="stop-color:#2C5A9A"
+   id="stop1210" />
+			<stop
+   offset="1"
+   style="stop-color:#374580"
+   id="stop1212" />
+		</linearGradient>
+		<path
+   style="fill:url(#SVGID_00000169533450373387631460000003169798735553612417_);"
+   d="M435.3,1112.9c1.9,0,0-2.2-1.9-3.3    c-1.5-0.9-3.1-1.8-4.3-2.9c-1.2-1.2-2.6-4.4-3.2-5.4c-1.7-2.9-4.2-5.1-9.3-5.7c-5.2-0.7-10.1,0.3-14.9,1.8    c-11.6,3.7-21.4,12.7-28.7,20.8c1.4,2.3,2.7,4.6,3.8,7c0.8,1.6,1.5,3.2,2,4.8c20.9-3.2,30.7-10.7,39.8-14.4    c5.7-2.5,11-2.7,14.3-2.7L435.3,1112.9L435.3,1112.9z"
+   id="path1215" />
+
+			<linearGradient
+   id="SVGID_00000150824696353328379200000015178783289231347082_"
+   gradientUnits="userSpaceOnUse"
+   x1="653"
+   y1="-5257.5029"
+   x2="761.13"
+   y2="-5257.5029"
+   gradientTransform="matrix(1 0 0 1 -378.48 6397.6089)">
+			<stop
+   offset="0.11"
+   style="stop-color:#38B1DA"
+   id="stop1217" />
+			<stop
+   offset="1"
+   style="stop-color:#326FB5"
+   id="stop1219" />
+		</linearGradient>
+		<path
+   style="fill:url(#SVGID_00000150824696353328379200000015178783289231347082_);"
+   d="M328.5,1161.7    c17.7-12,28.4-25.3,33.1-30.3c-38.3,0.9-54.5-19.3-60-27.9c10.5,16.3,26.9,29.3,23.7,47.5c-4.1,23.5-34.9,25.7-34.9,25.7    S304.8,1177.7,328.5,1161.7L328.5,1161.7L328.5,1161.7z"
+   id="path1222" />
+		<path
+   id="ellipse1224"
+   class="st3"
+   style="fill:#ffffff"
+   d="m 418.49999,1104.3 a 3.0999999,3 0 0 1 -3.1,3 3.0999999,3 0 0 1 -3.1,-3 3.0999999,3 0 0 1 3.1,-3 3.0999999,3 0 0 1 3.1,3 z" />
+	</g>
+</g>
+<g
+   id="g1238">
+	<g
+   id="g1236">
+		<path
+   class="st9"
+   d="M828.4,511.1c-1.2,0-2.4,0.1-3.5,0.3c-1.1,0.1-2.2,0.5-3.2,1c-0.9,0.4-1.7,1.1-2.3,2c-0.6,1-0.9,2.1-0.9,3.2    c0,0.8,0.1,1.7,0.3,2.5c0.3,1.1,1,2.1,2,2.7c1.6,1,3.7,1.5,6.4,1.5c3.3,0,5.8-0.2,7.4-0.5v-11.7c-0.8-0.2-1.7-0.4-2.5-0.5    C830.9,511.2,829.7,511.1,828.4,511.1L828.4,511.1L828.4,511.1z"
+   id="path1230" />
+		<path
+   class="st66"
+   d="M897.4,430.7c-10.7,10.7-21.5,21.4-32.2,32.1l-50.5,50.5l-0.1-0.1c-2.9,2.9-5.8,5.8-8.5,8.8    c-1.5,1.6-2,3.6-0.3,5.4c1.8,1.9,3.9,1.8,5.9,0.3c1.5-1.1,2.7-2.4,4-3.7c27.3-27.3,54.5-54.5,81.8-81.9l16.6-2.9    C911.2,436.5,900,428.2,897.4,430.7L897.4,430.7L897.4,430.7z"
+   id="path1232" />
+		<path
+   class="st66"
+   d="M905.3,455.1c0-1.6-1-3-2.5-3.4c-2.6-1-4.5,0.6-6.2,2.3c-22.2,22.2-44.4,44.4-66.6,66.6c-2,2-4,4.3-1.6,6.9    c2.7,2.9,5.2,0.8,7.2-1.3c22.4-22.4,44.9-44.8,67.3-67.3C904.1,457.8,905.2,456.7,905.3,455.1L905.3,455.1L905.3,455.1z     M860.9,452.4l4.7-4.7c-0.4-1.2-1.3-2.3-2.3-3.3c-21.3-21.4-42.7-42.7-64.1-64c-1.2-1.2-2.5-2.3-4.3-2.2c-1.5,0.1-2.6,0.7-3.2,2.1    c-1,2.4,0.3,4.2,1.9,5.8c21.3,21.4,42.7,42.7,64,64.1C858.6,451.1,859.8,452,860.9,452.4L860.9,452.4z M902.9,482    c2-2,3.7-4.4,1.1-6.9c-2.4-2.3-4.7-0.7-6.6,1.2c-8.5,8.5-17,17-25.5,25.5c-3,3-2.8,5.7,0.1,8.6c5,4.9,10,9.9,14.9,14.9    c2.7,2.8,5.7,4.6,9.5,3.9c0.9,0.1,1.6,0.2,2.2,0.1c2.8-0.3,6.3-0.1,6.4-3.9c0.1-4-3.4-4-6.2-3.9c-2.9,0.1-5.1-1.1-7-3.2    c-3-3.2-6-6.3-9.2-9.2c-2.9-2.6-2.5-4.4,0.2-6.9C889.5,495.6,896.2,488.7,902.9,482L902.9,482L902.9,482z M845.9,461.3    c1,1,2.3,2.1,3.6,2.5l4.7-4.6c-0.6-1.7-2-2.8-3.2-4c-13.1-13.1-26.2-26.2-39.3-39.3c-2.7-2.7-5.4-5.4-8.2-8.1    c-1.6-1.5-3.6-1.9-5.3-0.2c-1.7,1.6-1.5,3.6-0.2,5.5c0.6,0.8,1.2,1.6,2,2.3C815.2,430.6,830.5,445.9,845.9,461.3L845.9,461.3    L845.9,461.3z M828.5,466.9c2.5,2.5,4.9,5,7.5,7.3c0.6,0.5,1.3,0.9,2,1.1l4.9-4.9c-0.3-1.2-1.2-2.2-2.1-3.2    c-9.9-9.9-19.8-19.8-29.7-29.7c-0.8-0.8-1.8-1.5-2.8-2c-1.6-0.7-3.3-0.6-4.6,0.9c-1.3,1.4-1.3,3.1-0.3,4.6c0.9,1.4,2,2.6,3.2,3.8    C813.8,452.2,821.1,459.6,828.5,466.9L828.5,466.9z"
+   id="path1234" />
+	</g>
+</g>
+<g
+   id="g1251">
+	<g
+   id="g1249">
+		<path
+   class="st67"
+   d="M1201.3,1131.1c-0.2,0-0.4-0.1-0.6,0c-0.3,0-0.6,0.1-0.9,0.2c-1.2,0.6-1.7,1.9-1.2,3.1l0,0l5.6,13.2    c5.3-3.3,9.4-8.3,11.5-14.1L1201.3,1131.1L1201.3,1131.1L1201.3,1131.1z M1178.8,1132.9c-0.2-1.1-1.2-1.8-2.3-1.8    c-0.2,0-0.3,0-0.5,0l0,0l-14.3,2.4c2.2,5.8,6.2,10.7,11.5,14l5.5-13v-0.1C1178.9,1133.9,1179,1133.4,1178.8,1132.9L1178.8,1132.9    L1178.8,1132.9z M1190.8,1138c-0.6-1.2-2.1-1.6-3.3-1c-0.4,0.2-0.8,0.6-1,1l0,0l-7,12.4c5,1.7,10.4,1.9,15.6,0.8    c1-0.2,1.9-0.5,2.8-0.8L1190.8,1138L1190.8,1138L1190.8,1138z M1213,1109.3l-10.8,9.4l0,0c-1,0.9-1.1,2.4-0.2,3.4    c0.3,0.3,0.7,0.6,1.2,0.7v0.1l14,3.9C1217.8,1120.7,1216.3,1114.6,1213,1109.3L1213,1109.3L1213,1109.3z M1193,1110.4    c0.1,1.3,1.2,2.3,2.6,2.3c0.5,0,0.9-0.2,1.3-0.4l0,0l11.8-8.2c-4.5-4.3-10.3-7-16.6-7.8L1193,1110.4L1193,1110.4L1193,1110.4z     M1180.4,1112.2c1.1,0.8,2.6,0.5,3.4-0.5c0.3-0.4,0.4-0.8,0.5-1.3h0.1l0.8-14.1c-1,0.1-2,0.3-2.9,0.5c-5.2,1.1-9.9,3.7-13.7,7.3    L1180.4,1112.2L1180.4,1112.2L1180.4,1112.2z M1174.1,1122.9c1.3-0.3,2.1-1.7,1.7-2.9c-0.1-0.4-0.4-0.9-0.8-1.2v-0.1l-10.9-9.5    c-3.3,5.2-4.7,11.4-4,17.6L1174.1,1122.9L1174.1,1122.9L1174.1,1122.9z M1184.7,1127.1l4,1.9l4-1.9l1-4.2l-2.8-3.4h-4.4l-2.8,3.4    L1184.7,1127.1z"
+   id="path1240" />
+		<path
+   class="st67"
+   d="M1254.9,1135.3l-11.4-48.3c-0.6-2.5-2.4-4.7-4.8-5.8l-46.2-21.5c-2.4-1.1-5.2-1.1-7.7,0l-46.2,21.5    c-2.4,1.1-4.2,3.3-4.8,5.8l-11.4,48.3c-0.3,1.2-0.3,2.5,0,3.7c0.1,0.4,0.2,0.7,0.3,1.1c0.2,0.6,0.5,1.2,0.9,1.7    c0.2,0.2,0.3,0.5,0.5,0.7l32,38.7c0.1,0.2,0.3,0.3,0.4,0.5c0.5,0.5,1.1,1,1.7,1.4c0.8,0.5,1.6,0.8,2.5,1.1    c0.7,0.2,1.5,0.3,2.2,0.3h51.3c0.3,0,0.6,0,0.9-0.1c0.4-0.1,0.9-0.1,1.3-0.2c0.3-0.1,0.6-0.2,0.9-0.3c0.2-0.1,0.5-0.2,0.7-0.3    c0.3-0.2,0.7-0.3,1-0.5c0.8-0.5,1.5-1.1,2.1-1.8l1-1.2l31-37.6c0.6-0.7,1.1-1.5,1.4-2.4c0.1-0.4,0.2-0.7,0.3-1.1    C1255.2,1137.8,1255.2,1136.6,1254.9,1135.3L1254.9,1135.3L1254.9,1135.3z M1207,1154.1c0.1,0.4,0.3,0.7,0.5,1.1    c-0.3,0.5-0.4,1.1-0.2,1.6c0.7,1.5,1.5,2.9,2.4,4.3c0.5,0.7,1,1.4,1.5,2.2c0.1,0.2,0.3,0.5,0.4,0.7c0.8,1.3,0.4,2.9-1,3.7    s-3,0.3-3.8-0.9c-0.1-0.2-0.2-0.3-0.2-0.5c-0.1-0.2-0.2-0.5-0.3-0.7c-0.3-0.8-0.6-1.6-0.8-2.5c-0.5-1.6-1.1-3.1-1.9-4.5    c-0.3-0.4-0.8-0.8-1.4-0.8c-0.1-0.2-0.4-0.7-0.6-1c-8.2,3-17.3,3-25.5-0.1l-0.6,1.1c-0.4,0.1-0.9,0.3-1.2,0.6    c-0.9,1.5-1.7,3.1-2.1,4.8c-0.2,0.8-0.5,1.7-0.8,2.5c-0.1,0.2-0.2,0.5-0.3,0.7l0,0l0,0c-0.5,1.4-2.1,2.1-3.6,1.6    c-1.4-0.5-2.2-2.1-1.7-3.5c0.1-0.2,0.1-0.3,0.2-0.5s0.2-0.5,0.3-0.7c0.4-0.7,0.9-1.5,1.5-2.2c1-1.4,1.8-2.8,2.5-4.4    c0.1-0.5,0-1.1-0.2-1.5l0.5-1.2c-7.6-4.3-13.2-11.2-16-19.4l-1.2,0.2c-0.5-0.3-1-0.5-1.6-0.6c-1.7,0.3-3.3,0.8-4.8,1.4    c-0.8,0.3-1.6,0.7-2.5,0.9c-0.2,0.1-0.5,0.1-0.7,0.2c0,0,0,0-0.1,0l0,0c-1.5,0.5-3-0.3-3.5-1.7c-0.5-1.4,0.3-2.9,1.8-3.4    c0.2-0.1,0.3-0.1,0.5-0.1l0,0l0,0c0.2-0.1,0.5-0.1,0.7-0.2c0.9-0.1,1.8-0.2,2.7-0.2c1.7-0.1,3.3-0.4,5-0.8    c0.5-0.3,0.9-0.7,1.2-1.2l1.2-0.3c-1.3-8.5,0.8-17.2,5.7-24.3l-0.9-0.8c0-0.6-0.2-1.1-0.6-1.6c-1.3-1.1-2.7-2-4.1-2.8    c-0.8-0.4-1.6-0.8-2.3-1.3c-0.2-0.1-0.4-0.3-0.6-0.4l0,0c-1.3-0.9-1.6-2.7-0.7-4c0.5-0.6,1.4-1,2.2-0.9c0.7,0,1.4,0.3,1.9,0.7    c0.2,0.1,0.4,0.3,0.6,0.5c0.6,0.6,1.2,1.2,1.8,1.9c1.1,1.2,2.4,2.3,3.7,3.3c0.5,0.3,1.1,0.3,1.6,0.2c0.3,0.2,0.7,0.5,1,0.7    c4.9-5,11.2-8.5,18.1-10.1c1.7-0.4,3.3-0.6,5-0.8l0.1-1.1c0.4-0.4,0.7-0.9,0.9-1.4c0.1-1.6,0-3.3-0.3-4.9    c-0.2-0.8-0.3-1.7-0.4-2.6c0-0.2,0-0.5,0-0.7v-0.1c-0.2-1.5,1-2.8,2.5-3s2.9,0.9,3.1,2.4c0,0.2,0,0.4,0,0.5c0,0.2,0,0.6,0,0.8    c-0.1,0.9-0.2,1.7-0.4,2.6c-0.3,1.6-0.4,3.2-0.3,4.9c0.1,0.6,0.4,1,0.9,1.3c0,0.2,0,0.8,0.1,1.2c8.8,0.8,16.9,4.6,23,10.8l1.1-0.7    c0.6,0.1,1.2,0,1.7-0.2c1.3-1,2.6-2.1,3.7-3.3c0.6-0.7,1.2-1.3,1.8-1.9c0.2-0.1,0.4-0.3,0.6-0.5c1.1-1.1,2.9-1,3.9,0    c1.1,1.1,1.1,2.8,0,3.8c-0.1,0.1-0.3,0.2-0.5,0.4c-0.2,0.2-0.4,0.3-0.6,0.5c-0.7,0.5-1.5,0.9-2.3,1.3c-1.5,0.8-2.8,1.8-4.1,2.8    c-0.4,0.4-0.6,1-0.5,1.5c-0.2,0.1-0.7,0.6-1,0.9c4.9,7.1,7,15.8,5.8,24.2l1.1,0.3c0.3,0.5,0.7,0.9,1.2,1.2c1.6,0.4,3.3,0.7,5,0.8    c0.9,0,1.8,0.1,2.7,0.2c0.2,0,0.6,0.1,0.8,0.2c1.5,0.2,2.6,1.6,2.4,3s-1.6,2.5-3.1,2.3c-0.2,0-0.3-0.1-0.5-0.1l0,0c0,0,0,0-0.1,0    c-0.2-0.1-0.5-0.1-0.7-0.2c-0.8-0.3-1.7-0.6-2.5-0.9c-1.6-0.6-3.2-1.1-4.8-1.4c-0.6,0-1.1,0.2-1.6,0.6c-0.4-0.1-0.8-0.1-1.2-0.2    C1220.2,1142.9,1214.5,1149.8,1207,1154.1L1207,1154.1L1207,1154.1z"
+   id="path1242" />
+		<path
+   class="st3"
+   d="M1261,1136.6l-12.5-52.7c-0.7-2.8-2.6-5.1-5.2-6.3l-50.4-23.4c-2.7-1.2-5.7-1.2-8.4,0l-50.4,23.5    c-2.6,1.2-4.5,3.6-5.2,6.3l-12.4,52.7c-0.6,2.4-0.1,5,1.3,7.1c0.2,0.3,0.3,0.5,0.6,0.7l34.9,42.3c1.8,2.2,4.6,3.5,7.5,3.5h56    c2.9,0,5.7-1.3,7.5-3.5l34.9-42.3C1260.9,1142.2,1261.6,1139.3,1261,1136.6L1261,1136.6L1261,1136.6z M1254.9,1139    c-0.1,0.4-0.2,0.7-0.3,1.1c-0.3,0.9-0.8,1.7-1.4,2.4l-31,37.6l-1,1.2c-0.6,0.7-1.3,1.3-2.1,1.8c-0.3,0.2-0.6,0.4-1,0.5    c-0.2,0.1-0.4,0.2-0.7,0.3c-0.3,0.1-0.6,0.2-0.9,0.3c-0.4,0.1-0.9,0.2-1.3,0.2c-0.3,0-0.6,0.1-0.9,0.1h-50.8h-0.5    c-0.8,0-1.5-0.1-2.2-0.3c-0.9-0.2-1.8-0.6-2.5-1.1c-0.6-0.4-1.2-0.8-1.7-1.4c-0.2-0.2-0.3-0.3-0.4-0.5l-32-38.7    c-0.2-0.2-0.3-0.4-0.5-0.7c-0.4-0.5-0.7-1.1-0.9-1.7c-0.1-0.4-0.2-0.7-0.3-1.1c-0.3-1.2-0.3-2.5,0-3.7l11.4-48.3    c0.6-2.5,2.4-4.7,4.8-5.8l46.2-21.5c2.4-1.1,5.2-1.1,7.7,0l46.2,21.5c2.4,1.1,4.2,3.3,4.8,5.8l11.4,48.3    C1255.2,1136.6,1255.2,1137.8,1254.9,1139L1254.9,1139L1254.9,1139z"
+   id="path1245" />
+		<path
+   class="st3"
+   d="M1235,1131.5c-0.2-0.1-0.6-0.1-0.8-0.2c-0.9-0.1-1.8-0.2-2.7-0.2c-1.7-0.1-3.3-0.4-5-0.8    c-0.5-0.3-0.9-0.7-1.2-1.2l-1.1-0.3c1.2-8.5-0.9-17.1-5.8-24.2c0.3-0.2,0.8-0.7,1-0.9c0-0.6,0.2-1.1,0.5-1.5    c1.3-1.1,2.7-2,4.1-2.8c0.8-0.4,1.6-0.8,2.3-1.3c0.2-0.1,0.4-0.3,0.6-0.5c1.3-0.8,1.7-2.5,0.8-3.7c-0.8-1.3-2.6-1.6-3.8-0.8    c-0.2,0.1-0.3,0.2-0.5,0.3c-0.2,0.1-0.4,0.3-0.6,0.5c-0.7,0.6-1.3,1.2-1.8,1.9c-1.1,1.2-2.4,2.3-3.7,3.3c-0.5,0.2-1.1,0.3-1.7,0.2    l-1.1,0.7c-6.1-6.2-14.2-10-23-10.8c0-0.4-0.1-1-0.1-1.2c-0.5-0.3-0.8-0.8-0.9-1.3c-0.1-1.6,0.1-3.3,0.3-4.9    c0.2-0.8,0.3-1.7,0.4-2.6c0-0.2,0-0.5,0-0.8c0.2-1.5-1-2.8-2.5-3s-2.9,0.9-3.1,2.4c0,0.2,0,0.4,0,0.5v0.1c0,0.2,0,0.5,0,0.7    c0.1,0.9,0.2,1.7,0.4,2.6c0.3,1.6,0.4,3.2,0.3,4.9c-0.2,0.5-0.5,1-0.9,1.4l-0.1,1.1c-1.7,0.1-3.4,0.4-5,0.8    c-6.9,1.5-13.2,5-18.1,10.1c-0.3-0.2-0.7-0.5-1-0.7c-0.6,0.2-1.1,0.1-1.6-0.2c-1.3-1-2.6-2.1-3.7-3.3c-0.6-0.7-1.2-1.3-1.8-1.9    c-0.2-0.1-0.4-0.3-0.6-0.5c-0.6-0.4-1.2-0.7-1.9-0.7c-0.8,0-1.7,0.3-2.2,0.9c-0.9,1.3-0.6,3.1,0.7,4l0,0c0.2,0.1,0.4,0.3,0.6,0.4    c0.7,0.5,1.5,0.9,2.3,1.3c1.5,0.8,2.8,1.8,4.1,2.8c0.3,0.5,0.5,1,0.6,1.6l0.9,0.8c-4.9,7.2-6.9,15.8-5.7,24.3l-1.2,0.3    c-0.3,0.5-0.7,0.9-1.2,1.2c-1.6,0.4-3.3,0.7-5,0.8c-0.9,0-1.8,0.1-2.7,0.2c-0.2,0-0.5,0.1-0.7,0.2l0,0l0,0c-1.5,0.2-2.6,1.6-2.4,3    s1.6,2.5,3.1,2.3c0.2,0,0.3-0.1,0.5-0.1l0,0c0,0,0,0,0.1,0c0.2-0.1,0.5-0.1,0.7-0.2c0.8-0.3,1.7-0.6,2.5-0.9    c1.6-0.6,3.2-1.1,4.8-1.4c0.6,0,1.1,0.2,1.6,0.6l1.2-0.2c2.7,8.2,8.4,15.1,16,19.4l-0.5,1.2c0.2,0.5,0.3,1,0.2,1.5    c-0.7,1.5-1.5,3-2.5,4.4c-0.5,0.7-1,1.4-1.5,2.2c-0.1,0.2-0.2,0.5-0.4,0.7c-0.8,1.3-0.4,2.9,0.9,3.7c1.3,0.8,3,0.3,3.8-0.9    c0.1-0.2,0.2-0.3,0.2-0.5l0,0c0.1-0.2,0.2-0.5,0.3-0.7c0.3-0.8,0.6-1.6,0.8-2.5c0.5-1.7,1.2-3.3,2.1-4.8c0.3-0.3,0.8-0.5,1.2-0.6    l0.6-1.1c8.2,3.1,17.3,3.1,25.5,0.1c0.2,0.3,0.5,0.9,0.6,1c0.6,0.1,1.1,0.4,1.4,0.8c0.8,1.4,1.4,3,1.9,4.5    c0.2,0.8,0.5,1.7,0.8,2.5c0.1,0.2,0.2,0.5,0.3,0.7c0.5,1.4,2.1,2.1,3.6,1.6s2.2-2.1,1.7-3.5c-0.1-0.2-0.1-0.3-0.2-0.5    s-0.2-0.5-0.4-0.7c-0.4-0.7-0.9-1.5-1.5-2.2c-1-1.3-1.8-2.8-2.4-4.3c-0.2-0.5-0.1-1.1,0.2-1.6c-0.2-0.3-0.3-0.7-0.5-1.1    c7.6-4.4,13.3-11.3,15.9-19.5c0.4,0.1,1,0.2,1.2,0.2c0.4-0.4,1-0.6,1.6-0.6c1.7,0.3,3.3,0.8,4.8,1.4c0.8,0.4,1.6,0.7,2.5,0.9    c0.2,0.1,0.5,0.1,0.7,0.2c0,0,0,0,0.1,0l0,0c1.5,0.5,3-0.3,3.5-1.7C1237.2,1133.4,1236.4,1131.9,1235,1131.5    C1235.4,1131.5,1235.2,1131.4,1235,1131.5L1235,1131.5L1235,1131.5z M1208.7,1104l-11.8,8.2l0,0c-1.1,0.8-2.6,0.5-3.4-0.5    c-0.3-0.4-0.4-0.8-0.5-1.3l0,0l-0.8-14.1C1198.4,1097,1204.2,1099.7,1208.7,1104L1208.7,1104L1208.7,1104z M1186.4,1119.5h4.4    l2.8,3.4l-1,4.2l-4,1.9l-4-1.9l-1-4.2L1186.4,1119.5z M1182.2,1096.8c1-0.2,2-0.4,2.9-0.5l-0.8,14.1h-0.1    c-0.1,1.3-1.2,2.3-2.5,2.3c-0.5,0-0.9-0.2-1.3-0.4l0,0l-11.9-8.2C1172.3,1100.4,1177.1,1097.9,1182.2,1096.8L1182.2,1096.8z     M1164.2,1109.3l10.9,9.5v0.1c1,0.9,1.1,2.4,0.2,3.3c-0.3,0.3-0.7,0.6-1.2,0.7v0.1l-13.9,3.9    C1159.5,1120.7,1160.9,1114.6,1164.2,1109.3L1164.2,1109.3L1164.2,1109.3z M1178.7,1134.5l-5.5,13c-5.3-3.3-9.4-8.2-11.5-14    l14.3-2.4l0,0c0.2,0,0.3,0,0.5,0c1.3,0,2.4,1.1,2.4,2.4C1178.9,1133.8,1178.8,1134.1,1178.7,1134.5L1178.7,1134.5L1178.7,1134.5z     M1195.1,1151.2c-5.2,1.2-10.6,0.9-15.6-0.8l7-12.4l0,0c0.6-1.2,2.1-1.6,3.3-1c0.4,0.2,0.8,0.6,1,1h0.1l7,12.4    C1197,1150.7,1196,1151,1195.1,1151.2L1195.1,1151.2L1195.1,1151.2z M1204.1,1147.5l-5.6-13.2l0,0c-0.5-1.2,0-2.5,1.2-3.1    c0.3-0.1,0.6-0.2,0.9-0.2c0.2,0,0.4,0,0.6,0l0,0l14.4,2.4C1213.6,1139.2,1209.5,1144.2,1204.1,1147.5L1204.1,1147.5L1204.1,1147.5    z M1217.2,1126.8l-14-3.9v-0.1c-1.3-0.3-2.1-1.7-1.7-2.9c0.1-0.4,0.4-0.8,0.8-1.2l0,0l10.8-9.4    C1216.3,1114.5,1217.8,1120.7,1217.2,1126.8L1217.2,1126.8L1217.2,1126.8z"
+   id="path1247" />
+	</g>
+</g>
+<g
+   id="g1267">
+	<g
+   id="g1265">
+		<path
+   class="st67"
+   d="M1076.5,464.1c-0.2,0-0.3,0-0.5,0l0,0l-15.4,2.6c2.3,6.4,6.7,11.9,12.4,15.5l6-14.4v-0.1    c0.1-0.3,0.2-0.6,0.2-1C1079.1,465.3,1078,464.1,1076.5,464.1L1076.5,464.1L1076.5,464.1z"
+   id="path1253" />
+		<path
+   class="st67"
+   d="M1073.9,455c0.5-0.1,0.9-0.4,1.3-0.8c0.9-1.1,0.8-2.8-0.3-3.7v-0.1l-11.7-10.5l0,0    c-3.6,5.8-5.1,12.7-4.4,19.5L1073.9,455L1073.9,455L1073.9,455z"
+   id="path1255" />
+		<path
+   id="polygon1257"
+   class="st67"
+   style="fill:#326ce5"
+   d="m 1089.7,461.7 4.3,-2.1 1,-4.6 -2.9,-3.8 h -4.9 l -2.9,3.7 1,4.7 z" />
+		<path
+   class="st67"
+   d="M1161.7,469L1161.7,469l-12.5-54.1c-0.7-2.8-2.6-5.2-5.2-6.5l-50.4-24.1c-2.7-1.3-5.7-1.3-8.4,0l-50.4,24.1    c-2.6,1.3-4.5,3.6-5.2,6.5l-12.4,54.1c-0.3,1.4-0.3,2.8,0,4.2c0.1,0.4,0.2,0.8,0.3,1.2c0.2,0.7,0.6,1.3,1,2    c0.2,0.3,0.3,0.5,0.5,0.8l34.9,43.4c0.2,0.2,0.3,0.4,0.5,0.5c0.6,0.6,1.2,1.1,1.8,1.5c0.8,0.5,1.8,0.9,2.8,1.2    c0.8,0.2,1.6,0.3,2.4,0.3h56c0.3,0,0.7,0,1-0.1c0.5,0,1-0.1,1.4-0.3c0.3-0.1,0.7-0.2,1-0.3c0.2-0.1,0.5-0.2,0.8-0.3    c0.4-0.2,0.7-0.4,1.1-0.6c0.9-0.5,1.7-1.2,2.3-2l1.1-1.3l33.8-42.1c0.7-0.8,1.2-1.7,1.5-2.7c0.2-0.4,0.3-0.8,0.4-1.2    C1162.1,471.8,1162.1,470.4,1161.7,469L1161.7,469L1161.7,469z M1142.1,468.4c-0.5,1.6-2.2,2.4-3.8,1.9l0,0c0,0,0,0-0.1,0    c-0.2,0-0.6-0.1-0.8-0.2c-0.9-0.3-1.8-0.6-2.7-1c-1.7-0.7-3.4-1.2-5.2-1.5c-0.6,0-1.2,0.2-1.7,0.6c-0.2,0-0.9-0.2-1.3-0.2    c-2.9,9.1-9,16.8-17.2,21.6c0.1,0.4,0.3,0.8,0.5,1.2c-0.3,0.5-0.4,1.2-0.2,1.8c0.7,1.7,1.6,3.2,2.7,4.7c0.6,0.8,1.1,1.6,1.6,2.4    c0.1,0.2,0.3,0.6,0.4,0.8c0.1,0.2,0.2,0.3,0.2,0.5c0.6,1.6-0.2,3.3-1.8,3.8c-1.6,0.6-3.3-0.2-3.8-1.8c-0.1-0.2-0.3-0.5-0.4-0.8    c-0.3-0.9-0.6-1.8-0.9-2.7c-0.5-1.7-1.2-3.4-2.1-5c-0.4-0.5-0.9-0.8-1.5-0.9c-0.1-0.2-0.4-0.8-0.6-1.1c-8.9,3.4-18.7,3.3-27.5-0.1    l-0.7,1.2c-0.5,0.1-0.9,0.3-1.3,0.6c-1,1.7-1.8,3.5-2.3,5.4c-0.2,0.9-0.5,1.8-0.9,2.7c-0.1,0.2-0.3,0.5-0.4,0.8l0,0l0,0    c-0.1,0.2-0.2,0.4-0.2,0.5c-0.8,1.4-2.7,1.9-4.1,1s-1.9-2.7-1-4.1c0.1-0.2,0.3-0.6,0.4-0.8c0.5-0.8,1-1.6,1.6-2.4    c1.1-1.5,2-3.1,2.7-4.9c0.1-0.6,0-1.2-0.3-1.7l0.5-1.3c-8.2-4.8-14.3-12.5-17.2-21.5l-1.3,0.2c-0.5-0.4-1.1-0.6-1.7-0.6    c-1.8,0.3-3.5,0.9-5.2,1.5c-0.9,0.4-1.8,0.7-2.7,1c-0.2,0.1-0.5,0.1-0.8,0.2c0,0,0,0-0.1,0l0,0c-0.2,0.1-0.4,0.1-0.6,0.1    c-1.6,0.2-3.1-0.9-3.4-2.6c-0.2-1.6,0.9-3.1,2.6-3.4l0,0l0,0c0.2-0.1,0.6-0.1,0.8-0.2c0.9-0.1,1.9-0.2,2.9-0.2    c1.8-0.1,3.6-0.4,5.3-0.9c0.5-0.3,1-0.8,1.3-1.3l1.2-0.4c-1.4-9.4,0.8-19,6.1-26.9l-1-0.9c0-0.6-0.2-1.2-0.6-1.7    c-1.4-1.2-2.9-2.2-4.4-3.1c-0.8-0.4-1.7-0.9-2.5-1.5c-0.2-0.1-0.4-0.3-0.6-0.5h-0.1c-1.4-1-1.7-3-0.7-4.4c0.6-0.7,1.5-1.1,2.4-1    c0.8,0,1.5,0.3,2.1,0.8c0.2,0.2,0.5,0.4,0.7,0.5c0.7,0.7,1.3,1.4,2,2.1c1.2,1.3,2.6,2.6,4,3.6c0.6,0.3,1.2,0.4,1.8,0.2    c0.4,0.3,0.7,0.5,1.1,0.8c5.2-5.6,12-9.5,19.5-11.1c1.3-0.3,2.7-0.5,4-0.7v-12.6l23,15.8l-23,17v-12.3c-0.8,0.1-1.5,0.2-2.3,0.4    c-5.6,1.3-10.7,4-14.8,8.1l12.8,9.1l0,0c0.4,0.3,0.9,0.5,1.4,0.5c0.1,0.1,0.5,0,1-0.1h0.1c1.1-0.4,2.6-1,3.9-1.2    c4.5-0.5,6.3,0.2,8.5,1c0.1,0.1,0.2,0.1,0.4,0.1c4.5,2,6.7,6.2,7.3,8.9c0,0.3,0.1,0.6,0.2,0.9c0.1,0.9,0.1,1.5,0.1,1.5l16.7,4.5    c0.8-6.9-1.4-14.7-6.1-22l6.4-4.6c7.2,12.2,7.8,20.1,7.3,28.8l1.2,0.4c0.3,0.5,0.8,1,1.3,1.3c1.8,0.5,3.5,0.8,5.3,0.9    c1,0,1.9,0.1,2.9,0.2c0.2,0,0.6,0.1,0.9,0.2l0,0c0.2,0,0.4,0.1,0.5,0.1C1141.7,465.2,1142.6,466.9,1142.1,468.4L1142.1,468.4z"
+   id="path1259" />
+		<path
+   class="st67"
+   d="M1092,471.8c-0.2-0.5-0.6-0.8-1.1-1.1c-1.3-0.7-2.9-0.2-3.6,1.1l0,0l-7.6,13.7c5.4,1.9,11.3,2.1,16.8,0.9    l0,0c1-0.2,2.1-0.5,3-0.9L1092,471.8L1092,471.8L1092,471.8z"
+   id="path1261" />
+		<path
+   class="st67"
+   d="M1103.2,464c-0.2,0-0.4,0-0.6,0c-0.3,0-0.7,0.1-1,0.3c-1.3,0.6-1.8,2.1-1.3,3.4l0,0l6,14.6l0,0    c5.8-3.7,10.2-9.2,12.4-15.6L1103.2,464L1103.2,464L1103.2,464z"
+   id="path1263" />
+	</g>
+</g>
+<g
+   id="g1295">
+	<g
+   id="g1293">
+		<g
+   id="g1291">
+			<g
+   id="g1289">
+				<defs
+   id="defs1270">
+					<rect
+   id="SVGID_00000176000686438572105310000001367234708020135857_"
+   x="295.3"
+   y="380.6"
+   width="135.3"
+   height="149.1" />
+				</defs>
+				<clipPath
+   id="SVGID_00000150092641881346574450000006237314454458131841_">
+					<use
+   xlink:href="#SVGID_00000176000686438572105310000001367234708020135857_"
+   style="overflow:visible;"
+   id="use1272" />
+				</clipPath>
+				<g
+   style="clip-path:url(#SVGID_00000150092641881346574450000006237314454458131841_);"
+   clip-path="url(#SVGID_00000150092641881346574450000006237314454458131841_)"
+   id="g1287">
+					<g
+   id="g1285">
+						<defs
+   id="defs1276">
+							<rect
+   id="SVGID_00000077309734916802155190000008880278819887356341_"
+   x="293.9"
+   y="380.6"
+   width="135.3"
+   height="149.1" />
+						</defs>
+						<clipPath
+   id="SVGID_00000149382651996025500470000015004240877543443078_">
+							<use
+   xlink:href="#SVGID_00000077309734916802155190000008880278819887356341_"
+   style="overflow:visible;"
+   id="use1278" />
+						</clipPath>
+
+							<g
+   transform="matrix(1 0 0 1 3.051758e-05 0)"
+   style="clip-path:url(#SVGID_00000149382651996025500470000015004240877543443078_);"
+   clip-path="url(#SVGID_00000149382651996025500470000015004240877543443078_)"
+   id="g1283">
+
+								<g
+   id="use1281"
+   transform="matrix(2.34,0,0,-2.33,360.1646,455.1799)">
+	<g
+   id="g11057">
+		<path
+   class="st0"
+   d="m -17.2,32 c 0,0 -3.6,-12 -3.3,-15.6 0.2,-2.5 4.8,-5.8 4.8,-5.8 0,0 -2.5,-3 -3.5,-4.7 -1,-1.7 -2.6,-5.7 -2.6,-5.7 0,0 -7.6,9 -7,13.4 0.8,5.3 11.6,18.4 11.6,18.4 z m 34.5,0 c 0,0 3.6,-12 3.3,-15.6 -0.2,-2.5 -4.8,-5.8 -4.8,-5.8 0,0 2.5,-3 3.5,-4.7 1,-1.7 2.5,-5.7 2.5,-5.7 0,0 7.6,9 7,13.4 C 28.2,18.9 17.3,32 17.3,32 Z"
+   id="path11045" />
+		<path
+   class="st1"
+   d="m 0.2,17.9 c -10.1,0 -19.1,-7.2 -22,-17.7 L 0.2,-7 Z"
+   id="path11047" />
+		<path
+   class="st2"
+   d="m 0.2,18 c 10.1,0 19.1,-7.2 22,-17.7 L 0.2,-7 Z"
+   id="path11049" />
+		<path
+   class="st1"
+   d="m 0.2,0.3 h -22 v -15.4 c 0,0 8.9,-3.5 12.6,-6.3 3,-2.3 8.9,-10.6 8.9,-10.6 h 0.6 z"
+   id="path11051" />
+		<path
+   class="st2"
+   d="m 0.2,0.5 h 22 v -15.4 c 0,0 -8.9,-3.5 -12.6,-6.3 C 6.5,-23.6 0.7,-32 0.7,-32 H 0.2 Z"
+   id="path11053" />
+		<path
+   class="st3"
+   d="m -2.6,1 c 0,1.5 1.2,2.8 2.8,2.8 1.6,0 2.7,-1.3 2.7,-2.8 0,-1.5 -1.2,-2.8 -2.7,-2.8 -1.5,0 -2.8,1.3 -2.8,2.8 z"
+   id="path11055" />
+	</g>
+</g>
+						</g>
+					</g>
+				</g>
+			</g>
+		</g>
+	</g>
+</g>
+<g
+   id="g1301">
+	<g
+   id="g1299">
+		<path
+   class="st69"
+   d="M629.6,1380.8c39.8,0,72.4,32.2,72.3,71.4c0,39.8-32.6,71.6-73.2,71.6c-39.7,0-71.8-32.3-71.8-72.1    C557,1412.7,589.7,1380.8,629.6,1380.8L629.6,1380.8z M607.7,1405.8c0.9,4.5,0,8.6-1.3,12.7c-0.9,2.8-2.2,5.6-3,8.4    c-1.3,4.7-2.7,9.5-3.2,14.3c-0.8,7,2,13.1,6.7,19.2l-21.6-4.5c0,0.7,0,0.9,0.1,1.2c2,6,5.7,11,9.7,15.8c0.4,0.5,1.4,0.8,2.1,0.8    c21.6,0,43.2,0,64.7,0c0.7,0,1.6-0.1,2-0.6c4.6-4.8,8.2-10.3,10.4-17.3l-22.9,4.5c1.5-2.9,3.2-5.5,4.2-8.4c3.4-9.7,2-19.1-2.9-28    c-3.9-7.1-7.5-14.2-5.6-22.8c-4.1,4.1-5.7,9.2-6.7,14.5c-1,5.2-1.6,10.6-2.3,15.9c-0.1-0.2-0.2-0.3-0.3-0.4    c-0.1-0.6-0.2-1.1-0.2-1.7c-0.5-8.7-2.2-17.1-5.8-25.1c-2.1-4.7-4.5-9.5-2.3-15.2c-1.5,0.8-2.8,1.6-3.8,2.7    c-2.9,3.3-4,7.2-4.3,11.6c-0.3,3.7-0.6,7.4-1.3,11c-0.7,3.8-1.9,7.6-4.5,11.1C614.5,1418,614.4,1410.6,607.7,1405.8L607.7,1405.8    L607.7,1405.8z M663.3,1480.3h-67.7v11.7h67.7V1480.3z M609,1498c-0.1,9.7,9.9,17,22.2,16.5c10.2-0.4,19.2-8.4,18.5-16.5H609    L609,1498z"
+   id="path1297" />
+	</g>
+</g>
+<g
+   id="g1309">
+	<g
+   id="g1307">
+		<path
+   d="M1674.9,1049.2v145.1h101.2v-145.1H1674.9L1674.9,1049.2z M1759.3,1177.4h-67.5v-64.1h47.2v-23.6h20.2L1759.3,1177.4    L1759.3,1177.4L1759.3,1177.4z"
+   id="path1303" />
+		<path
+   d="M1712,1130.2h27v30.3h-27V1130.2z"
+   id="path1305" />
+	</g>
+</g>
+<g
+   id="g1336">
+	<g
+   id="g1334">
+		<g
+   id="Layer_3">
+			<path
+   class="st70"
+   d="M1429.8,167.7c1-8.4,0.7-9.6,6.9-8.2l1.6,0.1c4.8,0.2,11.1-0.8,14.8-2.5c7.9-3.7,12.7-9.8,4.8-8.2     c-17.9,3.7-19.1-2.4-19.1-2.4c18.9-28,26.8-63.5,19.9-72.2c-18.6-23.7-50.7-12.5-51.2-12.2h-0.2c-3.5-0.7-7.5-1.2-11.9-1.2     c-8.1-0.1-14.2,2.1-18.9,5.6c0,0-57.3-23.6-54.7,29.7c0.6,11.3,16.3,85.8,35,63.3c6.8-8.2,13.4-15.2,13.4-15.2     c3.3,2.2,7.2,3.3,11.3,2.9l0.3-0.3c-0.1,1-0.1,2,0.1,3.2c-4.8,5.4-3.4,6.3-13,8.3c-9.8,2-4,5.6-0.3,6.5c4.5,1.1,15,2.7,22.1-7.2     l-0.3,1.1c1.9,1.5,1.8,10.9,2,17.6c0.3,6.7,0.7,12.9,2.1,16.6c1.4,3.7,3,13.2,15.6,10.4C1420.9,201.4,1429,198.1,1429.8,167.7"
+   id="path1311" />
+			<path
+   class="st71"
+   d="M1457.9,148.9c-17.9,3.7-19.1-2.4-19.1-2.4c18.9-28,26.8-63.5,19.9-72.2c-18.6-23.7-50.7-12.5-51.2-12.2     h-0.2c-3.5-0.7-7.5-1.2-11.9-1.2c-8.1-0.1-14.2,2.1-18.9,5.6c0,0-57.3-23.6-54.7,29.7c0.6,11.3,16.3,85.8,35,63.3     c6.8-8.2,13.4-15.2,13.4-15.2c3.3,2.2,7.2,3.3,11.3,2.9l0.3-0.3c-0.1,1-0.1,2,0.1,3.2c-4.8,5.4-3.4,6.3-13,8.3     c-9.8,2-4,5.6-0.3,6.5c4.5,1.1,15,2.7,22.1-7.2l-0.3,1.1c1.9,1.5,3.2,9.8,3,17.4c-0.2,7.6-0.4,12.7,1.1,16.8s3,13.2,15.6,10.4     c10.6-2.3,16.1-8.1,16.8-18c0.5-7,1.8-5.9,1.8-12.2l1-2.9c1.1-9.4,0.2-12.5,6.7-11.1l1.6,0.1c4.8,0.2,11.1-0.8,14.8-2.5     C1461,153.4,1465.7,147.3,1457.9,148.9L1457.9,148.9L1457.9,148.9z"
+   id="path1313" />
+			<path
+   class="st72"
+   d="M1391.6,154.3c-0.5,17.6,0.1,35.3,1.8,39.6s5.4,12.7,18.1,10c10.6-2.3,14.4-6.7,16.1-16.4     c1.2-7.1,3.6-26.9,3.9-31"
+   id="path1315" />
+			<path
+   class="st72"
+   d="M1376.4,66.1c0,0-57.4-23.4-54.7,29.9c0.6,11.3,16.3,85.8,35,63.3c6.8-8.2,13-14.7,13-14.7"
+   id="path1317" />
+			<path
+   class="st72"
+   d="M1407.4,61.9c-2,0.6,31.9-12.4,51.2,12.2c6.8,8.7-1.1,44.2-19.9,72.2"
+   id="path1319" />
+			<path
+   class="st73"
+   d="M1438.7,146.3c0,0,1.2,6.1,19.1,2.4c7.8-1.6,3.1,4.5-4.8,8.2c-6.5,3-21.1,3.8-21.4-0.4     C1431,145.7,1439.3,149,1438.7,146.3c-0.5-2.4-4.2-4.8-6.7-10.8c-2.1-5.2-29.4-45.1,7.6-39.1c1.3-0.3-9.6-35.2-44.2-35.7     c-34.6-0.6-33.5,42.5-33.5,42.5"
+   id="path1321" />
+			<path
+   class="st72"
+   d="M1381.9,150c-4.8,5.4-3.4,6.3-13,8.3c-9.8,2-4,5.6-0.3,6.5c4.5,1.1,15,2.7,22.1-7.2c2.2-3,0-7.8-3-9.1     C1386.3,148,1384.4,147.2,1381.9,150L1381.9,150L1381.9,150z"
+   id="path1323" />
+			<path
+   class="st72"
+   d="M1381.6,149.9c-0.5-3.2,1-6.9,2.7-11.4c2.5-6.6,8.1-13.2,3.6-34.2c-3.4-15.6-26.1-3.2-26.1-1.1     s1,10.8-0.4,20.8c-1.8,13.1,8.3,24.2,20.1,23.1"
+   id="path1325" />
+			<path
+   class="st74"
+   d="M1376.2,102.9c-0.1,0.7,1.3,2.7,3.2,2.9c1.9,0.3,3.4-1.2,3.6-2c0.1-0.7-1.3-1.5-3.2-1.8     S1376.3,102.2,1376.2,102.9L1376.2,102.9L1376.2,102.9z"
+   id="path1327" />
+			<path
+   class="st75"
+   d="M1432.9,101.4c0.1,0.7-1.3,2.7-3.2,2.9c-1.9,0.3-3.4-1.2-3.6-2c-0.1-0.7,1.3-1.5,3.2-1.8     S1432.8,100.7,1432.9,101.4L1432.9,101.4L1432.9,101.4z"
+   id="path1329" />
+			<path
+   class="st72"
+   d="M1439.5,96.4c0.3,5.7-1.2,9.6-1.4,15.6c-0.3,8.8,4.2,18.9-2.6,28.9"
+   id="path1331" />
+		</g>
+	</g>
+</g>
+<g
+   id="g1347">
+	<g
+   id="g1345">
+
+			<linearGradient
+   id="SVGID_00000060726031986097742560000003928774270059632037_"
+   gradientUnits="userSpaceOnUse"
+   x1="734.63"
+   y1="-3731.999"
+   x2="734.63"
+   y2="-3624.709"
+   gradientTransform="matrix(1 0 0 1 -381.93 5153.1587)">
+			<stop
+   offset="0"
+   style="stop-color:#F05A28"
+   id="stop1338" />
+			<stop
+   offset="1"
+   style="stop-color:#FBCA0A"
+   id="stop1340" />
+		</linearGradient>
+		<path
+   style="fill:url(#SVGID_00000060726031986097742560000003928774270059632037_);"
+   d="M423.5,1443.2c-0.3-2.6-0.7-5.6-1.5-8.9    c-0.9-3.3-2.1-6.9-4-10.7s-4.3-7.6-7.5-11.4c-1.2-1.5-2.6-2.9-4-4.3c2.2-8.7-2.6-16.2-2.6-16.2c-8.3-0.5-13.6,2.6-15.5,4    c-0.3-0.1-0.6-0.3-1-0.4c-1.4-0.6-2.9-1.1-4.4-1.6s-3-0.9-4.6-1.3s-3.1-0.7-4.8-0.9c-0.3,0-0.5-0.1-0.9-0.1    c-3.6-11.6-14-16.4-14-16.4c-11.6,7.4-13.8,17.7-13.8,17.7s0,0.2-0.1,0.6c-0.6,0.2-1.3,0.4-1.9,0.6c-0.9,0.3-1.8,0.6-2.6,0.9    c-0.9,0.3-1.8,0.7-2.6,1.1c-1.8,0.8-3.5,1.6-5.2,2.6c-1.7,0.9-3.3,2-4.9,3l-0.4-0.2c-16.1-6.1-30.4,1.2-30.4,1.2    c-1.3,17.1,6.4,27.9,8,29.9c-0.4,1.1-0.7,2.1-1.1,3.2c-1.2,3.9-2.1,7.8-2.6,12c-0.1,0.6-0.2,1.2-0.2,1.8    c-14.9,7.4-19.3,22.4-19.3,22.4c12.4,14.3,26.9,15.2,26.9,15.2l0,0c1.8,3.3,4,6.4,6.4,9.3c1,1.2,2,2.4,3.1,3.5    c-4.5,12.9,0.6,23.7,0.6,23.7c13.8,0.5,22.9-6.1,24.8-7.5c1.4,0.5,2.8,0.9,4.2,1.2c4.3,1.1,8.6,1.8,13,1.9c1.1,0,2.2,0.1,3.2,0    h1.5h0.7l0,0c6.5,9.3,17.9,10.6,17.9,10.6c8.1-8.6,8.6-17.1,8.6-18.9l0,0v-0.4l0,0v-0.4c1.7-1.2,3.3-2.5,4.9-3.9    c3.2-2.9,6.1-6.3,8.5-9.9c0.2-0.3,0.4-0.7,0.6-1c9.2,0.5,15.7-5.7,15.7-5.7c-1.5-9.6-7-14.3-8.1-15.2l0,0c0,0,0,0-0.1-0.1    s-0.1-0.1-0.1-0.1l0,0c0,0-0.1-0.1-0.2-0.1c0-0.6,0.1-1.2,0.1-1.8c0.1-1,0.1-2.1,0.1-3.1v-1.6v-0.6v-0.8c0-0.3,0-0.6-0.1-0.8    c0-0.3,0-0.6-0.1-0.8l-0.1-0.8l-0.1-0.8c-0.2-1.1-0.3-2.1-0.6-3.2c-1-4.1-2.6-8.1-4.7-11.6s-4.8-6.7-7.8-9.3    c-3-2.6-6.4-4.8-9.8-6.3c-3.5-1.6-7.2-2.6-10.9-3.1c-1.8-0.3-3.7-0.3-5.5-0.3h-0.9c0,0-0.3,0-0.2,0h-0.3h-0.7c-0.3,0-0.5,0-0.7,0    c-0.9,0.1-1.9,0.2-2.8,0.4c-3.7,0.7-7.1,2-10.1,3.8s-5.7,4.1-7.8,6.7s-3.8,5.4-4.9,8.3s-1.8,6-2,8.9c0,0.7,0,1.5,0,2.2v0.6v0.6    c0,0.3,0,0.7,0.1,1.1c0.1,1.5,0.4,2.9,0.8,4.3c0.8,2.8,2.1,5.3,3.7,7.4s3.5,3.9,5.5,5.3s4.2,2.3,6.3,3s4.3,0.9,6.3,0.9h1.1    c0.1,0,0.3,0,0.4,0c0.2,0,0.4,0,0.6,0c0,0,0.1,0,0.2,0h0.2c0.1,0,0.3,0,0.4,0c0.3,0,0.5-0.1,0.7-0.1c0.3,0,0.5-0.1,0.7-0.2    c0.5-0.1,0.9-0.3,1.3-0.4c0.9-0.3,1.7-0.6,2.4-1c0.8-0.4,1.5-0.8,2.1-1.3c0.2-0.1,0.4-0.3,0.5-0.4c0.7-0.6,0.8-1.6,0.3-2.3    c-0.5-0.6-1.3-0.8-2-0.4c-0.2,0.1-0.3,0.2-0.5,0.3c-0.6,0.3-1.2,0.6-1.8,0.8s-1.3,0.4-2,0.5c-0.3,0-0.7,0.1-1.1,0.1    c-0.2,0-0.3,0-0.5,0h-1c-0.2,0-0.4,0-0.6,0c0,0-0.1,0,0,0h-0.2c-0.1,0-0.2,0-0.3,0c-0.2,0-0.4,0-0.6-0.1c-1.6-0.2-3.1-0.7-4.6-1.4    c-1.5-0.7-3-1.6-4.3-2.8s-2.5-2.6-3.4-4.2s-1.5-3.4-1.8-5.3c-0.1-0.9-0.2-1.9-0.2-2.8c0-0.3,0-0.5,0-0.8c0,0.1,0,0,0,0v-0.3    c0-0.1,0-0.3,0-0.4c0-0.5,0.1-1,0.2-1.5c0.7-4.1,2.8-8.1,5.9-11.1c0.8-0.8,1.7-1.4,2.6-2.1s1.9-1.2,2.9-1.7s2-0.8,3.1-1.2    c1.1-0.3,2.2-0.5,3.3-0.6c0.5,0,1.1-0.1,1.7-0.1h1.1c0.1,0,0,0,0,0h0.1h0.5c1.2,0.1,2.4,0.3,3.6,0.6c2.4,0.5,4.7,1.4,6.9,2.6    c4.4,2.4,8,6.2,10.3,10.7c1.1,2.3,2,4.7,2.3,7.2c0.1,0.6,0.2,1.3,0.2,1.9v0.5v0.5v1.8c0,0.3,0,0.8,0,1.1c0,0.7-0.1,1.4-0.2,2.1    s-0.2,1.4-0.3,2s-0.3,1.4-0.5,2c-0.3,1.3-0.8,2.6-1.3,4c-1,2.6-2.4,5-4,7.3c-3.3,4.5-7.8,8.2-12.9,10.5c-2.6,1.2-5.2,2-8,2.4    c-1.4,0.3-2.8,0.4-4.2,0.4h-2c0.2,0,0,0,0,0h-0.1c-0.8,0-1.5,0-2.3-0.1c-3-0.2-5.9-0.8-8.8-1.6c-2.9-0.8-5.6-2-8.3-3.3    c-5.2-2.8-10-6.7-13.6-11.3c-1.8-2.3-3.5-4.8-4.8-7.4s-2.4-5.4-3.1-8.1c-0.8-2.8-1.2-5.7-1.5-8.6v-0.6v-2.4l0,0v-1.3    c0-1.4,0.2-2.9,0.3-4.3s0.4-2.9,0.7-4.4c0.3-1.4,0.6-2.9,1.1-4.3c0.8-2.8,1.8-5.6,3-8.2c2.4-5.2,5.6-9.8,9.4-13.6    c0.9-0.9,1.9-1.8,2.9-2.6c1-0.8,2.1-1.6,3.2-2.3c1.1-0.7,2.2-1.4,3.4-2c0.5-0.3,1.1-0.6,1.8-0.8c0.3-0.1,0.6-0.3,0.9-0.4    s0.6-0.3,0.9-0.4c1.2-0.5,2.4-0.9,3.7-1.3c0.3-0.1,0.6-0.2,0.9-0.3c0.3-0.1,0.6-0.2,0.9-0.3c0.6-0.2,1.3-0.3,1.9-0.5    c0.3-0.1,0.6-0.1,1-0.2s0.6-0.1,1-0.2c0.3,0,0.6-0.1,1-0.2l0.5-0.1l0.5-0.1c0.3,0,0.6-0.1,1-0.1s0.7-0.1,1.1-0.1    c0.3,0,0.8-0.1,1.1-0.1c0.2,0,0.5,0,0.7-0.1h0.5h0.2h0.3c0.4,0,0.7,0,1.1-0.1h0.5c0,0,0.2,0,0,0h0.4c0.3,0,0.6,0,0.9,0    c1.2,0,2.5,0,3.8,0c2.5,0.1,4.9,0.4,7.2,0.8c4.7,0.9,9.2,2.4,13.2,4.4s7.6,4.4,10.8,7c0.2,0.2,0.4,0.3,0.6,0.5s0.4,0.3,0.5,0.5    c0.4,0.3,0.7,0.7,1.1,1s0.7,0.7,1.1,1s0.7,0.7,1,1.1c1.3,1.4,2.6,2.8,3.7,4.3c2.2,2.8,4,5.8,5.4,8.5c0.1,0.2,0.2,0.3,0.3,0.5    s0.2,0.3,0.3,0.5c0.2,0.3,0.3,0.7,0.5,1s0.3,0.6,0.5,1c0.1,0.3,0.3,0.6,0.4,1c0.5,1.3,1,2.5,1.4,3.7c0.6,1.9,1.1,3.5,1.5,5    c0.1,0.6,0.7,1,1.3,0.9c0.6,0,1.1-0.6,1.1-1.2C423.7,1447.1,423.7,1445.2,423.5,1443.2L423.5,1443.2z"
+   id="path1343" />
+	</g>
+</g>
+<g
+   id="g1644">
+
+		<linearGradient
+   id="SVGID_00000006678328463744774800000011545963384901783707_"
+   gradientUnits="userSpaceOnUse"
+   x1="1452.4"
+   y1="6785.9014"
+   x2="1452.4"
+   y2="6923.481"
+   gradientTransform="matrix(1 0 0 1 0 -6074.791)">
+		<stop
+   offset="0"
+   style="stop-color:#FFFFFF"
+   id="stop1349" />
+		<stop
+   offset="1"
+   style="stop-color:#00549E"
+   id="stop1351" />
+	</linearGradient>
+	<path
+   style="fill:url(#SVGID_00000006678328463744774800000011545963384901783707_);"
+   d="M1452.4,852.6c36.6,0,66.2-29.9,66.2-66.8   s-29.7-66.8-66.2-66.8s-66.2,29.9-66.2,66.8S1415.8,852.6,1452.4,852.6z"
+   id="path1354" />
+	<path
+   class="st78"
+   d="M1452.4,854.2c-13.4,0-26.5-4-37.7-11.5s-19.8-18.2-25-30.7s-6.5-26.3-3.9-39.5c2.6-13.3,9.1-25.5,18.6-35   c9.5-9.6,21.6-16.1,34.7-18.7c13.2-2.6,26.8-1.3,39.2,3.9c12.4,5.2,23,14,30.4,25.2s11.4,24.5,11.4,38c0,18.1-7.2,35.5-19.9,48.3   C1487.6,847,1470.4,854.2,1452.4,854.2L1452.4,854.2z M1452.4,720.5c-12.8,0-25.3,3.8-35.9,11s-18.9,17.4-23.8,29.3   c-4.9,11.9-6.2,25-3.7,37.7s8.7,24.3,17.7,33.4c9,9.1,20.6,15.3,33.1,17.9c12.5,2.5,25.6,1.2,37.4-3.7s21.9-13.3,29-24   s10.9-23.3,10.9-36.2c0-17.3-6.8-33.9-19-46.1C1486,727.4,1469.6,720.5,1452.4,720.5L1452.4,720.5z"
+   id="path1356" />
+	<path
+   class="st79"
+   d="M1484.3,828.8c-2.9,4.7-16,8.2-31.7,8.2s-28.8-3.5-31.7-8.2c-3.8,1.5-5.9,3.2-5.9,5.1   c0,5.2,16.8,9.4,37.6,9.4s37.6-4.2,37.6-9.4C1490.2,832,1488,830.3,1484.3,828.8L1484.3,828.8z"
+   id="path1358" />
+	<path
+   class="st80"
+   d="M1452.6,837c15.7,0,28.8-3.5,31.7-8.2c-6.7-2.6-18.4-4.3-31.7-4.3s-25,1.7-31.7,4.3   C1423.9,833.5,1437,837,1452.6,837z"
+   id="path1360" />
+	<path
+   class="st81"
+   d="M1479.3,804.9c2.1-2,4.4-3.8,6.9-5.5c11-7.5,8-19.3,5.3-28.9c-1.9-6.8,7.2-8.7,10.7,11.1   c3.5,19.4-17.8,34.7-23.6,34.7"
+   id="path1362" />
+	<path
+   class="st78"
+   d="M1478.6,817.3c-0.3,0-0.5-0.1-0.7-0.3s-0.3-0.4-0.3-0.7s0.1-0.5,0.3-0.7c0.2-0.2,0.4-0.3,0.7-0.3   c2.7,0,9.9-4.2,15.6-11c4.1-5,8.7-13,7-22.5c-1.8-9.8-4.9-14.2-7.2-14.9c-0.2-0.1-0.5-0.1-0.7-0.1s-0.5,0.1-0.6,0.3   c-0.5,0.4-0.8,1.5-0.3,3.2c2.6,9.2,6.1,21.9-5.7,30c-2.4,1.6-4.6,3.4-6.7,5.4c-0.2,0.1-0.4,0.2-0.7,0.2c-0.2,0-0.4-0.1-0.6-0.3   s-0.3-0.4-0.3-0.6s0.1-0.5,0.2-0.7c2.2-2.1,4.5-3.9,7-5.6c10.7-7.3,7.4-19.1,4.9-27.8c-0.6-2.1-0.3-4.1,0.8-5.1   c0.4-0.4,1-0.7,1.6-0.8s1.2-0.1,1.8,0.1c3.7,1.2,6.9,7.4,8.5,16.4c1.8,10.3-3,18.8-7.4,24.2   C1489.9,812.6,1482.2,817.3,1478.6,817.3L1478.6,817.3z"
+   id="path1364" />
+	<path
+   class="st82"
+   d="M1495.3,766.9c2.3,5.6,7.9,21.1,0.1,31s-13,9.4-13,9.4l0.8,7.5c8.2-4.3,21.9-17.3,19.1-33.2   C1500.3,771.2,1497.8,767.8,1495.3,766.9L1495.3,766.9z"
+   id="path1366" />
+	<path
+   class="st78"
+   d="M1478.6,817.3c-0.3,0-0.5-0.1-0.7-0.3s-0.3-0.4-0.3-0.7s0.1-0.5,0.3-0.7c0.2-0.2,0.4-0.3,0.7-0.3   c2.7,0,9.9-4.2,15.6-11c4.1-5,8.7-13,7-22.5c-1.8-9.8-4.9-14.2-7.2-14.9c-0.2-0.1-0.5-0.1-0.7-0.1s-0.5,0.1-0.6,0.3   c-0.5,0.4-0.8,1.5-0.3,3.2c2.6,9.2,6.1,21.9-5.7,30c-2.4,1.6-4.6,3.4-6.7,5.4c-0.2,0.1-0.4,0.2-0.7,0.2c-0.2,0-0.4-0.1-0.6-0.3   s-0.3-0.4-0.3-0.6s0.1-0.5,0.2-0.7c2.2-2.1,4.5-3.9,7-5.6c10.7-7.3,7.4-19.1,4.9-27.8c-0.6-2.1-0.3-4.1,0.8-5.1   c0.4-0.4,1-0.7,1.6-0.8s1.2-0.1,1.8,0.1c3.7,1.2,6.9,7.4,8.5,16.4c1.8,10.3-3,18.8-7.4,24.2   C1489.9,812.6,1482.2,817.3,1478.6,817.3L1478.6,817.3z"
+   id="path1368" />
+	<path
+   class="st83"
+   d="M1484.5,805.6c0,20.1-14.5,31.4-32.3,31.4s-32.3-11.3-32.3-31.4s14.5-51.5,32.3-51.5   S1484.5,785.5,1484.5,805.6z"
+   id="path1370" />
+	<path
+   class="st78"
+   d="M1452.2,837.9c-19.9,0-33.2-13-33.2-32.3c0-20.7,14.9-52.5,33.2-52.5s33.2,31.8,33.2,52.5   C1485.4,824.9,1472.1,837.9,1452.2,837.9L1452.2,837.9z M1452.2,755c-4.5,0-13.3,2.3-22.1,17.7c-5.8,10.2-9.3,22.8-9.3,32.9   c0,18.2,12.6,30.5,31.4,30.5s31.4-12.2,31.4-30.5c0-10-3.6-22.6-9.3-32.8C1465.5,757.3,1456.7,755,1452.2,755L1452.2,755   L1452.2,755z"
+   id="path1372" />
+	<path
+   class="st84"
+   d="M1452.2,754.1h-0.7c13.9,0.8,30.5,32.4,30.5,50.7c0,18.6-13.8,29.1-31,29.1c-6.4,0-12.2-0.1-17.1-1.5   c5.5,3.2,11.8,4.8,18.2,4.7c17.8,0,32.3-11.3,32.3-31.4S1470,754.1,1452.2,754.1L1452.2,754.1z"
+   id="path1374" />
+	<path
+   class="st84"
+   d="M1477.2,781.5l-5.1,4.6c0,0,5.8-1.2,6-2.3C1478.3,782.8,1477.2,781.5,1477.2,781.5L1477.2,781.5z"
+   id="path1376" />
+	<path
+   class="st84"
+   d="M1478.5,785.4l-5.9,4.6c0,0,6.7-1.2,6.9-2.3C1479.8,786.6,1478.5,785.4,1478.5,785.4L1478.5,785.4z"
+   id="path1378" />
+	<path
+   class="st84"
+   d="M1479.9,789.3l-6.9,5.3c0,0,7.8-1.4,8.1-2.6S1479.9,789.3,1479.9,789.3L1479.9,789.3z"
+   id="path1380" />
+	<path
+   class="st84"
+   d="M1479.6,820.2l-7.4-4.5c0,0,4.2,6.8,5.4,6.6C1478.9,822.2,1479.6,820.2,1479.6,820.2z"
+   id="path1382" />
+	<path
+   class="st84"
+   d="M1482.8,816.4l-8.2-2.7c0,0,5.6,5.6,6.8,5.2S1482.8,816.4,1482.8,816.4z"
+   id="path1384" />
+	<path
+   class="st84"
+   d="M1425.9,781.5l6,4.6c0,0-6.8-1.2-7.1-2.3C1424.6,782.8,1425.9,781.5,1425.9,781.5L1425.9,781.5z"
+   id="path1386" />
+	<path
+   class="st84"
+   d="M1424.3,785.4l7,4.6c0,0-7.9-1.2-8.2-2.3C1422.8,786.6,1424.3,785.4,1424.3,785.4L1424.3,785.4z"
+   id="path1388" />
+	<path
+   class="st84"
+   d="M1422.7,789.3l8.2,5.3c0,0-9.2-1.4-9.6-2.6S1422.7,789.3,1422.7,789.3L1422.7,789.3z"
+   id="path1390" />
+	<path
+   class="st3"
+   d="M1466.7,800.6c0,9.8-5.4,18.3-15.3,18.3s-15.3-8.5-15.3-18.3s5.4-23.6,15.3-23.6S1466.7,790.8,1466.7,800.6z"
+   id="path1392" />
+	<path
+   class="st78"
+   d="M1451.4,819.8c-9.5,0-16.2-7.9-16.2-19.2c0-5.6,1.4-11,4-15.9c3.1-5.6,7.4-8.6,12.2-8.6s9.1,3.1,12.2,8.6   c2.6,4.9,4,10.4,4,15.9C1467.6,811.9,1460.9,819.8,1451.4,819.8L1451.4,819.8z M1451.4,777.8c-9.3,0-14.4,13.5-14.4,22.8   c0,12,7.2,17.3,14.4,17.3s14.4-5.4,14.4-17.3C1465.8,791.3,1460.7,777.8,1451.4,777.8z"
+   id="path1394" />
+	<path
+   class="st81"
+   d="M1480.7,742.2c-0.1,1.6-3.2-0.5-4.2,0.7l-21.1-13c0.6-1.5,1.3-2.9,2.1-4.3c4.5-7.4,14.1-14.8,18.8-9.5   C1479.6,719.8,1481.4,732.7,1480.7,742.2L1480.7,742.2z"
+   id="path1396" />
+	<path
+   class="st78"
+   d="M1476.7,744.2l-0.7-0.4l-21.9-13.5l0.3-0.8c0.6-1.5,1.3-3,2.2-4.5c3.4-5.7,10.1-11.8,15.6-11.8   c0.9,0,1.8,0.2,2.7,0.5c0.8,0.4,1.6,0.9,2.2,1.6c3.6,4.1,5.3,17.4,4.6,26.8c0,0.2-0.1,0.4-0.2,0.6c-0.1,0.2-0.2,0.4-0.4,0.5   c-0.2,0.2-0.4,0.3-0.6,0.3c-0.2,0.1-0.4,0.1-0.7,0.1c-0.4,0-0.9-0.1-1.3-0.2c-0.4-0.1-0.7-0.1-1.1-0.2c-0.1,0-0.2,0-0.3,0   L1476.7,744.2L1476.7,744.2z M1477.5,741.5c0.5,0,1,0.1,1.5,0.2c0.2,0.1,0.5,0.1,0.7,0.1c0.7-9.8-1.3-21.9-4.1-25.1   c-0.4-0.5-0.9-0.9-1.5-1.1s-1.2-0.4-1.8-0.4c-4.6,0-10.7,5.5-13.9,10.8c-0.7,1.1-1.2,2.2-1.7,3.4l19.9,12.2   C1476.8,741.6,1477.1,741.5,1477.5,741.5L1477.5,741.5z"
+   id="path1398" />
+	<path
+   class="st78"
+   d="M1474,735.8c-0.1,0.5-8.9-4.7-8.9-4.7c0.2-0.5,0.4-1,0.7-1.4c1.5-2.5,4.6-6.2,6.3-4.1   C1472.5,726.2,1474.2,732.6,1474,735.8L1474,735.8z"
+   id="path1400" />
+	<path
+   class="st78"
+   d="M1473.9,736.8c-0.3,0-1.1,0-9.3-4.9l-0.7-0.4l0.3-0.8c0.2-0.5,0.5-1.1,0.8-1.6c0.7-1.2,3.4-5.2,5.9-5.2   c0.4,0,0.8,0.1,1.1,0.3c0.3,0.2,0.7,0.5,0.9,0.8c0.7,1,2.4,7.7,2.1,10.8c0,0.3-0.1,0.5-0.3,0.7   C1474.4,736.7,1474.2,736.8,1473.9,736.8L1473.9,736.8z M1466.3,730.6c2.5,1.5,5.2,3,6.7,3.7c-0.3-2.8-0.9-5.6-1.8-8.2   c0-0.1-0.1-0.1-0.2-0.2c-0.1,0-0.2-0.1-0.2-0.1c-0.9,0-2.8,1.9-4.2,4.2C1466.5,730.3,1466.4,730.4,1466.3,730.6L1466.3,730.6z"
+   id="path1402" />
+	<path
+   class="st85"
+   d="M1476.7,716.6l-5.1,4.6c0,0,5.8-1.2,6-2.3C1477.8,717.9,1476.7,716.6,1476.7,716.6L1476.7,716.6z"
+   id="path1404" />
+	<path
+   class="st83"
+   d="M1423.2,742.9c0.1,1.6,3.2-0.5,4.2,0.7l21.1-13c-0.6-1.5-1.3-2.9-2.1-4.3c-4.5-7.4-14-14.8-18.8-9.5   C1424.3,720.5,1422.5,733.4,1423.2,742.9L1423.2,742.9z"
+   id="path1406" />
+	<path
+   class="st84"
+   d="M1426.6,718.9l6,4.6c0,0-6.8-1.2-7.1-2.3C1425.3,720.1,1426.6,718.9,1426.6,718.9L1426.6,718.9z"
+   id="path1408" />
+	<path
+   class="st84"
+   d="M1424.5,723.1l4.6,3.3c0,0-5.2-0.9-5.4-1.6S1424.5,723.1,1424.5,723.1z"
+   id="path1410" />
+	<path
+   class="st78"
+   d="M1427.2,744.8l-0.6-0.6c-0.1,0-0.2,0-0.3,0c-0.4,0-0.7,0.1-1.1,0.2c-0.4,0.1-0.9,0.2-1.3,0.2   c-0.2,0-0.4,0-0.6-0.1s-0.4-0.2-0.6-0.3c-0.2-0.2-0.3-0.3-0.4-0.5s-0.2-0.4-0.2-0.6c-0.7-9.4,1-22.8,4.6-26.8   c0.6-0.7,1.3-1.2,2.2-1.6c0.8-0.4,1.7-0.5,2.6-0.5c5.5,0,12.1,6.1,15.6,11.8c0.9,1.4,1.6,2.9,2.2,4.5l0.3,0.8L1427.2,744.8   L1427.2,744.8z M1431.7,715.9c-0.6,0-1.3,0.1-1.8,0.4s-1.1,0.7-1.5,1.1c-2.8,3.2-4.8,15.3-4.1,25.1c0.2,0,0.5-0.1,0.7-0.1   c0.8-0.2,1.7-0.2,2.5,0l19.9-12.3c-0.5-1.2-1.1-2.3-1.7-3.4C1442.4,721.4,1436.3,715.9,1431.7,715.9z"
+   id="path1412" />
+	<path
+   class="st78"
+   d="M1429.9,736.4c0,0.5,8.9-4.7,8.9-4.7c-0.2-0.5-0.4-1-0.7-1.4c-1.5-2.5-4.6-6.2-6.3-4.1   C1431.4,726.8,1429.7,733.2,1429.9,736.4z"
+   id="path1414" />
+	<path
+   class="st78"
+   d="M1430,737.4c-0.3,0-0.5-0.1-0.7-0.3s-0.3-0.4-0.3-0.7c-0.2-3.2,1.4-9.9,2.1-10.8c0.2-0.3,0.5-0.6,0.9-0.8   c0.3-0.2,0.7-0.3,1.1-0.3c2.6,0,5.2,4,5.9,5.2c0.3,0.5,0.6,1,0.8,1.6l0.3,0.8l-0.7,0.4C1431.1,737.4,1430.3,737.5,1430,737.4   L1430,737.4z M1433.1,726.5c-0.1,0-0.2,0-0.4,0.3c-0.9,2.7-1.5,5.4-1.7,8.2c1.5-0.7,4.1-2.2,6.7-3.7c-0.1-0.2-0.2-0.3-0.3-0.5   C1435.9,728.4,1434,726.5,1433.1,726.5L1433.1,726.5z"
+   id="path1416" />
+	<path
+   class="st86"
+   d="M1460.7,782c0.8,1,1.5,2.1,2.2,3.3c6.4-1.7,11.5-4.9,14.4-8.9c-0.2-0.5-0.4-0.9-0.7-1.3   C1471.8,778.5,1466.4,780.9,1460.7,782L1460.7,782z"
+   id="path1418" />
+	<path
+   class="st86"
+   d="M1440.1,785c0.6-1.1,1.3-2.2,2.2-3.2c-5.2-1.1-10.2-3.3-14.5-6.4c-0.3,0.5-0.5,1-0.7,1.5   C1429.8,780.4,1434.4,783.3,1440.1,785L1440.1,785z"
+   id="path1420" />
+	<path
+   class="st87"
+   d="M1452,782.8c-3.3,0-6.5-0.3-9.7-1.1c-0.8,1-1.5,2.1-2.2,3.2c3.8,1.2,7.9,1.7,11.9,1.7c3.7,0,7.3-0.5,10.9-1.4   c-0.6-1.2-1.3-2.3-2.2-3.3C1457.8,782.6,1454.9,782.9,1452,782.8L1452,782.8z"
+   id="path1422" />
+	<path
+   class="st78"
+   d="M1451.4,819.8c-9.5,0-16.2-7.9-16.2-19.2c0-5.6,1.4-11,4-15.9c3.1-5.6,7.4-8.6,12.2-8.6s9.1,3.1,12.2,8.6   c2.6,4.9,4,10.4,4,15.9C1467.6,811.9,1460.9,819.8,1451.4,819.8L1451.4,819.8z M1451.4,777.8c-9.3,0-14.4,13.5-14.4,22.8   c0,12,7.2,17.3,14.4,17.3s14.4-5.4,14.4-17.3C1465.8,791.3,1460.7,777.8,1451.4,777.8z"
+   id="path1424" />
+	<path
+   class="st88"
+   d="M1479.1,772.9c-0.8,0.8-1.6,1.5-2.5,2.1c0.2,0.5,0.4,0.9,0.7,1.3C1478,775.3,1478.6,774.1,1479.1,772.9z"
+   id="path1426" />
+	<path
+   class="st78"
+   d="M1452.2,837.9c-19.9,0-33.2-13-33.2-32.3c0-20.7,14.9-52.5,33.2-52.5s33.2,31.8,33.2,52.5   C1485.4,824.9,1472.1,837.9,1452.2,837.9L1452.2,837.9z M1452.2,755c-4.5,0-13.3,2.3-22.1,17.7c-5.8,10.2-9.3,22.8-9.3,32.9   c0,18.2,12.6,30.5,31.4,30.5s31.4-12.2,31.4-30.5c0-10-3.6-22.6-9.3-32.8C1465.5,757.3,1456.7,755,1452.2,755L1452.2,755   L1452.2,755z"
+   id="path1428" />
+	<path
+   class="st83"
+   d="M1476.2,751.1c0-2.1,0.6-4.2,1.5-6c1-1.9,2.4-3.5,4.1-4.7c-6.3-7.5-17.2-12.4-29.6-12.4h-1.2   c1,4.3,1.4,8.8,1.2,13.2c0,17.8-6.4,32.9-15.4,38.8c4.9,1.8,10.1,2.7,15.4,2.7c15.7,0,29.1-7.9,33.7-18.9   C1480.2,761.9,1476.2,757,1476.2,751.1L1476.2,751.1z"
+   id="path1430" />
+	<path
+   class="st78"
+   d="M1452.2,783.8c-5.4,0-10.7-0.9-15.7-2.8c-0.2-0.1-0.3-0.2-0.4-0.3s-0.2-0.3-0.2-0.5s0-0.4,0.1-0.5   c0.1-0.2,0.2-0.3,0.3-0.4c8.9-5.9,14.9-21.2,14.9-38c0.2-4.4-0.2-8.7-1.2-13c0-0.1,0-0.3,0-0.4c0-0.2,0.1-0.3,0.2-0.4   c0.1-0.1,0.2-0.2,0.3-0.3c0.1-0.1,0.3-0.1,0.4-0.1h1.3c12.2,0,23.6,4.7,30.4,12.7c0.1,0.1,0.2,0.2,0.2,0.3s0.1,0.3,0,0.4   c0,0.1-0.1,0.3-0.1,0.4s-0.2,0.2-0.3,0.3c-1.6,1.1-2.9,2.6-3.8,4.3s-1.4,3.6-1.4,5.6c0,5.3,3.5,10,9,11.9c0.1,0,0.2,0.1,0.3,0.2   s0.2,0.2,0.2,0.3c0.1,0.1,0.1,0.3,0.1,0.4s0,0.3-0.1,0.4C1481.9,776,1468,783.8,1452.2,783.8L1452.2,783.8z M1438.9,779.8   c4.3,1.4,8.8,2,13.3,2c14.6,0,27.4-6.9,32.4-17.3c-5.7-2.5-9.4-7.6-9.4-13.4c0-2.1,0.5-4.1,1.4-6s2.2-3.5,3.8-4.8   c-6.5-7.1-16.9-11.2-28.2-11.2c0.8,4,1.1,8.2,1,12.3C1453.2,758,1447.7,772.9,1438.9,779.8L1438.9,779.8z"
+   id="path1432" />
+	<path
+   class="st81"
+   d="M1452.2,741.3c0-4.4-0.4-8.9-1.2-13.2c-19,0.5-34.2,12.6-34.2,27.4c0,10.9,8.2,20.3,20.1,24.7   C1445.8,774.2,1451.8,759,1452.2,741.3L1452.2,741.3z"
+   id="path1434" />
+	<path
+   class="st78"
+   d="M1436.8,781.1c-0.1,0-0.2,0-0.3-0.1c-12.6-4.7-20.7-14.8-20.7-25.6c0-15.4,15.4-27.8,35.2-28.4   c0.2,0,0.5,0.1,0.6,0.2c0.2,0.2,0.3,0.3,0.3,0.6c0.8,4.4,1.3,8.9,1.3,13.4c-0.4,18-6.6,33.6-15.8,39.7   C1437.2,781.1,1437,781.1,1436.8,781.1L1436.8,781.1z M1450.1,729.1c-18.2,0.8-32.4,12.3-32.4,26.4c0,9.9,7.4,19.1,19,23.6   c8.4-5.9,14.1-20.7,14.5-37.7C1451.2,737.2,1450.9,733.1,1450.1,729.1L1450.1,729.1z"
+   id="path1436" />
+	<path
+   class="st85"
+   d="M1419.6,745.5l6,4.6c0,0-6.8-1.2-7.1-2.3C1418.3,746.7,1419.6,745.5,1419.6,745.5L1419.6,745.5z"
+   id="path1438" />
+	<path
+   class="st85"
+   d="M1418.1,749.3l7,4.6c0,0-7.9-1.2-8.2-2.3S1418.1,749.3,1418.1,749.3L1418.1,749.3z"
+   id="path1440" />
+	<path
+   class="st84"
+   d="M1474,763c0-3.9-2.9-7-6.4-7c-1.2,0-2.4,0.4-3.4,1.1c-1,0.7-1.8,1.7-2.3,2.8c5.6,1.5,9.3,4.5,9.3,8.4   c0,0.2,0,0.3-0.1,0.5c0.9-0.7,1.6-1.5,2.1-2.6C1473.8,765.3,1474,764.1,1474,763L1474,763z"
+   id="path1442" />
+	<path
+   class="st81"
+   d="M1451,728.1c0.8,4.4,1.2,8.8,1.2,13.2C1452.4,736.9,1452,732.4,1451,728.1z"
+   id="path1444" />
+	<path
+   class="st78"
+   d="M1452.2,742.3c-0.3,0-0.5-0.1-0.7-0.3s-0.3-0.4-0.3-0.7c0-4.4-0.4-8.8-1.2-13c0-0.1,0-0.3,0-0.4   s0.1-0.2,0.1-0.4c0.1-0.1,0.2-0.2,0.3-0.3c0.1-0.1,0.2-0.1,0.3-0.2c0.1,0,0.3,0,0.4,0s0.2,0.1,0.4,0.1s0.2,0.2,0.3,0.3   c0.1,0.1,0.1,0.2,0.2,0.3c1,4.4,1.5,9,1.3,13.5c0,0.2-0.1,0.5-0.3,0.7S1452.5,742.3,1452.2,742.3L1452.2,742.3z"
+   id="path1446" />
+	<path
+   class="st81"
+   d="M1481.9,740.4c-1.7,1.2-3.1,2.8-4.1,4.7s-1.5,3.9-1.5,6c0,5.8,4,10.8,9.7,12.9c1.2-2.7,1.8-5.6,1.8-8.5   C1487.6,749.9,1485.5,744.5,1481.9,740.4L1481.9,740.4z"
+   id="path1448" />
+	<path
+   class="st78"
+   d="M1486.4,765.2l-0.9-0.3c-6.3-2.2-10.4-7.7-10.4-13.8c0-2.3,0.6-4.5,1.6-6.5c1.1-2,2.6-3.7,4.4-5l0.7-0.5   l0.6,0.7c3.8,4.3,6,9.9,6,15.7c0,3.1-0.6,6.1-1.8,8.9L1486.4,765.2L1486.4,765.2z M1481.7,741.8c-1.4,1.1-2.5,2.5-3.3,4.2   s-1.2,3.4-1.2,5.2c0,5,3.2,9.5,8.2,11.6c0.9-2.3,1.3-4.8,1.3-7.2C1486.7,750.4,1484.9,745.6,1481.7,741.8z"
+   id="path1450" />
+	<path
+   class="st78"
+   d="M1443.1,753.8c4.5-0.6,7.8-4.2,7.3-8.2c-0.5-3.9-4.6-6.7-9.1-6.1c-4.5,0.6-7.8,4.2-7.3,8.2   S1438.6,754.4,1443.1,753.8z"
+   id="path1452" />
+	<path
+   class="st3"
+   d="M1443.2,752.9c3.3-0.4,5.7-3.1,5.3-5.9c-0.4-2.9-3.3-4.8-6.6-4.4s-5.7,3.1-5.3,5.9   C1437,751.4,1439.9,753.4,1443.2,752.9z"
+   id="path1454" />
+	<path
+   class="st78"
+   d="M1442.8,750c1.2-0.2,2.1-1.2,2-2.3s-1.2-1.9-2.5-1.7s-2.1,1.2-2,2.3C1440.5,749.4,1441.6,750.2,1442.8,750z"
+   id="path1456" />
+	<path
+   class="st78"
+   d="M1435.8,741.4c-0.1,0-0.2,0-0.2,0l-2.3-0.9c-0.1,0-0.2,0-0.3-0.1c-0.1-0.1-0.2-0.1-0.2-0.2   c-0.1-0.1-0.1-0.2-0.1-0.3s0-0.2,0-0.3s0.1-0.2,0.2-0.2c0.1-0.1,0.2-0.1,0.3-0.2s0.2,0,0.3,0c0.1,0,0.2,0.1,0.3,0.1l2.3,0.9   c0.2,0.1,0.3,0.2,0.3,0.3s0.1,0.3,0,0.5c-0.1,0.1-0.1,0.2-0.2,0.3S1435.9,741.4,1435.8,741.4L1435.8,741.4z"
+   id="path1458" />
+	<path
+   class="st78"
+   d="M1437.7,739.9c-0.1,0-0.3,0-0.4-0.1l-2.7-1.9c-0.1-0.1-0.2-0.3-0.3-0.4s0-0.3,0.1-0.5s0.2-0.2,0.4-0.3   s0.3,0,0.5,0.1l2.7,1.9c0.1,0.1,0.2,0.3,0.3,0.4s0,0.3-0.1,0.5c-0.1,0.1-0.1,0.2-0.2,0.2S1437.8,739.8,1437.7,739.9L1437.7,739.9z"
+   id="path1460" />
+	<path
+   class="st78"
+   d="M1472.1,748c0.5-3.9-2.7-7.6-7.2-8.2c-4.5-0.6-8.6,2.1-9.1,6s2.7,7.6,7.2,8.2   C1467.5,754.7,1471.6,752,1472.1,748z"
+   id="path1462" />
+	<path
+   class="st3"
+   d="M1469.3,748.5c0.4-2.9-2-5.5-5.3-5.9s-6.2,1.5-6.6,4.4s2,5.5,5.3,5.9S1469,751.4,1469.3,748.5z"
+   id="path1464" />
+	<path
+   class="st78"
+   d="M1465.6,748.3c0.1-1.1-0.8-2.1-2-2.3s-2.3,0.6-2.5,1.7c-0.1,1.1,0.8,2.1,2,2.3   C1464.3,750.2,1465.5,749.4,1465.6,748.3z"
+   id="path1466" />
+	<path
+   class="st78"
+   d="M1470.1,741.4c-0.1,0-0.3-0.1-0.4-0.2c-0.1-0.1-0.2-0.2-0.2-0.4c0-0.1,0-0.3,0.1-0.4c0.1-0.1,0.2-0.2,0.3-0.3   l2.3-0.9c0.1-0.1,0.2-0.1,0.3-0.1s0.2,0,0.3,0c0.1,0,0.2,0.1,0.3,0.2c0.1,0.1,0.1,0.2,0.2,0.2s0.1,0.2,0,0.3c0,0.1,0,0.2-0.1,0.3   s-0.1,0.2-0.2,0.2c-0.1,0.1-0.2,0.1-0.3,0.1l-2.3,0.9C1470.3,741.4,1470.2,741.4,1470.1,741.4L1470.1,741.4z"
+   id="path1468" />
+	<path
+   class="st78"
+   d="M1468.3,739.9c-0.1,0-0.3-0.1-0.4-0.1s-0.2-0.2-0.2-0.3s0-0.3,0-0.4s0.1-0.2,0.2-0.3l2.7-1.9   c0.1-0.1,0.2-0.1,0.2-0.2s0.2-0.1,0.3,0c0.1,0,0.2,0,0.3,0.1c0.1,0,0.2,0.1,0.2,0.2c0.1,0.1,0.1,0.2,0.1,0.3s0,0.2,0,0.3   s-0.1,0.2-0.2,0.3s-0.2,0.1-0.2,0.2l-2.7,1.9C1468.6,739.8,1468.4,739.9,1468.3,739.9L1468.3,739.9z"
+   id="path1470" />
+	<path
+   class="st3"
+   d="M1471.2,768.3c0,5.9-8.6,10.7-19.1,10.7s-19.1-4.7-19.1-10.7s8.5-9.6,19.1-9.6S1471.2,762.4,1471.2,768.3   L1471.2,768.3z"
+   id="path1472" />
+	<path
+   class="st89"
+   d="M1452.2,777c-6.9,0-13.4-1.8-19.2-8.6c0.5,7.2,9.2,10.3,18.9,10.3c10.5,0,18.1-4.1,19.1-10.3   C1465.6,774.3,1462,776.9,1452.2,777L1452.2,777z"
+   id="path1474" />
+	<path
+   class="st78"
+   d="M1452.5,775.8c-5.8,0-11.1-3.1-13.6-7.8c0-0.2,0-0.3,0-0.4s0.2-0.2,0.3-0.3s0.3-0.1,0.4-0.1   c0.2,0,0.3,0.1,0.4,0.2c2.2,4.3,7.1,7.1,12.4,7.1h0.2c5.2-0.1,9.9-2.8,12.1-7c0-0.1,0.1-0.2,0.1-0.3c0.1-0.1,0.2-0.1,0.2-0.2   s0.2-0.1,0.3-0.1c0.1,0,0.2,0,0.3,0.1c0.1,0,0.2,0.1,0.2,0.2c0.1,0.1,0.1,0.2,0.1,0.3s0,0.2,0,0.3s-0.1,0.2-0.1,0.3   C1463.4,772.8,1458.3,775.7,1452.5,775.8L1452.5,775.8L1452.5,775.8z"
+   id="path1476" />
+	<path
+   class="st78"
+   d="M1452.1,780c-11.2,0-20.1-5.1-20.1-11.6s8.2-10.6,20.1-10.6s20.1,4.3,20.1,10.6S1463.4,780,1452.1,780z    M1452.1,759.7c-10.5,0-18.1,3.6-18.1,8.6c0,5.2,8.3,9.7,18.1,9.7s18.1-4.4,18.1-9.7C1470.2,763.3,1462.6,759.7,1452.1,759.7   L1452.1,759.7z"
+   id="path1478" />
+	<path
+   class="st78"
+   d="M1453.2,762.7h-1.5v12.8h1.5V762.7z"
+   id="path1480" />
+	<path
+   class="st78"
+   d="M1458,759.3c0,3.1-5.6,5-5.6,5s-5.6-1.9-5.6-5s2.5-2.8,5.6-2.8S1458,756.2,1458,759.3z"
+   id="path1482" />
+	<path
+   class="st90"
+   d="M1452.4,759.3c2,0,3.6-0.3,3.6-0.6s-1.6-0.6-3.6-0.6s-3.6,0.3-3.6,0.6S1450.4,759.3,1452.4,759.3z"
+   id="path1484" />
+	<path
+   class="st84"
+   d="M1471.3,824.5c0,2.8-1.2,14.6-8.2,13.7c-3.8-0.5-9.2-6.4-6.9-8c2.4-1.7-2.4-10.1,0.8-8   C1460.3,824.3,1471.3,821.7,1471.3,824.5L1471.3,824.5z"
+   id="path1486" />
+	<path
+   class="st3"
+   d="M1467.6,834.9c0,2.8-2.6,3.8-6.7,3.8s-7.4-2.2-7.4-5s1.8-5.1,5.3-2.9C1462.3,832.9,1467.6,832.1,1467.6,834.9   L1467.6,834.9z"
+   id="path1488" />
+	<path
+   class="st89"
+   d="M1460.5,836c-2.5-0.9-4.8-2.4-6.7-4.2c-0.2,0.5-0.3,0.9-0.3,1.4c0,3,3.6,5.5,7.9,5.5c1.9,0,3.8-0.5,5.4-1.5   C1464.7,837.2,1462.5,836.8,1460.5,836L1460.5,836z"
+   id="path1490" />
+	<path
+   class="st78"
+   d="M1461.5,839.5c-4.8,0-8.8-2.8-8.8-6.3c0-2.2,1.6-4.2,4.1-5.4c-0.4-1.8-0.6-3.7-0.7-5.6c0-0.1,0-0.2,0-0.3   s0.1-0.2,0.2-0.3s0.2-0.2,0.3-0.2c0.1,0,0.2-0.1,0.3-0.1c0.1,0,0.2,0,0.3,0.1c0.1,0,0.2,0.1,0.3,0.2c0.1,0.1,0.1,0.2,0.2,0.3   s0.1,0.2,0.1,0.3c0.1,2,0.3,4,0.8,6l0.2,0.7l-0.7,0.2c-2.3,0.8-3.7,2.4-3.7,4.1c0,2.6,3.2,4.7,7.1,4.7c3.1,0,5.9-1.3,6.8-3.4   c1.7-4,2.8-8.2,3.4-12.5c0-0.2,0.2-0.4,0.3-0.5c0.2-0.1,0.4-0.2,0.6-0.1c0.2,0,0.4,0.1,0.5,0.3s0.2,0.4,0.2,0.6   c-0.6,4.5-1.8,8.8-3.5,13C1468.7,837.7,1465.3,839.5,1461.5,839.5L1461.5,839.5z"
+   id="path1492" />
+	<path
+   class="st81"
+   d="M1432.6,824.5c0,2.8,1.2,14.6,8.2,13.7c3.8-0.5,9.2-6.4,6.9-8c-2.4-1.7,1.5-10.1-1.8-8   C1442.7,824.3,1432.5,821.7,1432.6,824.5L1432.6,824.5z"
+   id="path1494" />
+	<path
+   class="st3"
+   d="M1436.3,834.9c0,2.8,2.6,3.8,6.7,3.8s7.4-2.2,7.4-5s-1.8-5.1-5.3-2.9C1441.6,832.9,1436.3,832.1,1436.3,834.9   L1436.3,834.9z"
+   id="path1496" />
+	<path
+   class="st89"
+   d="M1444.1,836.3c2.4-1,4.6-2.6,6.4-4.6c0.2,0.4,0.3,0.9,0.3,1.3c0.2,3-3.3,5.7-7.7,5.9   c-1.9,0.1-3.8-0.3-5.5-1.2C1439.9,837.6,1442.1,837.1,1444.1,836.3L1444.1,836.3z"
+   id="path1498" />
+	<path
+   class="st78"
+   d="M1442.3,839.5c-3.8,0-7.2-1.8-8.3-4.3c-1.7-4.2-2.9-8.5-3.6-13c0-0.2,0.1-0.4,0.2-0.6   c0.1-0.2,0.3-0.3,0.5-0.3s0.4,0,0.6,0.1s0.3,0.3,0.3,0.5c0.6,4.3,1.8,8.5,3.4,12.6c0.9,2,3.7,3.3,6.8,3.3c3.9,0,7.1-2.1,7.1-4.7   c0-1.7-1.4-3.2-3.7-4.1l-0.7-0.2l0.2-0.7c0.4-2,0.7-4,0.8-6c0-0.1,0-0.2,0.1-0.3c0-0.1,0.1-0.2,0.2-0.3s0.2-0.2,0.3-0.2   s0.2-0.1,0.3-0.1s0.2,0,0.3,0.1c0.1,0,0.2,0.1,0.3,0.2c0.1,0.1,0.1,0.2,0.2,0.3s0,0.2,0,0.3c-0.1,1.9-0.3,3.8-0.7,5.6   c2.6,1.1,4.1,3.2,4.1,5.4C1451.2,836.7,1447.2,839.5,1442.3,839.5L1442.3,839.5z"
+   id="path1500" />
+	<path
+   class="st89"
+   d="M1463.9,765.7c0.5,0,0.9-0.4,0.9-1s-0.4-1-0.9-1s-0.9,0.4-0.9,1S1463.3,765.7,1463.9,765.7z"
+   id="path1502" />
+	<path
+   class="st89"
+   d="M1462,763.4c0.5,0,0.9-0.4,0.9-1s-0.4-1-0.9-1s-0.9,0.4-0.9,1S1461.5,763.4,1462,763.4z"
+   id="path1504" />
+	<path
+   class="st89"
+   d="M1461.4,766.7c0.5,0,0.9-0.4,0.9-1s-0.4-1-0.9-1s-0.9,0.4-0.9,1S1460.9,766.7,1461.4,766.7z"
+   id="path1506" />
+	<path
+   class="st89"
+   d="M1441.2,765.8c0.5,0,0.9-0.4,0.9-1s-0.4-1-0.9-1s-0.9,0.4-0.9,1S1440.7,765.8,1441.2,765.8z"
+   id="path1508" />
+	<path
+   class="st89"
+   d="M1443.7,766.7c0.5,0,0.9-0.4,0.9-1s-0.4-1-0.9-1s-0.9,0.4-0.9,1S1443.2,766.7,1443.7,766.7z"
+   id="path1510" />
+	<path
+   class="st89"
+   d="M1443.3,763.7c0.5,0,0.9-0.4,0.9-1s-0.4-1-0.9-1s-0.9,0.4-0.9,1S1442.8,763.7,1443.3,763.7z"
+   id="path1512" />
+	<path
+   class="st78"
+   d="M1478.1,765.6l-13.6-0.2c-0.2,0-0.3-0.1-0.5-0.2c-0.1-0.1-0.2-0.3-0.2-0.5s0.1-0.3,0.2-0.5s0.3-0.2,0.5-0.2   l13.6,0.2c0.2,0,0.3,0.1,0.5,0.2c0.1,0.1,0.2,0.3,0.2,0.5s-0.1,0.3-0.2,0.5S1478.3,765.6,1478.1,765.6L1478.1,765.6L1478.1,765.6z"
+   id="path1514" />
+	<path
+   class="st78"
+   d="M1462.7,763c-0.1,0-0.3-0.1-0.4-0.2c-0.1-0.1-0.2-0.2-0.2-0.4c0-0.1,0-0.3,0.1-0.4c0.1-0.1,0.2-0.2,0.3-0.3   l12.8-5.1c0.1-0.1,0.2-0.1,0.3-0.1c0.1,0,0.2,0,0.3,0c0.1,0,0.2,0.1,0.3,0.2c0.1,0.1,0.1,0.2,0.2,0.2c0,0.1,0.1,0.2,0.1,0.3   s0,0.2-0.1,0.3s-0.1,0.2-0.2,0.2s-0.2,0.1-0.3,0.1l-12.8,5.1C1462.8,763,1462.7,763,1462.7,763L1462.7,763z"
+   id="path1516" />
+	<path
+   class="st78"
+   d="M1427.2,765.6c-0.2,0-0.3-0.1-0.5-0.2c-0.1-0.1-0.2-0.3-0.2-0.5s0.1-0.3,0.2-0.5s0.3-0.2,0.5-0.2l13.6-0.2   c0.2,0,0.3,0.1,0.5,0.2c0.1,0.1,0.2,0.3,0.2,0.5s-0.1,0.3-0.2,0.5s-0.3,0.2-0.5,0.2L1427.2,765.6L1427.2,765.6L1427.2,765.6z"
+   id="path1518" />
+	<path
+   class="st78"
+   d="M1442.6,763c-0.1,0-0.2,0-0.2,0l-12.8-5.1c-0.1,0-0.2,0-0.3-0.1c-0.1-0.1-0.2-0.1-0.2-0.2   c-0.1-0.1-0.1-0.2-0.1-0.3s0-0.2,0.1-0.3c0-0.1,0.1-0.2,0.2-0.2c0.1-0.1,0.2-0.1,0.3-0.2s0.2,0,0.3,0c0.1,0,0.2,0,0.3,0.1l12.8,5.1   c0.1,0.1,0.2,0.2,0.3,0.3c0.1,0.1,0.1,0.3,0.1,0.4c0,0.1-0.1,0.3-0.2,0.4S1442.7,763,1442.6,763L1442.6,763L1442.6,763z"
+   id="path1520" />
+	<path
+   class="st91"
+   d="M1507.1,850.2c11.1,0,20.1-9.1,20.1-20.2s-9-20.2-20.1-20.2s-20.1,9.1-20.1,20.2S1496,850.2,1507.1,850.2z"
+   id="path1522" />
+	<path
+   class="st91"
+   d="M1507.1,809.7c4,0,7.8,1.2,11.2,3.4c3.3,2.2,5.9,5.4,7.4,9.1s1.9,7.8,1.1,11.7s-2.7,7.5-5.5,10.4   c-2.8,2.8-6.4,4.8-10.3,5.5c-3.9,0.8-7.9,0.4-11.6-1.2c-3.7-1.5-6.8-4.1-9-7.5c-2.2-3.3-3.4-7.2-3.4-11.2c0-5.4,2.1-10.5,5.9-14.3   S1501.7,809.7,1507.1,809.7L1507.1,809.7z M1507.1,809c-4.1,0-8.1,1.2-11.6,3.5s-6.1,5.6-7.7,9.4c-1.6,3.8-2,8.1-1.2,12.1   c0.8,4.1,2.8,7.8,5.7,10.8s6.6,4.9,10.7,5.8c4,0.8,8.2,0.4,12-1.2c3.8-1.6,7.1-4.3,9.3-7.7c2.3-3.5,3.5-7.5,3.5-11.7   c0-5.6-2.2-10.9-6.1-14.8C1517.9,811.2,1512.6,809,1507.1,809L1507.1,809z"
+   id="path1524" />
+	<path
+   class="st92"
+   d="M1489.3,823.4c-0.1,0-0.2,0-0.3-0.1l0.3-0.4l-0.3-0.3l0.1-0.1c2.3-2.7,10.7-11.4,21.9-12.2   c0.1,0,0.2,0,0.3,0.1c0.1,0.1,0.2,0.2,0.2,0.3s0,0.1,0,0.2s-0.1,0.1-0.1,0.2c0,0-0.1,0.1-0.2,0.1s-0.1,0-0.2,0   c-11.1,0.8-19.7,10-21.3,11.9c-0.1,0.1-0.1,0.1-0.2,0.2C1489.5,823.4,1489.4,823.4,1489.3,823.4L1489.3,823.4z"
+   id="path1526" />
+	<path
+   class="st92"
+   d="M1487.9,827.5c-0.1,0-0.2,0-0.3-0.1c-0.1,0-0.1-0.1-0.1-0.1s-0.1-0.1-0.1-0.2c0-0.1,0-0.1,0-0.2   s0-0.1,0.1-0.2c0.1-0.2,10.1-15.2,26.6-15.2c0.1,0,0.2,0,0.3,0.1s0.1,0.2,0.1,0.3s-0.1,0.2-0.1,0.3s-0.2,0.1-0.3,0.1   c-16,0-25.7,14.6-25.8,14.8c0,0.1-0.1,0.1-0.2,0.2C1488.1,827.5,1488,827.5,1487.9,827.5L1487.9,827.5z"
+   id="path1528" />
+	<path
+   class="st92"
+   d="M1487.9,830.1c-0.1,0-0.2,0-0.2-0.1s-0.1-0.1-0.2-0.2c0-0.1-0.1-0.2-0.1-0.2s0-0.2,0.1-0.2   c0.1-0.2,10.9-18.2,29.2-16.4c0.1,0,0.2,0.1,0.3,0.2c0.1,0.1,0.1,0.2,0.1,0.3s-0.1,0.2-0.2,0.3s-0.2,0.1-0.3,0.1   c-17.7-1.7-28.2,15.8-28.3,16c0,0.1-0.1,0.1-0.2,0.2C1488.1,830.1,1488,830.1,1487.9,830.1L1487.9,830.1z"
+   id="path1530" />
+	<path
+   class="st92"
+   d="M1524.6,838.7c-0.1,0-0.1,0-0.2,0s-0.1-0.1-0.2-0.1c0,0-0.1-0.1-0.1-0.2s0-0.1,0-0.2   c0-18.5-8.7-22.8-8.8-22.8c-0.1,0-0.1-0.1-0.2-0.1s-0.1-0.1-0.1-0.2c0-0.1,0-0.1,0-0.2s0-0.1,0-0.2c0-0.1,0.1-0.1,0.1-0.2   s0.1-0.1,0.2-0.1s0.1,0,0.2,0s0.1,0,0.2,0.1c0.4,0.2,9.3,4.6,9.3,23.7c0,0.1,0,0.1,0,0.2c0,0.1-0.1,0.1-0.1,0.2   c0,0-0.1,0.1-0.2,0.1C1524.7,838.7,1524.7,838.7,1524.6,838.7L1524.6,838.7z"
+   id="path1532" />
+	<path
+   class="st92"
+   d="M1523.3,840.5c-0.1,0-0.2,0-0.3-0.1s-0.1-0.2-0.2-0.3c-0.4-21.7-10-24.9-10.1-25c-0.1,0-0.2-0.1-0.3-0.2   c-0.1-0.1-0.1-0.2,0-0.4c0-0.1,0.1-0.1,0.1-0.2l0.1-0.1c0.1,0,0.1,0,0.2,0s0.1,0,0.2,0c0.4,0.1,10.4,3.4,10.8,25.9   c0,0.1,0,0.1,0,0.2s-0.1,0.1-0.1,0.2c0,0-0.1,0.1-0.2,0.1C1523.5,840.5,1523.4,840.5,1523.3,840.5L1523.3,840.5L1523.3,840.5z"
+   id="path1534" />
+	<path
+   class="st92"
+   d="M1521.6,842.8c-0.1,0-0.2-0.1-0.3-0.2c-0.1-0.1-0.1-0.2-0.1-0.3c1.3-20.3-8.4-25.6-9.7-26.2l0,0   c-0.4-0.1-0.5-0.4-0.4-0.6c0-0.1,0.1-0.2,0.2-0.3s0.2-0.1,0.3-0.1h0.1h0.1c0,0,0.1,0,0.1,0.1c1.9,0.9,11.5,6.8,10.2,27.2   c0,0.1-0.1,0.2-0.2,0.3C1521.9,842.7,1521.8,842.8,1521.6,842.8L1521.6,842.8z"
+   id="path1536" />
+	<path
+   class="st92"
+   d="M1519.7,845.5L1519.7,845.5c-0.2,0-0.2,0-0.3-0.1c-0.1,0-0.1-0.1-0.1-0.1s-0.1-0.1-0.1-0.2s0-0.1,0-0.2   c4.1-22.8-10.6-28.9-10.7-28.9s-0.1-0.1-0.2-0.1s-0.1-0.1-0.1-0.2c0-0.1,0-0.1,0-0.2s0-0.1,0-0.2c0-0.1,0.1-0.1,0.1-0.2   c0,0,0.1-0.1,0.2-0.1s0.1,0,0.2,0s0.1,0,0.2,0c0.2,0.1,15.6,6.4,11.3,30c0,0.1-0.1,0.2-0.2,0.3   C1519.9,845.5,1519.7,845.5,1519.7,845.5L1519.7,845.5z"
+   id="path1538" />
+	<path
+   class="st92"
+   d="M1499.2,847.7c-0.1,0-0.2,0-0.3-0.1s-0.1-0.2-0.2-0.3c-0.2-13.9,8.7-30.8,8.8-30.9c0.1-0.1,0.2-0.2,0.3-0.2   c0.1,0,0.2,0,0.3,0c0.1,0.1,0.2,0.2,0.2,0.3s0,0.2,0,0.3c-0.1,0.2-8.9,16.8-8.7,30.5c0,0.1-0.1,0.2-0.1,0.3   S1499.3,847.7,1499.2,847.7L1499.2,847.7L1499.2,847.7z"
+   id="path1540" />
+	<path
+   class="st92"
+   d="M1497.5,847.3c-0.1,0-0.2,0-0.3-0.1s-0.1-0.2-0.2-0.3c-0.2-13.9,8.9-30.9,9-31.1c0.1-0.1,0.2-0.2,0.3-0.2   s0.2,0,0.3,0c0.1,0.1,0.2,0.2,0.2,0.3s0,0.2,0,0.4c-0.1,0.2-9.1,17-8.9,30.6c0,0.1-0.1,0.2-0.1,0.3S1497.7,847.3,1497.5,847.3   L1497.5,847.3L1497.5,847.3z"
+   id="path1542" />
+	<path
+   class="st92"
+   d="M1500.8,848.4c-0.1,0-0.1,0-0.2,0s-0.1-0.1-0.2-0.1s-0.1-0.1-0.1-0.2s0-0.1,0-0.2c0.6-15.9,8.4-30.4,8.5-30.5   c0-0.1,0.1-0.1,0.1-0.2c0.1,0,0.1-0.1,0.2-0.1s0.1,0,0.2,0s0.1,0,0.2,0.1c0.1,0,0.1,0.1,0.2,0.1s0.1,0.1,0.1,0.2s0,0.1,0,0.2   c0,0.1,0,0.1-0.1,0.2c-0.1,0.1-7.7,14.5-8.3,30.1c0,0.1,0,0.1-0.1,0.2c0,0.1-0.1,0.1-0.1,0.2s-0.1,0.1-0.2,0.1   S1500.9,848.4,1500.8,848.4L1500.8,848.4z"
+   id="path1544" />
+	<path
+   class="st92"
+   d="M1504.1,849.1c-0.1,0-0.2,0-0.3-0.1s-0.1-0.2-0.2-0.3c-0.8-13.5,7.8-29.6,7.9-29.8c0-0.1,0.1-0.1,0.1-0.2   c0.1,0,0.1-0.1,0.2-0.1s0.1,0,0.2,0s0.1,0,0.2,0.1c0.1,0,0.1,0.1,0.2,0.1s0.1,0.1,0.1,0.2s0,0.1,0,0.2c0,0.1,0,0.1-0.1,0.2   c-0.1,0.2-8.5,16-7.8,29.2c0,0.1,0,0.1,0,0.2s-0.1,0.1-0.1,0.2c0,0-0.1,0.1-0.2,0.1C1504.2,849.1,1504.2,849.1,1504.1,849.1   L1504.1,849.1L1504.1,849.1z"
+   id="path1546" />
+	<path
+   class="st92"
+   d="M1502.5,849.1c-0.1,0-0.2,0-0.3-0.1c-0.1-0.1-0.1-0.2-0.2-0.3c-0.8-13.5,8-30.3,8.1-30.5   c0-0.1,0.1-0.1,0.1-0.2c0.1,0,0.1-0.1,0.2-0.1s0.1,0,0.2,0s0.1,0,0.2,0.1c0.1,0,0.1,0.1,0.2,0.1c0,0,0.1,0.1,0.1,0.2   c0,0.1,0,0.1,0,0.2c0,0.1,0,0.1-0.1,0.2c-0.1,0.2-8.7,16.8-8,30c0,0.1,0,0.1,0,0.2c0,0.1-0.1,0.1-0.1,0.2s-0.1,0.1-0.2,0.1   C1502.6,849.1,1502.6,849.1,1502.5,849.1L1502.5,849.1L1502.5,849.1z"
+   id="path1548" />
+	<path
+   class="st92"
+   d="M1505.7,849.9c-0.1,0-0.2,0-0.3-0.1c-0.1-0.1-0.1-0.2-0.2-0.3c-1.2-13.3,7.3-29.3,7.4-29.5   c0.1-0.1,0.2-0.2,0.3-0.2c0.1,0,0.2,0,0.3,0c0.1,0.1,0.2,0.2,0.2,0.3s0,0.2,0,0.3c-0.1,0.2-8.4,15.9-7.2,28.9c0,0.1,0,0.2-0.1,0.3   S1505.9,849.9,1505.7,849.9L1505.7,849.9L1505.7,849.9z"
+   id="path1550" />
+	<path
+   class="st92"
+   d="M1516,824.7L1516,824.7c-0.5-0.1-1.6-0.3-2.2-0.4l-0.5-0.1c-0.1,0-0.2-0.1-0.3-0.2c-0.1-0.1-0.1-0.2-0.1-0.4   c0-0.1,0.1-0.2,0.2-0.3s0.2-0.1,0.4-0.1l0.5,0.1c0.7,0.1,1.7,0.3,2.2,0.5c0.1,0,0.2,0.1,0.3,0.2c0.1,0.1,0.1,0.2,0.1,0.3   s-0.1,0.2-0.2,0.3C1516.3,824.6,1516.2,824.7,1516,824.7L1516,824.7L1516,824.7z"
+   id="path1552" />
+	<path
+   class="st92"
+   d="M1517.8,830.1c-0.1,0-0.1,0-0.2,0l-0.7-0.2c-1.5-0.5-4.3-1.5-5.4-1.8c-0.1,0-0.1,0-0.2-0.1   c-0.1,0-0.1-0.1-0.1-0.1s-0.1-0.1-0.1-0.2c0-0.1,0-0.1,0-0.2c0-0.1,0.1-0.2,0.2-0.3s0.2-0.1,0.4,0c1.1,0.3,3.8,1.2,5.5,1.8l0.7,0.2   c0.1,0,0.2,0.1,0.3,0.2c0.1,0.1,0.1,0.2,0,0.4c0,0.1-0.1,0.2-0.2,0.2C1518,830.1,1517.9,830.1,1517.8,830.1L1517.8,830.1z"
+   id="path1554" />
+	<path
+   class="st92"
+   d="M1518.6,832c-0.1,0-0.1,0-0.2,0l-0.9-0.3c-2.1-0.8-4.3-1.5-6.5-2c-0.1,0-0.1,0-0.2-0.1   c-0.1,0-0.1-0.1-0.1-0.1s-0.1-0.1-0.1-0.2c0-0.1,0-0.1,0-0.2c0-0.1,0-0.1,0.1-0.2l0.1-0.1c0.1,0,0.1-0.1,0.2-0.1s0.1,0,0.2,0   c2.3,0.5,4.5,1.2,6.7,2l0.9,0.3c0.1,0,0.2,0.1,0.3,0.2c0.1,0.1,0.1,0.2,0.1,0.3s-0.1,0.2-0.2,0.3   C1518.8,832,1518.7,832.1,1518.6,832L1518.6,832L1518.6,832z"
+   id="path1556" />
+	<path
+   class="st92"
+   d="M1519,833.7c-0.1,0-0.1,0-0.2,0c-2.5-1-5.2-1.8-7.9-2.2c-0.1,0-0.2-0.1-0.3-0.2s-0.1-0.2-0.1-0.4   s0.1-0.2,0.2-0.3s0.2-0.1,0.3-0.1c2.8,0.4,5.5,1.2,8.1,2.2c0.1,0,0.2,0.1,0.3,0.2c0.1,0.1,0.1,0.2,0,0.4c0,0.1-0.1,0.2-0.2,0.2   C1519.2,833.7,1519.1,833.7,1519,833.7L1519,833.7z"
+   id="path1558" />
+	<path
+   class="st92"
+   d="M1519,835.3c-0.1,0-0.1,0-0.2,0c-2.9-1.1-5.9-2-9-2.5c-0.1,0-0.1,0-0.2-0.1c-0.1,0-0.1-0.1-0.1-0.1   s-0.1-0.1-0.1-0.2c0-0.1,0-0.1,0-0.2c0-0.1,0.1-0.2,0.2-0.3s0.2-0.1,0.4-0.1c3.1,0.5,6.2,1.4,9.2,2.5c0.1,0,0.1,0.1,0.2,0.1   s0.1,0.1,0.1,0.2c0,0.1,0,0.1,0,0.2s0,0.1,0,0.2c0,0.1-0.1,0.2-0.2,0.2C1519.2,835.3,1519.1,835.3,1519,835.3L1519,835.3z"
+   id="path1560" />
+	<path
+   class="st92"
+   d="M1519,837c-0.1,0-0.2,0-0.2-0.1c-1.9-1.1-5-1.7-7.7-2.2c-0.7-0.1-1.3-0.2-1.9-0.4c-0.1,0-0.1,0-0.2-0.1   c-0.1,0-0.1-0.1-0.1-0.1s-0.1-0.1-0.1-0.2c0-0.1,0-0.1,0-0.2c0-0.1,0.1-0.2,0.2-0.3s0.2-0.1,0.4-0.1c0.6,0.1,1.2,0.2,1.9,0.4   c2.8,0.5,5.9,1.1,8,2.3c0.1,0.1,0.2,0.1,0.2,0.2c0,0.1,0,0.2,0,0.3s-0.1,0.2-0.2,0.3C1519.2,837,1519.1,837,1519,837L1519,837z"
+   id="path1562" />
+	<path
+   class="st92"
+   d="M1508.6,836.9c-0.1,0-0.2,0-0.3-0.1c-0.1-0.1-0.1-0.2-0.2-0.3c0-0.1,0-0.2,0-0.3c0.1-0.1,0.1-0.2,0.2-0.2   l1.9-0.9c0.1-0.1,0.2-0.1,0.4,0c0.1,0,0.2,0.1,0.3,0.2s0.1,0.2,0,0.4s-0.1,0.2-0.2,0.3l-1.9,1   C1508.8,836.8,1508.7,836.9,1508.6,836.9z"
+   id="path1564" />
+	<path
+   class="st92"
+   d="M1507.5,838.9c-0.1,0-0.1,0-0.2,0s-0.1,0-0.2-0.1s-0.1-0.1-0.1-0.2s0-0.1,0-0.2s0-0.1,0-0.2s0.1-0.1,0.1-0.2   c0.1,0,0.1-0.1,0.2-0.1s0.1,0,0.2,0c1.5-0.7,3-1.5,4.4-2.4c0.1,0,0.1,0,0.2-0.1c0.1,0,0.1,0,0.2,0s0.1,0,0.2,0.1   c0.1,0,0.1,0.1,0.1,0.1s0.1,0.1,0.1,0.2c0,0.1,0,0.1,0,0.2c0,0.1,0,0.1-0.1,0.2l-0.1,0.1C1510.5,837.5,1508.1,838.9,1507.5,838.9   L1507.5,838.9z"
+   id="path1566" />
+	<path
+   class="st92"
+   d="M1507.6,840.5L1507.6,840.5c-0.2,0-0.3-0.1-0.4-0.2c-0.1-0.1-0.1-0.2-0.1-0.4c0-0.1,0.1-0.2,0.2-0.3   s0.2-0.1,0.4-0.1c0.5,0,3.9-1.8,6.8-3.5c0.1,0,0.1-0.1,0.2-0.1s0.1,0,0.2,0s0.1,0,0.2,0.1c0.1,0,0.1,0.1,0.1,0.2   c0,0.1,0.1,0.1,0.1,0.2c0,0.1,0,0.1,0,0.2c0,0.1-0.1,0.1-0.1,0.2c-0.1,0-0.1,0.1-0.2,0.1C1512.1,838.5,1508.7,840.5,1507.6,840.5   L1507.6,840.5z"
+   id="path1568" />
+	<path
+   class="st92"
+   d="M1507.6,842.1L1507.6,842.1c-0.1,0-0.2,0-0.3,0c-0.1,0-0.1-0.1-0.2-0.1s-0.1-0.1-0.1-0.2c0-0.1,0-0.1,0-0.2   c0-0.1,0-0.1,0.1-0.2c0-0.1,0.1-0.1,0.1-0.2c0.1,0,0.1-0.1,0.2-0.1s0.1,0,0.2,0c1.1,0.1,5.7-2.9,8.3-4.7c0.1-0.1,0.2-0.1,0.4-0.1   c0.1,0,0.2,0.1,0.3,0.2c0,0,0.1,0.1,0.1,0.2s0,0.1,0,0.2c0,0.1,0,0.1-0.1,0.2l-0.1,0.1C1515.3,838,1509.5,842.1,1507.6,842.1   L1507.6,842.1z"
+   id="path1570" />
+	<path
+   class="st92"
+   d="M1504.3,818.1c-0.1,0-0.1,0-0.2,0c-0.4-0.2-0.9-0.8-1-1.1c0-0.1-0.1-0.1-0.1-0.2s0-0.1,0-0.2   c0-0.1,0-0.1,0.1-0.2l0.1-0.1c0.1,0,0.1-0.1,0.2-0.1s0.1,0,0.2,0s0.1,0,0.2,0.1c0.1,0,0.1,0.1,0.1,0.2c0.1,0.2,0.3,0.5,0.5,0.7   c0.1,0,0.2,0.1,0.3,0.2s0.1,0.2,0,0.4c0,0.1-0.1,0.2-0.2,0.2S1504.4,818.1,1504.3,818.1L1504.3,818.1z"
+   id="path1572" />
+	<path
+   class="st92"
+   d="M1502.3,821.9c-0.1,0-0.1,0-0.2,0c-0.8-0.4-2-2.3-2.2-2.7c0-0.1-0.1-0.1-0.1-0.2c0-0.1,0-0.1,0-0.2   c0-0.1,0-0.1,0.1-0.2c0,0,0.1-0.1,0.2-0.1s0.1-0.1,0.2-0.1s0.1,0,0.2,0s0.1,0,0.2,0.1c0.1,0,0.1,0.1,0.1,0.2   c0.5,0.8,1.4,2.2,1.8,2.3c0.1,0,0.2,0.1,0.2,0.2c0.1,0.1,0.1,0.2,0,0.3s-0.1,0.2-0.2,0.3C1502.5,821.9,1502.4,822,1502.3,821.9   L1502.3,821.9L1502.3,821.9z"
+   id="path1574" />
+	<path
+   class="st92"
+   d="M1500.9,825.3c-0.1,0-0.1,0-0.2,0c-0.8-0.3-2.8-2.9-3.6-4.1c0,0-0.1-0.1-0.1-0.2c0-0.1,0-0.1,0-0.2   c0-0.1,0-0.1,0.1-0.2l0.1-0.1c0.1-0.1,0.2-0.1,0.4-0.1c0.1,0,0.2,0.1,0.3,0.2c1.2,1.7,2.8,3.5,3.2,3.7c0.1,0,0.2,0.1,0.3,0.2   c0.1,0.1,0.1,0.2,0,0.4c0,0.1-0.1,0.2-0.2,0.2C1501.1,825.3,1501,825.3,1500.9,825.3L1500.9,825.3z"
+   id="path1576" />
+	<path
+   class="st92"
+   d="M1500.3,826.8c-0.1,0-0.2,0-0.3-0.1c-1.3-1.4-2.6-2.8-3.8-4.3c-0.1-0.1-0.1-0.2-0.1-0.3s0.1-0.2,0.2-0.3   c0.1,0,0.1-0.1,0.2-0.1s0.1,0,0.2,0s0.1,0,0.2,0.1c0.1,0,0.1,0.1,0.1,0.1c1.2,1.5,2.4,2.9,3.7,4.2c0.1,0.1,0.1,0.2,0.1,0.2   s0,0.2,0,0.3s-0.1,0.2-0.2,0.2S1500.4,826.8,1500.3,826.8L1500.3,826.8L1500.3,826.8z"
+   id="path1578" />
+	<path
+   class="st92"
+   d="M1499.2,829.2L1499.2,829.2c-1.3-0.2-4.8-3.8-5.8-4.9c-0.1-0.1-0.1-0.2-0.1-0.3s0.1-0.2,0.1-0.3   s0.2-0.1,0.3-0.1s0.2,0,0.3,0.1c2,2.2,4.5,4.5,5.1,4.7c0.1,0,0.1,0,0.2,0s0.1,0.1,0.2,0.1s0.1,0.1,0.1,0.2s0,0.1,0,0.2   c0,0.1,0,0.1-0.1,0.2s-0.1,0.1-0.1,0.2c-0.1,0-0.1,0.1-0.2,0.1S1499.3,829.2,1499.2,829.2L1499.2,829.2L1499.2,829.2z"
+   id="path1580" />
+	<path
+   class="st92"
+   d="M1498.1,830.9c-0.1,0-0.2,0-0.2-0.1c-0.9-0.5-4.5-4.3-5.2-5.1c-0.1-0.1-0.1-0.2-0.1-0.3s0.1-0.2,0.2-0.3   s0.2-0.1,0.3-0.1s0.2,0.1,0.3,0.2c1.6,1.7,4.4,4.6,5,4.9c0.1,0,0.2,0.1,0.2,0.2c0.1,0.1,0.1,0.2,0,0.3s-0.1,0.2-0.2,0.3   C1498.3,830.9,1498.2,830.9,1498.1,830.9L1498.1,830.9L1498.1,830.9z"
+   id="path1582" />
+	<path
+   class="st92"
+   d="M1489.9,829.5L1489.9,829.5c-0.2,0-0.2,0-0.3,0s-0.1-0.1-0.1-0.1s-0.1-0.1-0.1-0.2s0-0.1,0-0.2   c0-0.1,0.1-0.2,0.2-0.3s0.2-0.1,0.3-0.1c0.3,0,2.1-0.2,3.7-0.4c0.1,0,0.1,0,0.2,0s0.1,0,0.2,0.1c0.1,0,0.1,0.1,0.1,0.1   c0,0.1,0.1,0.1,0.1,0.2c0,0.1,0,0.3-0.1,0.4c-0.1,0.1-0.2,0.2-0.3,0.2C1493,829.2,1490.6,829.5,1489.9,829.5L1489.9,829.5z"
+   id="path1584" />
+	<path
+   class="st92"
+   d="M1488.6,831.2L1488.6,831.2c-0.2,0-0.3-0.1-0.4-0.2c-0.1-0.1-0.1-0.2-0.1-0.3s0-0.1,0-0.2   c0-0.1,0.1-0.1,0.1-0.2s0.1-0.1,0.2-0.1s0.1,0,0.2,0c0.8,0,4.9-0.5,6.4-0.7c0.1,0,0.2,0,0.3,0.1c0.1,0.1,0.2,0.2,0.2,0.3   s0,0.2-0.1,0.3s-0.2,0.2-0.3,0.2C1494.8,830.5,1489.8,831.2,1488.6,831.2L1488.6,831.2z"
+   id="path1586" />
+	<path
+   class="st92"
+   d="M1488.5,834.4c-0.1,0-0.2,0-0.3-0.1c-0.1-0.1-0.1-0.2-0.2-0.2c0-0.1,0-0.1,0-0.2c0-0.1,0-0.1,0.1-0.2   c0-0.1,0.1-0.1,0.1-0.2c0.1,0,0.1-0.1,0.2-0.1c1.4-0.5,6.2-1.1,8.6-1.4c0.6-0.1,1-0.1,1.1-0.2l0.1,0.5l0.4,0.2   c-0.1,0.1-0.6,0.3-1.5,0.4c-2.1,0.3-7.1,1-8.4,1.4C1488.6,834.4,1488.6,834.4,1488.5,834.4L1488.5,834.4z"
+   id="path1588" />
+	<path
+   class="st92"
+   d="M1489.3,835.9c-0.1,0-0.2,0-0.3-0.1s-0.2-0.2-0.2-0.3s0-0.2,0.1-0.3s0.2-0.2,0.3-0.2c1.3-0.4,8-1.5,8.3-1.5   c0.1,0,0.1,0,0.2,0s0.1,0,0.2,0.1c0.1,0,0.1,0.1,0.1,0.1s0.1,0.1,0.1,0.2c0,0.1,0,0.3-0.1,0.4s-0.2,0.2-0.3,0.2   c-0.1,0-6.9,1.1-8.2,1.5C1489.4,835.9,1489.3,835.9,1489.3,835.9L1489.3,835.9z"
+   id="path1590" />
+	<path
+   class="st92"
+   d="M1489.8,837.4c-0.1,0-0.2-0.1-0.3-0.2c-0.1-0.1-0.1-0.2-0.1-0.3s0-0.2,0.1-0.3s0.2-0.2,0.3-0.2   c1.5-0.1,7-1,7.1-1s0.3,0,0.4,0.1s0.2,0.2,0.2,0.3s0,0.1,0,0.2c0,0.1,0,0.1-0.1,0.2l-0.1,0.1c-0.1,0-0.1,0-0.2,0.1   C1496.8,836.4,1491.4,837.3,1489.8,837.4L1489.8,837.4L1489.8,837.4z"
+   id="path1592" />
+	<path
+   class="st92"
+   d="M1490.8,839.2c-0.4,0-0.5-0.1-0.6-0.2c-0.1-0.1-0.1-0.2-0.1-0.3s0-0.2,0.1-0.3s0.2-0.2,0.3-0.2s0.2,0,0.3,0   c2-0.2,4.1-0.6,6-1.1c0.1,0,0.2,0,0.4,0.1c0.1,0.1,0.2,0.2,0.2,0.3s0,0.3-0.1,0.4c-0.1,0.1-0.2,0.2-0.3,0.2   C1493.2,839,1491.6,839.2,1490.8,839.2L1490.8,839.2z"
+   id="path1594" />
+	<path
+   class="st92"
+   d="M1491.2,841.2c-0.1,0-0.2,0-0.3-0.1c-0.1-0.1-0.2-0.2-0.2-0.3s0-0.2,0-0.3s0.1-0.2,0.2-0.2s0.2-0.1,0.3,0   c1.8-0.4,3.5-0.9,5.2-1.5c0.1,0,0.1,0,0.2,0s0.1,0,0.2,0s0.1,0.1,0.2,0.1s0.1,0.1,0.1,0.2s0,0.1,0,0.2c0,0.1,0,0.1-0.1,0.2   c0,0.1-0.1,0.1-0.1,0.2c-0.1,0-0.1,0.1-0.2,0.1C1492.8,840.9,1491.6,841.2,1491.2,841.2L1491.2,841.2z"
+   id="path1596" />
+	<path
+   class="st92"
+   d="M1492.5,842.8c-0.1,0-0.2-0.1-0.3-0.2c-0.1-0.1-0.1-0.2-0.1-0.3s0-0.2,0.1-0.3s0.2-0.2,0.3-0.2   c1.3-0.3,2.6-0.8,3.8-1.3c0.1,0,0.2,0,0.3,0.1c0.1,0,0.2,0.1,0.2,0.2c0,0.1,0.1,0.2,0,0.3c0,0.1-0.1,0.2-0.2,0.3   C1495.9,841.7,1493.2,842.8,1492.5,842.8L1492.5,842.8z"
+   id="path1598" />
+	<path
+   class="st92"
+   d="M1493.7,844.6c-0.1,0-0.2,0-0.3-0.1s-0.1-0.1-0.2-0.2c-0.1-0.1-0.1-0.2,0-0.4s0.1-0.2,0.2-0.3l2.9-1.3   c0.1,0,0.1,0,0.2,0s0.1,0,0.2,0s0.1,0.1,0.2,0.1s0.1,0.1,0.1,0.2c0,0.1,0.1,0.1,0.1,0.2c0,0.1,0,0.1,0,0.2c0,0.1-0.1,0.1-0.1,0.2   c-0.1,0-0.1,0.1-0.2,0.1l-2.9,1.3C1493.8,844.6,1493.7,844.6,1493.7,844.6L1493.7,844.6z"
+   id="path1600" />
+	<path
+   class="st92"
+   d="M1487.9,832.8c-0.1,0-0.2,0-0.3-0.1c-0.1-0.1-0.1-0.2-0.2-0.3c0-0.1,0-0.2,0.1-0.3s0.2-0.2,0.3-0.2l8.6-1.2   c0.1,0,0.2,0,0.3,0.1c0.1,0.1,0.2,0.2,0.2,0.3s0,0.2-0.1,0.3s-0.2,0.2-0.3,0.2L1487.9,832.8L1487.9,832.8L1487.9,832.8z"
+   id="path1602" />
+	<path
+   class="st92"
+   d="M1490.6,820c-0.1,0-0.2,0-0.3-0.1c-0.1,0-0.1-0.1-0.1-0.2s-0.1-0.1-0.1-0.2s0-0.1,0-0.2s0.1-0.1,0.1-0.2   c4.1-5,9.8-8.3,16.2-9.4c0.1,0,0.1,0,0.2,0s0.1,0,0.2,0.1c0.1,0,0.1,0.1,0.1,0.1c0,0.1,0.1,0.1,0.1,0.2c0,0.1,0,0.1,0,0.2   s-0.1,0.1-0.1,0.2l-0.1,0.1c-0.1,0-0.1,0-0.2,0.1c-6.1,1.1-11.6,4.3-15.5,9c-0.1,0-0.1,0.1-0.2,0.1   C1490.7,820,1490.6,820,1490.6,820L1490.6,820z"
+   id="path1604" />
+	<path
+   class="st92"
+   d="M1525.8,835.9c-0.1,0-0.1,0-0.2,0s-0.1-0.1-0.2-0.1s-0.1-0.1-0.1-0.2c0-0.1,0-0.1,0-0.2   c0-14.1-8.1-20.4-8.2-20.5s-0.2-0.2-0.2-0.3s0-0.3,0.1-0.4l0.1-0.1c0.1,0,0.1,0,0.2-0.1c0.1,0,0.1,0,0.2,0s0.1,0,0.2,0.1   c0.4,0.3,8.6,6.7,8.6,21.2c0,0.1-0.1,0.2-0.1,0.3S1526,835.9,1525.8,835.9L1525.8,835.9z"
+   id="path1606" />
+	<path
+   class="st92"
+   d="M1501.3,823.4c-0.1,0-0.1,0-0.2,0s-0.1-0.1-0.2-0.1c-0.5-0.5-2.4-2.7-2.4-2.7l0.7-0.6c0,0,1.9,2.2,2.4,2.7   c0.1,0.1,0.1,0.2,0.1,0.3s-0.1,0.2-0.1,0.3c-0.1,0-0.1,0.1-0.2,0.1C1501.4,823.4,1501.4,823.4,1501.3,823.4L1501.3,823.4z"
+   id="path1608" />
+	<path
+   class="st92"
+   d="M1499.2,827.5c-0.1,0-0.2,0-0.3-0.1c-1.3-1.2-2.6-2.4-3.7-3.8c-0.1-0.1-0.1-0.2-0.1-0.3s0.1-0.2,0.1-0.3   s0.2-0.1,0.3-0.1s0.2,0,0.3,0.1c1.1,1.3,2.3,2.5,3.6,3.6c0.1,0.1,0.2,0.2,0.2,0.3s0,0.3-0.1,0.4c0,0.1-0.1,0.1-0.2,0.2   S1499.3,827.5,1499.2,827.5L1499.2,827.5z"
+   id="path1610" />
+	<path
+   class="st92"
+   d="M1503.1,820.7c-0.1,0-0.1,0-0.2,0s-0.4-0.2-2.2-2.3c-0.1-0.1-0.1-0.2-0.1-0.3s0.1-0.2,0.2-0.3   s0.2-0.1,0.3-0.1s0.2,0,0.3,0.1c0.6,0.7,1.2,1.4,1.8,2c0.1,0,0.1,0.1,0.2,0.1s0.1,0.1,0.1,0.2c0,0.1,0,0.1,0,0.2s0,0.1,0,0.2   c0,0.1-0.1,0.2-0.2,0.2C1503.3,820.6,1503.2,820.7,1503.1,820.7L1503.1,820.7z"
+   id="path1612" />
+	<path
+   class="st92"
+   d="M1503.6,819.6c-0.1,0-0.1,0-0.2,0c-0.6-0.4-1.2-1-1.5-1.7c0,0-0.1-0.1-0.1-0.2c0-0.1,0-0.1,0-0.2   c0-0.1,0-0.1,0.1-0.2c0-0.1,0.1-0.1,0.1-0.1c0.1,0,0.1-0.1,0.2-0.1s0.1,0,0.2,0s0.1,0,0.2,0.1c0.1,0,0.1,0.1,0.1,0.2   c0.3,0.5,0.7,0.9,1.1,1.3c0.1,0,0.1,0,0.2,0.1c0.1,0,0.1,0.1,0.1,0.2s0,0.1,0,0.2s0,0.1,0,0.2c0,0.1-0.1,0.2-0.2,0.2   C1503.8,819.6,1503.7,819.6,1503.6,819.6L1503.6,819.6z"
+   id="path1614" />
+	<path
+   class="st92"
+   d="M1491.1,827.9c-0.1,0-0.2,0-0.3-0.1c-0.1-0.1-0.1-0.2-0.2-0.3c0-0.1,0-0.2,0.1-0.4s0.2-0.2,0.3-0.2l1.9-0.4   c0.1,0,0.1,0,0.2,0s0.1,0,0.2,0.1s0.1,0.1,0.1,0.1s0.1,0.1,0.1,0.2c0,0.1,0,0.1,0,0.2s0,0.1-0.1,0.2l-0.1,0.1   c-0.1,0-0.1,0.1-0.2,0.1L1491.1,827.9L1491.1,827.9L1491.1,827.9z"
+   id="path1616" />
+	<path
+   class="st92"
+   d="M1517.8,828.4c-0.1,0-0.1,0-0.2,0c-0.4-0.2-3.6-1-5.6-1.6c-0.1,0-0.2-0.1-0.3-0.2c-0.1-0.1-0.1-0.2-0.1-0.4   c0-0.1,0-0.1,0.1-0.2l0.1-0.1c0,0,0.1,0,0.2-0.1c0.1,0,0.1,0,0.2,0c0.5,0.1,5.1,1.3,5.7,1.6c0.1,0,0.2,0.1,0.3,0.2   c0.1,0.1,0.1,0.2,0.1,0.3s-0.1,0.2-0.2,0.3C1518.1,828.3,1517.9,828.4,1517.8,828.4L1517.8,828.4z"
+   id="path1618" />
+	<path
+   class="st92"
+   d="M1516.7,826.5c-0.1,0-0.2,0-0.3-0.1c-0.2-0.1-2.2-0.6-4-1.1c-0.1,0-0.1,0-0.2-0.1c-0.1,0-0.1-0.1-0.2-0.1   s-0.1-0.1-0.1-0.2c0-0.1,0-0.1,0-0.2c0-0.1,0.1-0.1,0.1-0.2c0,0,0.1-0.1,0.2-0.1s0.1,0,0.2-0.1c0.1,0,0.1,0,0.2,0   c1.5,0.3,2.9,0.7,4.3,1.2c0.1,0.1,0.2,0.1,0.2,0.2s0,0.2,0,0.3s-0.1,0.2-0.2,0.2C1516.8,826.4,1516.7,826.5,1516.7,826.5   L1516.7,826.5z"
+   id="path1620" />
+	<path
+   class="st92"
+   d="M1514.6,822.9c0.2,0,0.4-0.2,0.4-0.4s-0.2-0.4-0.4-0.4s-0.4,0.2-0.4,0.4S1514.3,822.9,1514.6,822.9z"
+   id="path1622" />
+	<path
+   class="st92"
+   d="M1505,816.5c0.3,0,0.5-0.1,0.5-0.3s-0.2-0.3-0.5-0.3s-0.5,0.1-0.5,0.3S1504.7,816.5,1505,816.5z"
+   id="path1624" />
+	<path
+   class="st92"
+   d="M1494.9,845.5c-0.1,0-0.2,0-0.3-0.1c-0.1-0.1-0.1-0.2-0.2-0.3c0-0.1,0-0.2,0.1-0.3s0.1-0.2,0.2-0.2l1.2-0.5   c0.1,0,0.2,0,0.4,0c0.1,0,0.2,0.2,0.2,0.3s0,0.1,0,0.2c0,0.1,0,0.1,0,0.2c0,0.1-0.1,0.1-0.1,0.2c-0.1,0-0.1,0.1-0.2,0.1l-1.2,0.5   C1495.1,845.5,1495,845.5,1494.9,845.5L1494.9,845.5z"
+   id="path1626" />
+	<path
+   class="st92"
+   d="M1497.5,846.5c0.3-0.2,0.4-0.5,0.3-0.6s-0.4-0.1-0.7,0.1c-0.3,0.2-0.4,0.5-0.3,0.6S1497.2,846.7,1497.5,846.5   z"
+   id="path1628" />
+	<path
+   class="st92"
+   d="M1507.1,844c-0.1,0-0.2,0-0.3-0.1s-0.1-0.2-0.2-0.3c0-0.1,0-0.2,0-0.3c0.1-0.1,0.1-0.2,0.2-0.2   c2.6-1.2,9.4-4.5,10.6-5.7c0,0,0.1-0.1,0.2-0.1s0.1,0,0.2,0s0.1,0,0.2,0s0.1,0.1,0.2,0.1s0.1,0.1,0.1,0.2s0,0.1,0,0.2   c0,0.1,0,0.1,0,0.2c0,0.1-0.1,0.1-0.1,0.2c-1.5,1.7-9.9,5.5-10.9,6C1507.2,844,1507.1,844,1507.1,844L1507.1,844z"
+   id="path1630" />
+	<path
+   class="st92"
+   d="M1506.7,846.3c-0.1,0-0.2,0-0.3-0.1c-0.1-0.1-0.1-0.2-0.2-0.3c0-0.1,0-0.2,0-0.3c0.1-0.1,0.1-0.2,0.2-0.2   c3-1.3,10.9-5.2,12.1-7.2c0-0.1,0.1-0.1,0.1-0.2c0.1,0,0.1-0.1,0.2-0.1s0.1,0,0.2,0s0.1,0,0.2,0.1c0.1,0,0.1,0.1,0.2,0.1   s0.1,0.1,0.1,0.2s0,0.1,0,0.2c0,0.1,0,0.1-0.1,0.2c-1.5,2.6-11.4,7.1-12.5,7.6C1506.8,846.3,1506.8,846.3,1506.7,846.3   L1506.7,846.3z"
+   id="path1632" />
+	<path
+   class="st92"
+   d="M1506.7,847.9c-0.1,0-0.2,0-0.2-0.1c-0.1,0-0.1-0.1-0.2-0.2c0-0.1-0.1-0.1-0.1-0.2c0-0.1,0-0.1,0-0.2   s0.1-0.1,0.1-0.2c0,0,0.1-0.1,0.2-0.1c5.6-2.7,11.7-6.1,12.1-6.9c0-0.1,0.1-0.1,0.1-0.2c0.1,0,0.1-0.1,0.2-0.1s0.1,0,0.2,0   s0.1,0,0.2,0s0.2,0.2,0.2,0.3s0,0.2,0,0.4c-0.7,1.6-10.6,6.5-12.5,7.5C1506.8,847.9,1506.8,847.9,1506.7,847.9L1506.7,847.9z"
+   id="path1634" />
+	<path
+   class="st92"
+   d="M1507.1,849.1c-0.1,0-0.2,0-0.3-0.1c-0.1-0.1-0.1-0.2-0.2-0.3c0-0.1,0-0.2,0.1-0.3s0.1-0.2,0.2-0.2   c4.5-1.9,11.2-5,11.6-6.1c0.1-0.1,0.2-0.2,0.3-0.3s0.2,0,0.4,0c0.1,0,0.2,0.2,0.2,0.3c0.1,0.1,0,0.2,0,0.4   C1518.6,844.4,1509.1,848.3,1507.1,849.1C1507.2,849.1,1507.1,849.1,1507.1,849.1L1507.1,849.1z"
+   id="path1636" />
+	<path
+   class="st92"
+   d="M1508.6,849.9c-0.1,0-0.2,0-0.3-0.1c-0.1-0.1-0.1-0.2-0.2-0.3c0-0.1,0-0.2,0.1-0.3s0.1-0.2,0.2-0.2   c4.4-1.8,9.3-3.9,9.8-4.4c0-0.1,0.1-0.1,0.1-0.2c0.1,0,0.1-0.1,0.2-0.1s0.1,0,0.2,0s0.1,0,0.2,0.1c0.1,0,0.1,0.1,0.1,0.1   s0.1,0.1,0.1,0.2c0,0.1,0,0.1,0,0.2c0,0.1,0,0.1-0.1,0.2c-0.5,0.9-7.3,3.7-10.2,4.8C1508.7,849.9,1508.7,849.9,1508.6,849.9   L1508.6,849.9z"
+   id="path1638" />
+	<path
+   class="st92"
+   d="M1526.6,831.1c-0.1,0-0.2,0-0.3-0.1c-0.1-0.1-0.2-0.2-0.2-0.3c-1.9-11.7-6.3-15.1-6.7-15.4   c-0.1,0-0.2-0.1-0.2-0.2c-0.1-0.1-0.1-0.2-0.1-0.3s0-0.2,0.1-0.3s0.2-0.2,0.3-0.2c0.7,0,5.7,4.1,7.6,16.2c0,0.1,0,0.3-0.1,0.4   S1526.8,831.1,1526.6,831.1L1526.6,831.1L1526.6,831.1z"
+   id="path1640" />
+	<path
+   class="st78"
+   d="M1507.1,809.7c4,0,7.8,1.2,11.2,3.4c3.3,2.2,5.9,5.4,7.4,9.1s1.9,7.8,1.1,11.7s-2.7,7.5-5.5,10.4   c-2.8,2.8-6.4,4.8-10.3,5.5c-3.9,0.8-7.9,0.4-11.6-1.2c-3.7-1.5-6.8-4.1-9-7.5c-2.2-3.3-3.4-7.2-3.4-11.2c0-5.4,2.1-10.5,5.9-14.3   S1501.7,809.7,1507.1,809.7L1507.1,809.7z M1507.1,807.3c-4.4,0-8.8,1.3-12.5,3.8s-6.6,6-8.3,10.2s-2.2,8.7-1.3,13.1   c0.9,4.4,3,8.4,6.2,11.6c3.1,3.2,7.2,5.3,11.5,6.2s8.9,0.4,13-1.3s7.6-4.6,10.1-8.4c2.5-3.7,3.8-8.1,3.8-12.6c0-6-2.4-11.8-6.6-16   C1518.7,809.7,1513,807.3,1507.1,807.3L1507.1,807.3z"
+   id="path1642" />
+</g>
+<g
+   id="g1683">
+	<g
+   id="path14-2">
+		<path
+   class="st93"
+   d="M410.7,830.3c-4.3,0-6.4,1.7-8.8,3.6c-2.6,2.1-5.6,4.4-11.3,4.4s-8.7-2.4-11.3-4.4c-2.4-1.9-4.5-3.6-8.8-3.6    s-6.4,1.7-8.8,3.6c-2.6,2.1-5.6,4.4-11.3,4.4s-8.7-2.4-11.3-4.4c-2.4-1.9-4.5-3.6-8.8-3.6s-6.4,1.7-8.8,3.6    c-1.9,1.6-4,2.9-6.4,3.7c11.2,9.9,25.4,15.9,40.3,17.2c0.4,0,0.8,0.1,1.3,0.1c1.5,0.1,3,0.2,4.5,0.2s3-0.1,4.5-0.2    c0.4,0,0.8-0.1,1.3-0.1c18.3-1.5,35.2-10.2,47.2-24.1C412.9,830.4,411.8,830.3,410.7,830.3"
+   id="path1646" />
+	</g>
+	<g
+   id="path16">
+		<path
+   class="st93"
+   d="M309.9,778.1c4.7,0,7.1-1.8,9.5-3.8c2.6-2.1,5.3-4.2,10.6-4.2s8,2.1,10.6,4.2c2.5,2,4.8,3.8,9.5,3.8    s7.1-1.8,9.5-3.8c2.6-2.1,5.3-4.2,10.7-4.2s8,2.1,10.6,4.2c2.5,2,4.8,3.8,9.5,3.8s7.1-1.8,9.5-3.8c2.6-2.1,5.3-4.2,10.7-4.2    s8,2.1,10.7,4.2c2.4,1.9,4.7,3.7,9.3,3.8c-0.6-6.3-2.1-12.4-4.4-18.3c-2.1-0.8-4.1-1.9-5.8-3.4c-2.5-2-4.9-3.9-9.7-3.9    s-7.2,1.9-9.7,3.9c-2.6,2-5.2,4.1-10.4,4.1s-7.9-2.1-10.4-4.1s-4.9-3.9-9.7-3.9s-7.2,1.9-9.7,3.9c-2.6,2-5.2,4.1-10.4,4.1    s-7.9-2.1-10.4-4.1s-4.9-3.9-9.7-3.9s-7.2,1.9-9.7,3.9c-2.6,2-5.2,4.1-10.4,4.1s-7.9-2.1-10.4-4.1c-0.6-0.4-1.1-0.9-1.7-1.3    c-2.3,4.9-4.1,10-5.2,15.3c3.6,0.6,5.7,2.3,7.8,4C302.8,776.2,305.2,778.1,309.9,778.1"
+   id="path1649" />
+	</g>
+	<g
+   id="path18">
+		<path
+   class="st93"
+   d="M309.9,759.3c4.9,0,7.2-1.9,9.7-3.9c2.6-2,5.2-4.1,10.4-4.1s7.9,2.1,10.5,4.2c2.5,2,4.9,3.9,9.7,3.9    s7.2-1.9,9.7-3.9c2.6-2,5.2-4.1,10.4-4.1s7.9,2.1,10.4,4.1s4.9,3.9,9.7,3.9s7.2-1.9,9.7-3.9c2.6-2,5.2-4.1,10.4-4.1    s7.9,2.1,10.4,4.1c1.4,1.2,2.9,2.2,4.6,2.9c-14.5-35.8-55.4-52.8-91.1-38.1c-15.8,6.5-28.6,18.5-36.1,33.8c0.7,0.5,1.3,1,1.9,1.4    C302.7,757.5,305,759.3,309.9,759.3"
+   id="path1652" />
+	</g>
+	<g
+   id="path20">
+		<path
+   class="st93"
+   d="M410.7,810.8c-4.5,0-6.6,1.7-9.1,3.6c-2.6,2-5.5,4.4-11.1,4.4s-8.5-2.3-11.1-4.4c-2.5-2-4.6-3.6-9.1-3.6    s-6.6,1.7-9.1,3.6c-2.6,2-5.5,4.4-11.1,4.4s-8.5-2.3-11.1-4.4c-2.5-2-4.6-3.6-9.1-3.6s-6.6,1.7-9.1,3.6c-2.6,2-5.5,4.4-11.1,4.4    s-8.5-2.3-11.1-4.4c-0.7-0.5-1.3-1-1.9-1.5c3.5,7.9,8.4,15.1,14.4,21.2c3.4-0.3,5.3-1.8,7.5-3.5c2.6-2.1,5.6-4.4,11.3-4.4    s8.7,2.4,11.3,4.4c2.4,1.9,4.5,3.6,8.8,3.6s6.4-1.7,8.8-3.6c2.6-2.1,5.6-4.4,11.3-4.4s8.7,2.4,11.3,4.4c2.4,1.9,4.5,3.6,8.8,3.6    s6.4-1.7,8.8-3.6c2.6-2.1,5.6-4.4,11.3-4.4c2,0,4.1,0.3,5.9,1.1c2.5-3.3,4.7-6.8,6.6-10.4c-1.2-0.7-2.4-1.5-3.5-2.4    C417.3,812.5,415.2,810.8,410.7,810.8"
+   id="path1655" />
+	</g>
+	<g
+   id="path22">
+		<path
+   class="st93"
+   d="M430.8,779.9c-5.3,0-8-2.1-10.5-4.2c-2.5-2-4.8-3.8-9.5-3.8s-7.1,1.8-9.5,3.8c-2.6,2.1-5.3,4.2-10.6,4.2    s-8-2.1-10.7-4.2c-2.5-2-4.8-3.8-9.5-3.8s-7.1,1.8-9.5,3.8c-2.6,2.1-5.3,4.2-10.7,4.2s-8-2.1-10.6-4.2c-2.5-2-4.8-3.8-9.5-3.8    s-7.1,1.8-9.5,3.8c-2.6,2.1-5.3,4.2-10.6,4.2s-8-2.1-10.6-4.2c-2-1.6-3.9-3.1-7-3.6c-0.6,3.4-1,6.8-1.1,10.2    c0,0.9-0.1,1.8-0.1,2.7s0,1.8,0.1,2.7v1.2c4.6,0.4,7.2,2.4,9.5,4.2c2.4,1.9,4.7,3.7,9.3,3.7s6.9-1.8,9.3-3.7    c2.5-2,5.4-4.3,10.9-4.3s8.3,2.3,10.9,4.3c2.4,1.9,4.7,3.7,9.3,3.7s6.9-1.8,9.3-3.7c2.5-2,5.4-4.3,10.9-4.3s8.3,2.3,10.9,4.3    c2.4,1.9,4.7,3.7,9.3,3.7s6.9-1.8,9.3-3.7c2.5-2,5.4-4.3,10.9-4.3s8.3,2.3,10.9,4.3c2.2,1.8,4.4,3.5,8.4,3.7    c0.4-2.1,0.6-4.3,0.8-6.5c0.1-0.9,0.1-1.7,0.2-2.6v-5.4C430.9,781.4,430.8,779.9,430.8,779.9"
+   id="path1658" />
+	</g>
+	<g
+   id="path24">
+		<path
+   class="st93"
+   d="M410.7,791.4c-4.6,0-6.9,1.8-9.3,3.7c-2.5,2-5.4,4.3-10.9,4.3s-8.3-2.3-10.9-4.3c-2.4-1.9-4.7-3.7-9.3-3.7    s-6.9,1.8-9.3,3.7c-2.5,2-5.4,4.3-10.9,4.3s-8.3-2.3-10.9-4.3c-2.4-1.9-4.7-3.7-9.3-3.7s-6.9,1.8-9.3,3.7c-2.5,2-5.4,4.3-10.9,4.3    s-8.3-2.3-10.9-4.3c-2.1-1.7-4.1-3.3-7.7-3.6c0.5,5.8,1.8,11.5,3.7,17c2.1,0.8,4.1,2,5.8,3.5c2.5,2,4.6,3.6,9.1,3.6    s6.6-1.7,9.1-3.6c2.6-2,5.5-4.4,11.1-4.4s8.5,2.3,11.1,4.4c2.5,2,4.6,3.6,9.1,3.6s6.6-1.7,9.1-3.6c2.6-2,5.5-4.4,11.1-4.4    s8.5,2.3,11.1,4.4c2.5,2,4.6,3.6,9.1,3.6s6.6-1.7,9.1-3.6c2.6-2,5.5-4.4,11.1-4.4s8.5,2.3,11.1,4.4c0.9,0.8,1.9,1.4,2.9,2.1    c2.2-4.7,3.8-9.6,4.8-14.7c-4.6-0.3-7.2-2.4-9.5-4.2C417.6,793.2,415.3,791.4,410.7,791.4"
+   id="path1661" />
+	</g>
+	<g
+   id="path26">
+		<path
+   class="st3"
+   d="M399.4,830.7c-2.4,1.9-4.5,3.6-8.8,3.6s-6.4-1.7-8.8-3.6c-2.6-2.1-5.6-4.4-11.3-4.4s-8.7,2.4-11.3,4.4    c-2.4,1.9-4.5,3.6-8.8,3.6s-6.4-1.7-8.8-3.6c-2.6-2.1-5.6-4.4-11.3-4.4s-8.7,2.4-11.3,4.4c-2.1,1.7-4,3.2-7.5,3.5    c1.1,1.2,2.3,2.3,3.6,3.3c2.3-0.8,4.5-2.1,6.4-3.7c2.4-1.9,4.5-3.6,8.8-3.6s6.4,1.7,8.8,3.6c2.6,2.1,5.6,4.4,11.3,4.4    s8.7-2.4,11.3-4.4c2.4-1.9,4.5-3.6,8.8-3.6s6.4,1.7,8.8,3.6c2.6,2.1,5.6,4.4,11.3,4.4s8.7-2.4,11.3-4.4c2.4-1.9,4.5-3.6,8.8-3.6    c1.1,0,2.2,0.1,3.2,0.4c0.9-1.1,1.8-2.2,2.7-3.3c-1.9-0.7-3.9-1.1-5.9-1.1C405,826.3,402,828.6,399.4,830.7"
+   id="path1664" />
+	</g>
+	<g
+   id="g1669">
+		<path
+   class="st3"
+   d="M410.7,807.6c-5.6,0-8.5,2.3-11.1,4.4c-2.5,2-4.6,3.6-9.1,3.6s-6.6-1.7-9.1-3.6c-2.6-2-5.5-4.4-11.1-4.4    s-8.5,2.3-11.1,4.4c-2.5,2-4.6,3.6-9.1,3.6s-6.6-1.7-9.1-3.6c-2.6-2-5.5-4.4-11.1-4.4s-8.5,2.3-11.1,4.4c-2.5,2-4.6,3.6-9.1,3.6    s-6.6-1.7-9.1-3.6c-1.7-1.5-3.7-2.7-5.8-3.5c0.6,1.6,1.2,3.1,1.8,4.6c0.7,0.5,1.3,0.9,1.9,1.5c2.6,2,5.5,4.4,11.1,4.4    s8.5-2.3,11.1-4.4c2.5-2,4.6-3.6,9.1-3.6s6.6,1.7,9.1,3.6c2.6,2,5.5,4.4,11.1,4.4s8.5-2.3,11.1-4.4c2.5-2,4.6-3.6,9.1-3.6    s6.6,1.7,9.1,3.6c2.6,2,5.5,4.4,11.1,4.4s8.5-2.3,11.1-4.4c2.5-2,4.6-3.6,9.1-3.6s6.6,1.7,9.1,3.6c1.1,0.9,2.3,1.7,3.5,2.4    c0.5-1,1-1.9,1.4-2.9c-1-0.6-2-1.3-2.9-2.1C419.3,809.9,416.3,807.6,410.7,807.6"
+   id="path1667" />
+	</g>
+	<g
+   id="g1673">
+		<path
+   class="st3"
+   d="M410.7,788.8c-5.5,0-8.4,2.3-10.9,4.3c-2.4,1.9-4.7,3.7-9.3,3.7s-6.9-1.8-9.3-3.7c-2.5-2-5.4-4.3-10.9-4.3    s-8.4,2.3-10.9,4.3c-2.4,1.9-4.7,3.7-9.3,3.7s-6.9-1.8-9.3-3.7c-2.5-2-5.4-4.3-10.9-4.3s-8.3,2.3-10.9,4.3    c-2.4,1.9-4.7,3.7-9.3,3.7s-6.9-1.8-9.3-3.7c-2.3-1.8-4.9-3.9-9.5-4.2c0,0.9,0.1,1.7,0.2,2.6c3.6,0.4,5.6,2,7.7,3.6    c2.5,2,5.4,4.3,10.9,4.3s8.3-2.3,10.9-4.3c2.4-1.9,4.7-3.7,9.3-3.7s6.9,1.8,9.3,3.7c2.5,2,5.4,4.3,10.9,4.3s8.3-2.3,10.9-4.3    c2.4-1.9,4.7-3.7,9.3-3.7s6.9,1.8,9.3,3.7c2.5,2,5.4,4.3,10.9,4.3s8.3-2.3,10.9-4.3c2.4-1.9,4.7-3.7,9.3-3.7s6.9,1.8,9.3,3.7    c2.3,1.8,4.9,3.9,9.5,4.2c0.2-0.8,0.3-1.7,0.5-2.5c-4-0.2-6.1-1.9-8.4-3.7C419.1,791.1,416.2,788.8,410.7,788.8"
+   id="path1671" />
+	</g>
+	<g
+   id="g1677">
+		<path
+   class="st3"
+   d="M309.9,779.9c5.4,0,8-2.1,10.6-4.2c2.5-2,4.8-3.8,9.5-3.8s7.1,1.8,9.5,3.8c2.6,2.1,5.3,4.2,10.6,4.2    s8-2.1,10.7-4.2c2.5-2,4.8-3.8,9.5-3.8s7.1,1.8,9.5,3.8c2.6,2.1,5.3,4.2,10.7,4.2s8-2.1,10.6-4.2c2.5-2,4.8-3.8,9.5-3.8    s7.1,1.8,9.5,3.8c2.6,2,5.3,4.2,10.5,4.2v-0.2c0-0.6-0.1-1.1-0.1-1.7c-4.5-0.1-6.8-1.9-9.3-3.8c-2.6-2.1-5.3-4.2-10.7-4.2    s-8.1,2.1-10.7,4.2c-2.5,2-4.8,3.8-9.5,3.8s-7.1-1.8-9.5-3.8c-2.6-2.1-5.3-4.2-10.6-4.2s-8,2.1-10.7,4.2c-2.5,2-4.8,3.8-9.5,3.8    s-7.1-1.8-9.5-3.8c-2.6-2.1-5.3-4.2-10.6-4.2s-8,2.1-10.6,4.2c-2.5,2-4.8,3.8-9.5,3.8s-7.1-1.8-9.5-3.8c-2.1-1.7-4.3-3.3-7.8-4    c-0.1,0.6-0.2,1.2-0.4,1.8c3.1,0.5,5.1,2,7,3.6C301.8,777.8,304.5,779.9,309.9,779.9"
+   id="path1675" />
+	</g>
+	<g
+   id="g1681">
+		<path
+   class="st3"
+   d="M309.9,760.4c5.2,0,7.9-2.1,10.4-4.1s4.9-3.9,9.7-3.9s7.2,1.9,9.7,3.9c2.6,2,5.2,4.1,10.4,4.1    s7.9-2.1,10.4-4.1s4.9-3.9,9.7-3.9s7.2,1.9,9.7,3.9c2.6,2,5.2,4.1,10.4,4.1s7.9-2.1,10.4-4.1s4.9-3.9,9.7-3.9s7.2,1.9,9.7,3.9    c1.7,1.5,3.7,2.7,5.8,3.4c-0.2-0.5-0.4-0.9-0.5-1.4c-1.7-0.8-3.2-1.7-4.6-2.9c-2.6-2-5.2-4.1-10.4-4.1s-7.9,2.1-10.4,4.1    s-4.9,3.9-9.7,3.9s-7.2-1.9-9.7-3.9c-2.6-2-5.2-4.1-10.4-4.1s-7.9,2.1-10.4,4.1s-4.9,3.9-9.7,3.9s-7.1-1.8-9.6-3.8    c-2.6-2-5.2-4.1-10.4-4.1s-7.9,2.1-10.4,4.1s-4.9,3.9-9.7,3.9s-7.2-1.9-9.7-3.9c-0.6-0.5-1.2-1-1.9-1.4c-0.2,0.3-0.3,0.7-0.5,1    c0.6,0.4,1.1,0.9,1.7,1.3C302,758.3,304.7,760.4,309.9,760.4"
+   id="path1679" />
+	</g>
+</g>
+<g
+   id="g1779">
+	<path
+   class="st67"
+   d="M1242.6,823.4c-0.3,0.7-0.6,1.3-1,2c-1,1.6-2.2,3-3.7,4.3c-0.1,0-0.1,0-0.1,0c-0.8,0.8-1.6,1.4-2.5,2   c-2,1.4-4.1,2.6-6.2,3.9c-1.9,1.1-3.9,2.3-5.7,3.5c-2,1.4-3.8,3-5.6,4.6c-1.9,1.7-3.9,3.5-5.9,5c-1.9,1.5-4,2.7-6.2,3.5   c-1.6,0.6-3.2,0.9-4.8,1.1c-2,0.2-4,0.2-6.1,0c-2.3-0.2-4.7-0.4-7-0.6c-0.1,0-0.2,0-0.3,0c-0.1,0-0.1,0-0.2,0   c-2.5-0.2-5-0.3-7.4-0.1c-0.1,0-0.1,0-0.2,0c-0.9,0-1.8,0.1-2.7,0.2c-1.6,0.1-3.2,0.3-4.7,0.4s-3.2,0.2-4.8,0.2   c-2.6,0-5.1-0.3-7.5-1.2c-0.4-0.2-0.9-0.3-1.3-0.5c-2-0.9-3.9-2.2-5.6-3.5c-1-0.8-1.9-1.6-2.9-2.4c-0.4-0.4-0.9-0.7-1.3-1.1   c-0.4-0.4-0.8-0.8-1.2-1.1c-1.1-1-2.2-2-3.3-2.9c-2.1-1.7-4.4-3.1-6.8-4.5c-2.1-1.2-4.2-2.5-6.3-3.8c-1.2-0.8-2.4-1.7-3.5-2.7   c-0.3-0.3-0.7-0.6-1-0.9c-1.2-1.4-2.3-2.8-3.2-4.4c-1.1-2.1-1.8-4.3-2.5-6.5c-0.7-2.5-1.2-5.1-1.8-7.6c-0.8-3.5-1.9-6.8-3.3-10   c-1-2.3-2.1-4.5-2.9-6.9c-0.7-2-1.3-4-1.6-6.1c-0.2-1.6-0.3-3.2-0.1-4.9c0.3-3,1.3-5.9,2.5-8.7c0.6-1.3,1.1-2.6,1.7-4   c0.7-1.5,1.3-3.1,1.9-4.6c0.3-0.7,0.4-1.4,0.7-2.1c0.3-0.6,0.4-1.2,0.6-1.8c0.1-0.5,0.2-1,0.3-1.4c0.6-2.1,1-4.3,1.5-6.4   c0.2-0.7,0.4-1.3,0.4-2c0.3-0.4,0.3-0.9,0.5-1.4c0.2-0.9,0.6-1.7,0.8-2.6c0.3-0.8,0.7-1.6,1.1-2.4c0.6-1.3,1.5-2.5,2.4-3.7   c0.5-0.6,1.1-1.2,1.6-1.7c1.7-1.7,3.7-3,5.8-4.3c2.1-1.3,4.2-2.5,6.3-3.8c2.3-1.4,4.4-2.9,6.4-4.7c0.1-0.1,0.2-0.1,0.2-0.3   c0,0,0.1,0,0.1-0.1h0.1c0.4-0.4,0.9-0.7,1.3-1.2c0.1-0.2,0.4-0.2,0.5-0.4c0.4-0.5,0.9-0.8,1.3-1.2s0.8-0.7,1.2-1   c0.8-0.7,1.6-1.3,2.4-2c1.5-1.2,3.1-2.3,4.7-3.2c1.9-1,3.9-1.7,6.1-2s4.4-0.3,6.6-0.2c0.2,0,0.4,0,0.6,0c0.1,0,0.1,0,0.2,0   c1,0.1,2,0.2,3,0.3c1.4,0.1,2.9,0.3,4.4,0.4c0.7,0.1,1.4,0.2,2.1,0.1c0.1,0,0.1,0,0.2,0c1.9,0.2,3.9,0.1,5.8-0.1c0.1,0,0.1,0,0.2,0   c0.9,0,1.7-0.1,2.6-0.2c2.6-0.2,5.2-0.5,7.8-0.6c0.7,0,1.5,0,2.2,0c0.1,0,0.2,0,0.3,0c1,0.1,2.1,0.2,3.1,0.4c1.4,0.3,2.7,0.7,4,1.2   c1.2,0.5,2.4,1.2,3.5,1.9c1.5,1,3,2.1,4.3,3.3c2,1.7,4,3.5,6,5.2c1.6,1.4,3.3,2.7,5.2,3.8c1.9,1.2,3.9,2.3,5.9,3.5s3.9,2.4,5.7,3.9   c1.5,1.3,2.9,2.7,4,4.3c0.8,1.2,1.5,2.5,2.1,3.9c0.2,0.5,0.4,0.9,0.5,1.4c0,0.1,0,0.1,0.1,0.1c0,0,0,0.1,0.1,0.1   c0,0.3,0.1,0.5,0.2,0.7c0,0.1,0,0.1,0,0.2c0,0.1,0,0.1,0.1,0.1c0.4,1.3,0.8,2.6,1,3.9c-0.1,0.1,0,0.2,0.1,0.2   c0.1,0.7,0.3,1.4,0.4,2c0.3,1.5,0.7,3,1,4.5c0,0.1,0,0.3,0.1,0.4c0,0.1,0.1,0.2,0.2,0.2c0.1,0.7,0.3,1.3,0.5,2   c0.7,2.2,1.6,4.4,2.5,6.5c1,2.3,2.1,4.6,2.9,6.9c0.7,1.9,1.2,3.8,1.5,5.7c0.3,2,0.2,4-0.1,5.9c-0.5,2.8-1.4,5.5-2.5,8.1   c-0.9,2.3-2,4.5-2.9,6.7c-0.3,0.8-0.6,1.6-0.9,2.5c-0.1,0-0.1,0-0.1,0.1s0,0.1,0,0.2c-0.1,0-0.1,0-0.1,0.1s0,0.1,0,0.2   c-0.1,0-0.1,0-0.1,0.1s0,0.2-0.1,0.4c-0.8,2.5-1.3,5.1-1.9,7.7c-0.6,2.7-1.2,5.3-2.2,7.8C1243.2,822.1,1243,822.7,1242.6,823.4   C1242.6,823.3,1242.6,823.3,1242.6,823.4L1242.6,823.4z M1182.8,846.5c2.6,0,5.2-0.2,7.8-0.5c3.8-0.5,7.6-1.3,11.2-2.5   c2.6-0.9,5.2-1.8,7.7-3.1c1.6-0.8,3.2-1.6,4.7-2.5c4-2.4,7.7-5.1,11.1-8.3c1.3-1.2,2.6-2.5,3.8-3.9c3.7-4.2,6.9-8.7,9.3-13.8   c0.4-0.8,0.8-1.5,1.1-2.2c0.7-1.6,1.4-3.3,1.9-5c0.2-0.8,0.5-1.5,0.8-2.2c0.5-1.3,0.8-2.7,1.1-4.1c1-4,1.5-8.2,1.6-12.3   c0.1-3,0-6-0.4-9.1c-0.3-2.9-0.9-5.7-1.6-8.5c-1.3-4.9-3.1-9.5-5.6-14c-1.2-2.2-2.5-4.3-4-6.4c-1.3-1.9-2.8-3.7-4.3-5.3   c-0.5-0.5-1-1.1-1.5-1.6c-1.1-1.2-2.3-2.3-3.5-3.3c-0.4-0.4-0.8-0.8-1.3-1.2c-3.5-2.9-7.2-5.5-11.2-7.6c-1.1-0.6-2.2-1.1-3.3-1.6   c-1.7-0.8-3.4-1.5-5.1-2c-1.5-0.5-3-1-4.6-1.3c-0.7-0.1-1.4-0.3-2-0.5c-1-0.3-2-0.4-3-0.6s-2-0.3-3-0.4c-0.8-0.1-1.6-0.2-2.3-0.3   c-2.2-0.2-4.4-0.2-6.6-0.2c-2.8,0-5.7,0.3-8.4,0.7c-3,0.5-5.9,1.1-8.7,2c-4,1.2-7.9,2.8-11.5,4.9c-6,3.3-11.3,7.4-15.9,12.4   c-4.4,4.8-8,10.2-10.8,16.1c-1.6,3.5-2.9,7.1-3.8,10.8c-0.6,2.4-1.1,4.8-1.4,7.2c-0.2,1.4-0.3,2.8-0.4,4.2c-0.1,2.3-0.2,4.6,0,6.9   c0.1,2.2,0.3,4.5,0.7,6.7c0.5,3.2,1.3,6.4,2.2,9.5c0.3,1,0.7,1.9,1,2.8c0.5,1.6,1.3,3,1.9,4.6c0.3,0.8,0.8,1.6,1.2,2.3   c3.4,6.4,7.7,12,13,16.9c4.7,4.3,9.9,7.8,15.6,10.5C1164.8,844.6,1173.6,846.5,1182.8,846.5L1182.8,846.5z"
+   id="path1685" />
+	<path
+   class="st94"
+   d="M1244.1,748.9c-0.1-0.2-0.2-0.5-0.2-0.7C1244,748.4,1244.1,748.6,1244.1,748.9z"
+   id="path1687" />
+	<path
+   class="st94"
+   d="M1199.4,715.2c-0.1,0-0.2,0-0.3,0C1199.3,715.1,1199.4,715.1,1199.4,715.2z"
+   id="path1689" />
+	<path
+   class="st94"
+   d="M1171,715.3c-0.1,0-0.1,0-0.2,0C1170.9,715.2,1171,715.2,1171,715.3z"
+   id="path1691" />
+	<path
+   class="st94"
+   d="M1246.9,760.5c-0.1,0-0.2-0.1-0.2-0.2C1246.9,760.2,1246.9,760.3,1246.9,760.5z"
+   id="path1693" />
+	<path
+   class="st94"
+   d="M1245.3,753.3c-0.1-0.1-0.2-0.1-0.1-0.2C1245.3,753.1,1245.3,753.2,1245.3,753.3z"
+   id="path1695" />
+	<path
+   class="st94"
+   d="M1180.7,716.1c-0.1,0-0.1,0-0.2,0C1180.6,716,1180.6,716,1180.7,716.1z"
+   id="path1697" />
+	<path
+   class="st94"
+   d="M1186.7,716c-0.1,0-0.1,0-0.2,0C1186.5,715.9,1186.6,715.9,1186.7,716z"
+   id="path1699" />
+	<path
+   class="st94"
+   d="M1179.6,852.6c0.1,0,0.1,0,0.2,0C1179.7,852.7,1179.6,852.7,1179.6,852.6z"
+   id="path1701" />
+	<path
+   class="st94"
+   d="M1187.2,852.7c0.1,0,0.1,0,0.2,0C1187.3,852.8,1187.3,852.8,1187.2,852.7z"
+   id="path1703" />
+	<path
+   class="st94"
+   d="M1247.8,805C1247.8,804.9,1247.8,804.9,1247.8,805C1247.8,804.9,1247.8,804.9,1247.8,805z"
+   id="path1705" />
+	<path
+   class="st94"
+   d="M1247.7,805.2L1247.7,805.2L1247.7,805.2z"
+   id="path1707" />
+	<path
+   class="st94"
+   d="M1247.6,805.5C1247.6,805.4,1247.6,805.4,1247.6,805.5C1247.7,805.5,1247.6,805.5,1247.6,805.5z"
+   id="path1709" />
+	<path
+   class="st94"
+   d="M1244.1,749.1C1244.1,749.1,1244,749.1,1244.1,749.1L1244.1,749.1z"
+   id="path1711" />
+	<path
+   class="st94"
+   d="M1243.8,748C1243.8,748,1243.7,748,1243.8,748C1243.7,748,1243.7,748,1243.8,748z"
+   id="path1713" />
+	<path
+   class="st94"
+   d="M1146.1,726.4C1146.1,726.4,1146,726.5,1146.1,726.4C1146,726.5,1146,726.5,1146.1,726.4z"
+   id="path1715" />
+	<path
+   class="st94"
+   d="M1242.6,823.4C1242.6,823.3,1242.6,823.3,1242.6,823.4C1242.6,823.3,1242.6,823.4,1242.6,823.4z"
+   id="path1717" />
+	<path
+   class="st94"
+   d="M1237.9,829.7C1237.9,829.6,1237.9,829.6,1237.9,829.7C1237.9,829.6,1237.9,829.6,1237.9,829.7z"
+   id="path1719" />
+	<path
+   class="st94"
+   d="M1182.8,846.5c-9.2,0-18-1.9-26.4-5.9c-5.7-2.7-10.9-6.2-15.6-10.5c-5.3-4.9-9.7-10.5-13-16.9   c-0.4-0.8-0.9-1.5-1.2-2.3c-0.6-1.5-1.3-3-1.9-4.6c-0.3-1-0.8-1.9-1-2.8c-0.9-3.1-1.8-6.3-2.2-9.5c-0.3-2.2-0.6-4.4-0.7-6.7   s-0.1-4.6,0-6.9c0.1-1.4,0.2-2.8,0.4-4.2c0.3-2.4,0.8-4.8,1.4-7.2c0.9-3.7,2.2-7.3,3.8-10.8c2.8-5.9,6.3-11.3,10.8-16.1   c4.6-5,9.9-9.1,15.9-12.4c3.7-2,7.5-3.6,11.5-4.9c2.9-0.9,5.8-1.5,8.7-2c2.8-0.4,5.6-0.7,8.4-0.7c2.2,0,4.4,0,6.6,0.2   c0.8,0.1,1.6,0.2,2.3,0.3c1,0.2,2,0.2,3,0.4s2,0.3,3,0.6c0.7,0.2,1.4,0.4,2,0.5c1.6,0.3,3.1,0.8,4.6,1.3c1.7,0.6,3.4,1.3,5.1,2   c1.1,0.5,2.2,1,3.3,1.6c4,2.1,7.8,4.6,11.2,7.6c0.4,0.4,0.8,0.8,1.3,1.2c1.2,1,2.4,2.1,3.5,3.3c0.5,0.5,1,1.1,1.5,1.6   c1.6,1.7,3,3.5,4.3,5.3c1.5,2,2.8,4.2,4,6.4c2.4,4.4,4.3,9.1,5.6,14c0.7,2.8,1.3,5.7,1.6,8.5c0.3,3,0.5,6,0.4,9.1   c-0.1,4.2-0.6,8.3-1.6,12.3c-0.3,1.4-0.6,2.8-1.1,4.1c-0.3,0.7-0.5,1.5-0.8,2.2c-0.6,1.7-1.2,3.3-1.9,5c-0.3,0.8-0.7,1.5-1.1,2.2   c-2.4,5.1-5.6,9.6-9.3,13.8c-1.2,1.3-2.5,2.7-3.8,3.9c-3.4,3.2-7.1,6-11.1,8.3c-1.5,0.9-3.1,1.7-4.7,2.5c-2.5,1.2-5.1,2.2-7.7,3.1   c-3.7,1.2-7.4,2-11.2,2.5C1188,846.4,1185.4,846.6,1182.8,846.5L1182.8,846.5z M1239.6,784.2c0-31.3-25.2-56.4-56.3-56.7   c-10.2-0.1-19.8,2.4-28.6,7.5c-9,5.1-16,12.2-21.2,21.2c-4.9,8.7-7.4,18-7.4,28c0,31.5,25.3,56.7,56.6,56.8   c4.8,0,10.9-0.6,16.9-2.5c4.2-1.3,8.2-3,11.9-5.2c5.3-3.1,9.9-7,14-11.5c2.6-2.9,4.8-6,6.7-9.4c2.6-4.5,4.5-9.3,5.8-14.4   C1239,793.5,1239.6,788.9,1239.6,784.2L1239.6,784.2z"
+   id="path1721" />
+	<path
+   class="st67"
+   d="M1239.6,784.2c0,4.7-0.5,9.3-1.7,13.8c-1.2,5.1-3.2,9.9-5.8,14.4c-1.9,3.4-4.1,6.5-6.7,9.4   c-4.1,4.6-8.7,8.4-14,11.5c-3.8,2.2-7.8,3.9-11.9,5.2c-6,1.9-12.1,2.5-16.9,2.5c-31.3-0.1-56.6-25.3-56.6-56.8   c0-10,2.4-19.4,7.4-28c5.1-9,12.2-16.1,21.2-21.2c8.8-5.1,18.4-7.5,28.6-7.5C1214.3,727.8,1239.5,753,1239.6,784.2L1239.6,784.2z    M1146.9,811C1146.9,811,1146.9,811.1,1146.9,811c0,0.4-0.1,0.7-0.2,1.1c-0.1,0.2-0.1,0.5-0.1,0.7c0,0.6,0.3,0.9,0.8,1   c0.2,0.1,0.4,0,0.7,0c0.3,0,0.6,0,0.9-0.1c0.1,0,0.2,0,0.2,0.1s0,0.1-0.1,0.2c-0.1,0-0.1,0.1-0.2,0.1c-0.6,0.5-1.3,1-1.9,1.5   c-0.4,0.3-0.4,0.6-0.1,1c0.2,0.2,0.4,0.5,0.6,0.7c0.4,0.4,0.6,0.5,1,0.1c0.4-0.3,0.8-0.6,1.2-0.9c1.4-1.1,2.8-2.3,4.2-3.4   c0.5-0.4,0.5-0.7,0.2-1.2c-0.5-0.7-1.2-0.9-2-0.8c-0.9,0.1-1.8,0.3-2.7,0.4c-0.1,0-0.2,0-0.2-0.1c0.1-0.2,0.1-0.4,0.2-0.6   c0.3-0.8,0.6-1.6,0.9-2.4c0.2-0.7,0.2-1.2-0.4-1.7c-0.1-0.1-0.3-0.2-0.4-0.4c-0.3-0.2-0.4-0.2-0.7,0c-0.1,0.1-0.2,0.2-0.3,0.2   c-0.8,0.7-1.7,1.4-2.5,2.1c-0.9,0.7-1.8,1.4-2.7,2.2c-0.4,0.3-0.4,0.5-0.2,1c0.2,0.3,0.3,0.5,0.6,0.7c0.4,0.4,0.7,0.4,1.1,0.1   c0.4-0.3,0.8-0.7,1.2-1C1146.1,811.6,1146.5,811.3,1146.9,811L1146.9,811z M1185.5,789.1L1185.5,789.1c0-3.5,0-7,0-10.5   c0-0.2,0-0.3,0-0.5s0.1-0.3,0.3-0.3c0.1,0,0.2,0,0.3,0c0.8,0,1.5,0,2.3,0c0.6,0,1.2,0,1.9,0c0.4,0,0.8,0.1,1.1,0.3   c0.4,0.3,0.8,0.3,1.3,0.3c1.2,0,2.2-0.9,2.3-2.1c0.2-1.3-0.5-2.4-1.7-2.8c-0.7-0.2-1.4-0.1-2,0.3c-0.3,0.2-0.5,0.3-0.8,0.3   c-1.5,0-3,0-4.5,0c-0.3,0-0.4-0.1-0.4-0.4c0-0.6,0-1.2,0-1.8c0-0.4,0.1-0.7,0.4-0.8c0.1-0.1,0.3-0.2,0.4-0.2   c2.8-1.5,4.1-4.5,3.4-7.5c-1-4.8-6.5-7-10.6-4.4c-2.2,1.4-3.4,3.5-3.3,6.2c0.1,2.5,1.2,4.4,3.4,5.7c0.4,0.2,0.8,0.4,1.1,0.6   c0.3,0.1,0.4,0.3,0.4,0.6c0,0.6,0,1.1,0,1.7c0,0.4-0.1,0.5-0.5,0.5c-0.1,0-0.2,0-0.3,0c-1.4,0-2.8,0-4.2,0c-0.4,0-0.9-0.1-1.3-0.3   c-0.3-0.2-0.7-0.3-1-0.4c-0.6-0.1-1.1,0-1.6,0.3c-1,0.6-1.4,1.9-1,3.1c0.3,0.8,1.4,1.8,2.8,1.5c0.3-0.1,0.5-0.2,0.8-0.3   c0.4-0.2,0.7-0.3,1.2-0.3c1.5,0,3.1,0,4.6,0c0.6,0,0.6,0.1,0.6,0.6v0.1c0,7,0,13.9,0,20.9c0,0.1,0,0.3,0,0.4c0,0.3-0.2,0.4-0.4,0.4   c-0.1,0-0.2,0-0.3,0c-1.2-0.1-2.4-0.3-3.6-0.5c-1.5-0.3-3-0.6-4.5-1.2c-1.2-0.4-2.1-1.3-3.1-2.1c-0.2-0.2-0.4-0.5-0.6-0.7   c-0.5-0.6-0.9-1.2-1.3-1.8c-0.2-0.3-0.2-0.5,0.2-0.6c0.1,0,0.2,0,0.3-0.1c0.2-0.1,0.5-0.2,0.5-0.4c0.1-0.3,0-0.5-0.2-0.7   c-0.4-0.4-0.8-0.8-1.2-1.3c-0.5-0.6-1.1-1.1-1.5-1.7c-0.1-0.2-0.3-0.3-0.5-0.5c-0.3-0.5-0.9-0.9-1.3-1.4c-0.3-0.4-0.8-0.3-1,0.2   c-0.1,0.2-0.2,0.5-0.2,0.7c-0.6,1.8-1.1,3.6-1.7,5.5c0,0.1-0.1,0.3-0.1,0.4c-0.1,0.5,0.2,0.7,0.6,0.8c0.2,0,0.4,0,0.6,0   c0.5,0,0.8,0.2,1.1,0.6c0.1,0.1,0.1,0.3,0.2,0.4c1.6,3.1,3.8,5.7,6.6,7.8c2.8,2.1,5.9,3.7,9.4,4.4c0.4,0.1,0.7,0.3,1,0.6   s0.6,0.6,0.9,0.9c0.5,0.5,0.9,0.9,1.4,1.4c0.5,0.4,0.9,0.4,1.4,0c0.2-0.2,0.4-0.3,0.5-0.5c0.6-0.7,1.3-1.3,1.9-1.9   c0.3-0.2,0.6-0.4,0.9-0.4c0.8,0,1.6-0.3,2.3-0.5c1.2-0.4,2.4-0.9,3.6-1.5c2.2-1.1,4.3-2.3,6-4.1c0.5-0.5,1-0.9,1.5-1.5   c0.9-1.1,1.7-2.2,2.4-3.4c0.2-0.3,0.4-0.7,0.6-1s0.3-0.4,0.7-0.2c0.2,0.1,0.3,0.1,0.5,0.1c0.6,0.1,1-0.4,0.9-1   c0-0.1-0.1-0.3-0.1-0.4c-0.2-1-0.5-2-0.7-3c-0.2-0.9-0.4-1.8-0.7-2.7c0-0.1-0.1-0.3-0.1-0.4c-0.2-0.4-0.5-0.5-0.9-0.3   c-0.1,0.1-0.3,0.2-0.4,0.3c-1.4,1.4-2.8,2.7-4.3,4.1c-0.2,0.2-0.4,0.4-0.5,0.6c-0.2,0.3-0.2,0.5,0.2,0.7c0.2,0.1,0.5,0.2,0.7,0.3   c0.3,0.1,0.3,0.2,0.2,0.5c-0.2,0.3-0.5,0.7-0.7,1c-1.4,1.8-3.1,3.1-5.3,3.8c-2.1,0.6-4.2,1-6.4,1.1c-0.9,0-0.9,0-0.9-0.8   C1185.5,796,1185.5,792.6,1185.5,789.1L1185.5,789.1z M1131,785.2c0,0.3,0,0.5,0,0.7s0.1,0.4,0.3,0.5c0.4,0.2,0.8,0.3,1.1,0.5   c2.1,1,4.4,1.6,6.8,1.8c2.2,0.1,4.4,0,6.5-0.6c1.3-0.4,2.6-0.9,3.9-1.5c2.1-1,4.3-1.6,6.7-1.8c1.8-0.1,3.6,0,5.4,0.4   c1.4,0.3,2.6,0.8,3.9,1.4c0.9,0.4,1.7,0.8,2.6,1.2c3.6,1.3,7.3,1.3,11,0.5c0.4-0.1,0.5-0.2,0.5-0.7c0-0.4-0.1-0.4-0.4-0.3   c-1.1,0.3-2.2,0.5-3.3,0.5c-1.9,0.1-3.8,0-5.7-0.4c-1.5-0.3-2.9-0.9-4.3-1.6c-0.7-0.4-1.5-0.7-2.3-0.9c-0.8-0.3-1.6-0.5-2.4-0.6   c-2.7-0.5-5.5-0.5-8.2,0.1c-1.5,0.3-2.9,0.9-4.3,1.5c-2.2,1.1-4.4,1.8-6.8,1.9c-2.4,0.1-4.8-0.1-7.1-0.8c-0.9-0.3-1.7-0.7-2.5-1.1   C1132,785.5,1131.5,785.3,1131,785.2L1131,785.2z M1193.5,746.7c0.1,0,0.2,0,0.3,0c0.3,0,0.4-0.2,0.4-0.5c0-0.1-0.1-0.3-0.1-0.4   c-0.2-0.6-0.4-1.3-0.6-1.9c-0.2-0.6-0.2-0.7,0.4-0.9c0.2-0.1,0.5-0.3,0.7-0.5c0.5-0.5,0.7-1.2,0.7-2c0.1-1.2-0.5-2-1.6-2.5   c-0.4-0.2-0.8-0.3-1.2-0.4c-1-0.3-1.9-0.4-2.9-0.6c-0.8-0.2-0.9-0.1-1.1,0.8c-0.3,1.8-0.7,3.6-1.1,5.4c-0.1,0.5-0.2,1-0.3,1.5   c0,0.2-0.1,0.4,0.1,0.6c0.4,0.4,0.9,0.5,1.5,0.5c0.5-0.1,0.7-0.5,0.8-0.9c0-0.1,0-0.1,0-0.2c0.1-0.4,0.2-0.9,0.3-1.3   c0.1-0.2,0.2-0.3,0.4-0.3c0.5,0,0.8,0.2,0.9,0.7c0.2,0.6,0.4,1.3,0.6,1.9c0.2,0.6,0.6,1,1.3,1   C1193.1,746.7,1193.3,746.7,1193.5,746.7L1193.5,746.7z M1172.1,827.1c-0.1-0.2-0.1-0.3-0.1-0.4c-0.4-1.2-0.8-2.3-1.2-3.4   c-0.3-0.8-0.8-1.3-1.7-1.3c-0.5,0-0.6,0.1-0.7,0.5c-0.4,1.8-1,3.6-1.5,5.4c-0.1,0.5-0.3,0.9-0.4,1.3c-0.1,0.5,0,0.7,0.5,0.9   c0.2,0.1,0.3,0.1,0.5,0.2c0.9,0.2,1.1,0.2,1.3-0.7c0.2-0.9,0.5-1.8,0.7-2.6c0-0.1,0-0.2,0.2-0.2c0.1,0.1,0.2,0.2,0.2,0.4   c0.4,1.1,0.7,2.2,1.1,3.3c0.1,0.2,0.1,0.3,0.2,0.5c0.2,0.4,0.5,0.6,0.9,0.7c0.2,0,0.5,0.1,0.8,0.1s0.5-0.1,0.6-0.4   c0.1-0.2,0.1-0.5,0.2-0.7c0.5-1.9,1.1-3.9,1.6-5.8c0.1-0.2,0.1-0.4,0.1-0.6c0.1-0.3-0.1-0.5-0.3-0.6c-0.2-0.1-0.5-0.2-0.8-0.2   c-0.8-0.2-1-0.1-1.2,0.7s-0.4,1.6-0.7,2.5C1172.3,826.7,1172.3,826.9,1172.1,827.1z M1216.8,807.2c-0.2,0-0.5,0-0.8,0.1   c-0.5,0.2-0.9,0.5-1.2,0.9c-0.7,0.8-1.4,1.7-2.1,2.6c-0.5,0.6-0.4,0.9,0.2,1.4c0.1,0,0.1,0.1,0.2,0.1c1.1,0.8,2.2,1.7,3.3,2.6   c0.6,0.5,1.2,1,1.8,1.4c0.4,0.3,0.7,0.3,1-0.1c0.2-0.2,0.4-0.5,0.6-0.8c0.3-0.4,0.2-0.6-0.2-0.9c-0.4-0.3-0.8-0.7-1.3-1   c-0.3-0.3-0.4-0.5-0.1-0.8c0.2-0.2,0.5-0.3,0.8-0.2c0.5,0.1,0.9,0.2,1.4,0.3c0.4,0.1,0.8,0.2,1.2,0c0.6-0.2,0.9-0.7,1.2-1.2   c0.2-0.4,0.1-0.5-0.3-0.6c-0.6-0.1-1.2-0.2-1.8-0.3c-0.9-0.2-0.9-0.1-1-1C1219.4,808.1,1218.3,807.2,1216.8,807.2L1216.8,807.2z    M1173.4,746.3c0.1,0,0.2,0,0.3,0c1.6-0.3,3.1-0.6,4.7-0.8c0.2,0,0.4-0.1,0.6-0.1c0.3-0.1,0.3-0.2,0.3-0.5c0-0.4-0.1-0.8-0.2-1.1   c-0.1-0.2-0.2-0.3-0.4-0.3c-0.2,0-0.5,0-0.7,0.1c-0.8,0.2-1.7,0.3-2.5,0.4c-0.5,0.1-0.6,0-0.7-0.5c0-0.1,0-0.1,0-0.2   c0-0.3,0.1-0.5,0.4-0.6c0.2,0,0.4-0.1,0.6-0.1c0.7-0.1,1.4-0.2,2.1-0.4c0.4-0.1,0.5-0.3,0.5-0.6s-0.1-0.7-0.2-1s-0.3-0.4-0.6-0.4   c-0.3,0-0.7,0.1-1,0.2c-0.6,0.1-1.1,0.2-1.7,0.3c-0.2,0-0.4,0.1-0.6-0.2c-0.3-0.5-0.1-1,0.4-1.1s1-0.2,1.6-0.3   c0.4-0.1,0.9-0.1,1.3-0.2c0.4-0.1,0.5-0.2,0.5-0.7c0-0.2-0.1-0.5-0.1-0.7c-0.1-0.6-0.2-0.7-0.9-0.6c-0.5,0.1-1,0.2-1.5,0.3   c-1.1,0.2-2.2,0.4-3.3,0.5c-0.5,0.1-0.7,0.3-0.7,0.8c0,0.1,0,0.2,0,0.3c0.3,1.7,0.6,3.4,0.9,5.1c0.1,0.6,0.2,1.3,0.4,1.9   C1172.9,746.3,1173,746.3,1173.4,746.3L1173.4,746.3z M1196.9,830.5c1.5,0,2.7-0.6,3.5-1.7c0.5-0.6,0.7-1.2,0.6-2s-0.3-1.5-0.6-2.2   c-0.2-0.3-0.3-0.4-0.7-0.3c-0.3,0.1-0.6,0.2-0.8,0.3c-0.5,0.2-1,0.4-1.5,0.6c-0.3,0.1-0.4,0.3-0.3,0.6c0.1,0.2,0.2,0.5,0.2,0.8   c0.1,0.3,0.3,0.5,0.7,0.4c0.1,0,0.2,0,0.3-0.1c0.2,0,0.3-0.1,0.5,0c0.1,0.1,0.1,0.3,0,0.5c0,0.1-0.1,0.2-0.2,0.3   c-0.3,0.4-0.7,0.6-1.1,0.7c-0.5,0.1-1,0-1.3-0.5c-0.6-0.8-0.9-1.7-0.9-2.7c-0.1-1,0.9-1.8,1.8-1.4c0.9,0.3,1.7,0.2,2.5-0.2   c0.4-0.1,0.4-0.3,0.2-0.7c-0.3-0.5-0.8-0.8-1.3-1c-1.6-0.6-3.7,0-4.8,1.3c-0.6,0.8-0.8,1.6-0.7,2.5c0.2,0.8,0.4,1.7,0.8,2.5   C1194.3,829.8,1195.5,830.5,1196.9,830.5z M1233.5,795.3c0-0.3,0-0.4-0.3-0.5c-0.1,0-0.2-0.1-0.3-0.1c-2.2-1-4.6-1.5-7-1.6   c-2.3-0.1-4.5,0.1-6.7,0.9c-1.2,0.4-2.4,1-3.6,1.5c-2,1-4.2,1.5-6.4,1.6c-1.6,0.1-3.2,0-4.8-0.3c-0.2,0-0.4,0-0.5,0.2   s-0.2,0.4-0.3,0.6c-0.2,0.3-0.2,0.4,0.2,0.5h0.1c1.1,0.2,2.3,0.3,3.5,0.4c1.3,0.1,2.5,0,3.8-0.2c2.1-0.3,4-1,5.8-1.9   c1.1-0.6,2.3-1,3.5-1.3c1.9-0.5,3.8-0.6,5.7-0.5c1.4,0.1,2.8,0.2,4.2,0.7c0.9,0.3,1.7,0.7,2.6,1c0.3,0.1,0.3,0.1,0.4-0.2   C1233.4,795.8,1233.5,795.5,1233.5,795.3L1233.5,795.3z M1209.4,816.5c0-0.2-0.1-0.3-0.2-0.5s-0.2-0.3-0.3-0.5   c-0.3-0.5-0.6-0.5-1-0.2s-0.8,0.5-1.2,0.8c-0.9,0.7-1.8,1.3-2.8,2c-0.5,0.3-0.5,0.6-0.2,1c0,0,0.1,0.1,0.1,0.2   c1.3,1.8,2.5,3.6,3.8,5.4c0.4,0.6,0.5,0.8,1.3,0.2c1.2-0.9,2.5-1.8,3.7-2.6c0.2-0.1,0.3-0.2,0.4-0.4s0.2-0.3,0.1-0.5   c-0.2-0.3-0.4-0.7-0.7-1c-0.2-0.1-0.3-0.2-0.5-0.1c-0.1,0-0.2,0.1-0.3,0.2c-0.8,0.5-1.6,1.1-2.3,1.6c-0.2,0.1-0.3,0.2-0.5,0.1   c-0.5-0.3-0.6-0.8-0.1-1.2c0.6-0.4,1.1-0.8,1.7-1.2c0.2-0.1,0.3-0.2,0.5-0.4s0.2-0.4,0.1-0.6c-0.2-0.4-0.4-0.7-0.7-1   c-0.2-0.2-0.4-0.2-0.6,0c-0.1,0.1-0.2,0.1-0.3,0.2c-0.6,0.5-1.3,0.9-1.9,1.4c-0.3,0.2-0.5,0.2-0.7-0.1c-0.1-0.1-0.2-0.2-0.2-0.4   c-0.1-0.2,0-0.3,0.1-0.4c0.1-0.1,0.2-0.1,0.2-0.2c0.7-0.5,1.5-1,2.2-1.5C1209.3,816.9,1209.4,816.8,1209.4,816.5L1209.4,816.5z    M1158.4,825.2c0,0.5,0.1,1,0.4,1.4c0.2,0.2,0.5,0.4,0.8,0.5c0.3,0,0.7-0.1,0.7-0.5c0-0.2,0.1-0.4,0.1-0.6c0.6-2.1,1.1-4.3,1.6-6.4   c0.2-0.7,0.1-1-0.5-1.4c-0.3-0.2-0.6-0.4-0.9-0.5c-0.6-0.4-0.8-0.4-1.3,0.1c-1.4,1.1-2.9,2.2-4.3,3.3c-0.5,0.4-1.1,0.8-1.6,1.3   c-0.3,0.2-0.3,0.4,0,0.7c0.3,0.2,0.6,0.5,1,0.7c0.3,0.2,0.6,0.1,0.9,0c0.1-0.1,0.2-0.1,0.3-0.2c0.4-0.3,0.4-0.3,0.9,0   s1.1,0.7,1.6,1C1158.3,824.6,1158.5,824.8,1158.4,825.2L1158.4,825.2z M1184.2,824.1c-0.2,0-0.4,0.1-0.7,0.1c-0.8,0.1-1,0.3-1.3,1   c-0.7,2.2-1.4,4.4-2.1,6.7c0,0.1-0.1,0.3-0.1,0.4c-0.1,0.3,0.1,0.5,0.4,0.6c0.7,0.1,1.8-0.5,2-1.1c0.1-0.2,0.3-0.4,0.5-0.4   c0.8,0,1.5,0,2.3,0c0.3,0,0.4,0.1,0.6,0.4c0.1,0.1,0.1,0.3,0.1,0.4c0.1,0.2,0.3,0.4,0.6,0.4c0.5,0,1,0,1.5-0.1   c0.2,0,0.3-0.2,0.2-0.4c0-0.1-0.1-0.2-0.1-0.3c-0.8-2-1.5-4-2.3-6c-0.1-0.3-0.3-0.7-0.5-1C1185.2,824.3,1184.8,824.1,1184.2,824.1   L1184.2,824.1z M1156.1,746.5c0,0.3-0.1,0.6,0,0.9c0.2,0.5,0.4,0.9,0.6,1.3c0.3,0.6,0.7,1.1,1.1,1.6c0.5,0.7,1.1,1.1,1.9,1.2   c1.9,0.4,4.1-0.9,4.8-2.7c0.3-0.7,0.3-1.4,0-2.1c-0.1-0.3-0.4-0.6-0.6-0.5c-0.4,0.1-0.8,0.3-1,0.6s-0.5,0.7-0.5,1.1   c-0.1,0.6-0.4,1-0.9,1.3c-0.7,0.3-1.3,0.3-1.8-0.4s-0.9-1.3-1.2-2c-0.4-0.8,0-1.6,0.8-2c0.4-0.2,0.8-0.2,1.2,0   c0.4,0.2,0.9,0.2,1.3,0c0.2-0.1,0.4-0.2,0.7-0.3c0.5-0.3,0.5-0.5,0.2-1c-0.3-0.4-0.8-0.6-1.3-0.8c-0.2-0.1-0.3-0.2-0.5-0.2   c-1.3-0.1-2.6,0.2-3.6,1.1C1156.6,744.5,1156,745.4,1156.1,746.5L1156.1,746.5z M1132.2,795c-0.1,0.3,0.1,0.5,0.1,0.7   c0,0.8,0.5,1.2,1.2,1.4c2.4,1,4.9,1.4,7.5,1.3c1.9,0,3.8-0.3,5.6-0.9c1.2-0.4,2.3-0.9,3.4-1.5c1.5-0.7,3.2-1.2,4.8-1.5   c1.2-0.2,2.5-0.2,3.8-0.1c0.5,0,0.5,0,0.5-0.5c0-0.1,0-0.2,0-0.4c0-0.5-0.1-0.6-0.6-0.6c-0.3,0-0.6,0-0.9,0c-2,0-3.9,0.2-5.9,0.8   c-1.4,0.4-2.6,1.1-3.9,1.7c-1.7,0.8-3.4,1.3-5.3,1.4c-1.3,0.1-2.5,0.1-3.8,0c-1.7-0.2-3.3-0.5-4.8-1.2   C1133.4,795.5,1132.8,795.2,1132.2,795L1132.2,795z M1174.4,780.4c0.2,0,0.5,0,0.7,0c1.4,0,2.7-0.2,4.1-0.5c0.1,0,0.2,0,0.3-0.1   c0.2-0.1,0.2-0.3,0.2-0.5c-0.1-0.2-0.2-0.1-0.4-0.1c-1.1,0.3-2.1,0.4-3.2,0.5c-1.6,0.1-3.3,0.1-4.9-0.2c-1.7-0.3-3.4-0.9-5-1.7   c-1.7-0.8-3.4-1.5-5.2-1.8c-1.4-0.2-2.7-0.2-4.1-0.2c-2.8,0-5.4,0.7-7.9,2c-1.1,0.5-2.1,1-3.3,1.3c-1.4,0.4-2.8,0.6-4.2,0.7   c-1.6,0-3.2,0-4.8-0.3c-1.7-0.3-3.3-1.1-4.9-1.8c-0.3-0.1-0.4,0-0.4,0.3c0,0.2,0.1,0.3,0.3,0.4c0.3,0.2,0.7,0.3,1,0.5   c2.3,1.1,4.8,1.7,7.4,1.7c2,0,4-0.2,6-0.7c1.2-0.4,2.4-0.9,3.6-1.5c2.3-1.2,4.9-1.7,7.4-1.8c3.1-0.1,6.1,0.6,8.8,2   C1168.6,779.8,1171.4,780.5,1174.4,780.4L1174.4,780.4z M1204.9,787.4c-0.1,0.2,0,0.3,0.1,0.5c0.1,0.5,0.2,0.6,0.7,0.6   c0.8,0.1,1.6,0.1,2.4,0.1c2.5,0,4.9-0.4,7.2-1.3c0.9-0.4,1.8-0.9,2.8-1.3c2.4-1,4.9-1.4,7.5-1.3c2.5,0.1,4.9,0.6,7.1,1.7   c0.5,0.2,1,0.5,1.5,0.7c0.2,0.1,0.3,0.1,0.3-0.1c0.1-0.4-0.1-0.9-0.5-1.1c-1.6-0.7-3.1-1.5-4.8-1.8c-0.3,0-0.6-0.2-0.9-0.2   c-0.8-0.1-1.7-0.2-2.5-0.2c-1.9-0.1-3.8,0.1-5.7,0.5c-1.4,0.4-2.8,1-4.1,1.6c-3,1.5-6.2,2-9.5,1.7   C1206.1,787.5,1205.5,787.5,1204.9,787.4L1204.9,787.4z M1211.1,746.1c0-0.1,0-0.3-0.2-0.3c-0.1-0.1-0.2-0.2-0.4-0.3   c-1.6-1-3.1-2-4.7-3c-0.1-0.1-0.2-0.1-0.4-0.2c-0.3-0.1-0.5-0.1-0.7,0.1c-0.2,0.2-0.4,0.5-0.5,0.8s0,0.6,0.2,0.8s0.4,0.3,0.7,0.4   s0.4,0.2,0.6,0.4s0.2,0.3,0.1,0.5c-0.3,0.4-0.6,0.9-0.8,1.3c-0.7,1.1-1.4,2.2-2.1,3.3c-0.3,0.5-0.2,0.7,0.2,1   c0.2,0.2,0.4,0.3,0.6,0.4c0.7,0.4,0.8,0.4,1.3-0.3c0.7-1.1,1.4-2.2,2.2-3.4c0.2-0.3,0.4-0.6,0.6-0.9c0.2-0.3,0.4-0.3,0.8-0.2   s0.7,0.4,1.1,0.6c0.2,0.1,0.3,0.2,0.5,0.1C1210.5,747.3,1211.1,746.5,1211.1,746.1L1211.1,746.1z M1234.4,778.6   c0-0.2-0.1-0.4-0.4-0.5c-1-0.4-2.1-1-3.1-1.3c-1.8-0.6-3.7-0.8-5.6-0.8c-2.9,0-5.6,0.5-8.2,1.8c-0.9,0.5-1.9,0.9-2.9,1.3   c-1.3,0.5-2.8,0.7-4.2,0.8c-1.7,0.2-3.4,0.1-5.2-0.2c-1.8-0.3-3.4-0.9-5.1-1.7c-1.1-0.6-2.2-1-3.4-1.4c-0.2,0-0.3-0.1-0.4,0.1   c-0.1,0.2,0,0.4,0.2,0.5c0.1,0,0.1,0,0.2,0.1c1.1,0.3,2.2,0.8,3.3,1.3c2.2,1,4.4,1.8,6.9,1.9c1.7,0.1,3.3,0.1,4.9-0.2   c1.9-0.3,3.6-0.9,5.3-1.8c2.3-1.1,4.7-1.9,7.2-1.9c1.7,0,3.5,0,5.2,0.4c1.3,0.3,2.5,0.8,3.7,1.3c0.4,0.2,0.8,0.4,1.3,0.6   C1234.3,778.8,1234.4,778.8,1234.4,778.6L1234.4,778.6z M1202.3,786.7c-0.1-0.1-0.2-0.1-0.3-0.2c-0.9-0.4-1.8-0.8-2.7-1.2   c-0.7-0.3-1.4-0.6-2.1-0.9c-0.7-0.3-1.5-0.4-2.2-0.6c-0.8-0.2-1.6-0.2-2.4-0.3c-1.8-0.1-3.6,0.1-5.3,0.4c-0.5,0.1-0.6,0.2-0.6,0.7   v0.1c0,0.3,0.1,0.3,0.4,0.3c1.5-0.4,3.1-0.5,4.7-0.4c2.3,0,4.6,0.4,6.7,1.4c0.7,0.3,1.4,0.6,2.1,1c0.2,0.1,0.4,0.2,0.7,0.2   C1201.7,787.4,1202,787.2,1202.3,786.7L1202.3,786.7z M1191.2,793c-0.1,0-0.2,0-0.3,0c-1.2,0-2.4,0.2-3.6,0.4   c-0.6,0.1-0.7,0.2-0.7,0.8c0,0.1,0,0.3,0,0.4c0,0.3,0.1,0.4,0.4,0.3c0.1,0,0.2,0,0.2,0c1-0.2,2-0.4,3-0.4c2-0.1,4,0,5.9,0.6   c0.3,0.1,0.8-0.1,0.9-0.4c0-0.1,0.1-0.1,0-0.2c-0.3-0.4-0.4-0.8-1-0.9C1194.5,793.2,1192.8,793,1191.2,793L1191.2,793z M1172.5,797   c0.2,0.2,0.4,0.3,0.6,0.4c1,0.3,2.1,0.6,3.1,0.8c0.9,0.1,1.7,0.1,2.6-0.2s0.9-0.3,0.9-1.3c0-0.4-0.1-0.4-0.4-0.3   c-1.9,0.5-3.8,0.7-5.8,0.6C1173.2,797,1172.8,797,1172.5,797L1172.5,797z"
+   id="path1723" />
+	<path
+   class="st94"
+   d="M1185.4,789.1c0,3.5,0,6.9,0,10.3c0,0.9,0,0.9,0.9,0.8c2.2-0.1,4.3-0.4,6.4-1.1c2.2-0.7,3.9-2,5.3-3.8   c0.3-0.3,0.5-0.7,0.7-1c0.2-0.2,0.1-0.4-0.2-0.5c-0.2-0.1-0.5-0.2-0.7-0.3c-0.3-0.2-0.4-0.4-0.2-0.7c0.1-0.2,0.3-0.4,0.5-0.6   c1.4-1.4,2.8-2.7,4.3-4.1c0.1-0.1,0.2-0.2,0.4-0.3c0.4-0.2,0.7-0.1,0.9,0.3c0.1,0.1,0.1,0.3,0.1,0.4c0.2,0.9,0.5,1.8,0.7,2.7   c0.2,1,0.5,2,0.7,3c0,0.1,0.1,0.3,0.1,0.4c0.1,0.6-0.3,1-0.9,1c-0.2,0-0.3,0-0.5-0.1c-0.3-0.1-0.5-0.1-0.7,0.2s-0.4,0.7-0.6,1   c-0.7,1.2-1.5,2.3-2.4,3.4c-0.4,0.5-1,1-1.5,1.5c-1.7,1.8-3.8,3-6,4.1c-1.2,0.6-2.3,1.1-3.6,1.5c-0.8,0.2-1.5,0.5-2.3,0.5   c-0.4,0-0.7,0.1-0.9,0.4c-0.7,0.6-1.4,1.2-1.9,1.9c-0.2,0.2-0.3,0.3-0.5,0.5c-0.5,0.4-0.9,0.4-1.4,0s-0.9-0.9-1.4-1.4   c-0.3-0.3-0.6-0.6-0.9-0.9c-0.3-0.3-0.6-0.5-1-0.6c-3.5-0.7-6.6-2.3-9.4-4.4c-2.8-2.1-5-4.7-6.6-7.8c-0.1-0.1-0.1-0.3-0.2-0.4   c-0.2-0.4-0.6-0.6-1.1-0.6c-0.2,0-0.4,0-0.6,0c-0.4,0-0.7-0.3-0.6-0.8c0-0.1,0.1-0.3,0.1-0.4c0.6-1.8,1.1-3.6,1.7-5.5   c0.1-0.2,0.1-0.5,0.2-0.7c0.3-0.5,0.7-0.6,1-0.2c0.4,0.5,0.9,0.9,1.3,1.4c0.1,0.2,0.3,0.3,0.5,0.5c0.5,0.6,1,1.2,1.5,1.7   c0.4,0.4,0.8,0.9,1.2,1.3c0.2,0.2,0.3,0.4,0.2,0.7c-0.1,0.3-0.3,0.4-0.5,0.4c-0.1,0-0.2,0-0.3,0.1c-0.4,0.1-0.4,0.2-0.2,0.6   c0.4,0.7,0.8,1.3,1.3,1.8c0.2,0.2,0.4,0.5,0.6,0.7c0.9,0.8,1.8,1.6,3.1,2.1c1.5,0.5,3,0.9,4.5,1.2c1.2,0.2,2.4,0.4,3.6,0.5   c0.1,0,0.2,0,0.3,0c0.3,0,0.4-0.1,0.4-0.4c0-0.1,0-0.3,0-0.4c0-7,0-13.9,0-20.9V778c0-0.5-0.1-0.6-0.6-0.6c-1.5,0-3.1,0-4.6,0   c-0.4,0-0.8,0.1-1.2,0.3c-0.2,0.1-0.5,0.3-0.8,0.3c-1.4,0.3-2.5-0.7-2.8-1.5c-0.4-1.1,0-2.5,1-3.1c0.5-0.3,1-0.4,1.6-0.3   c0.4,0.1,0.7,0.2,1,0.4c0.4,0.2,0.8,0.3,1.3,0.3c1.4,0,2.8,0,4.2,0c0.1,0,0.2,0,0.3,0c0.4,0,0.5-0.1,0.5-0.5c0-0.6,0-1.1,0-1.7   c0-0.3-0.2-0.5-0.4-0.6c-0.4-0.2-0.8-0.3-1.1-0.6c-2.2-1.3-3.3-3.2-3.4-5.7c-0.1-2.7,1-4.8,3.3-6.2c4.1-2.6,9.6-0.3,10.6,4.4   c0.7,3.1-0.6,6-3.4,7.5c-0.1,0.1-0.3,0.1-0.4,0.2c-0.3,0.2-0.4,0.5-0.4,0.8c0.1,0.6,0,1.2,0,1.8c0,0.4,0.1,0.4,0.4,0.4   c1.5,0,3,0,4.5,0c0.3,0,0.6-0.2,0.8-0.3c0.6-0.4,1.3-0.5,2-0.3c1.2,0.3,1.9,1.4,1.7,2.8c-0.1,1.1-1.1,2-2.3,2.1   c-0.5,0-0.9,0-1.3-0.3c-0.3-0.2-0.7-0.3-1.1-0.3c-0.6,0-1.2,0-1.9,0c-0.8,0-1.5,0-2.3,0c-0.1,0-0.2,0-0.3,0c-0.2,0-0.3,0.1-0.3,0.3   s0,0.3,0,0.5C1185.4,782,1185.4,785.6,1185.4,789.1L1185.4,789.1L1185.4,789.1z M1179.3,765c0,1,0.4,1.8,1.1,2.4   c0.8,0.7,1.7,1,2.7,1c1.8-0.1,3.4-1.7,3.3-3.8c-0.1-1.9-1.8-3.4-3.7-3.4C1180.8,761.3,1179.2,762.9,1179.3,765L1179.3,765z"
+   id="path1725" />
+	<path
+   class="st94"
+   d="M1146.9,811c-0.4,0.2-0.7,0.5-1.1,0.8s-0.8,0.6-1.2,1c-0.5,0.4-0.7,0.4-1.1-0.1c-0.2-0.2-0.4-0.4-0.6-0.7   c-0.3-0.5-0.2-0.7,0.2-1c0.9-0.7,1.8-1.4,2.7-2.2c0.8-0.7,1.7-1.4,2.5-2.1c0.1-0.1,0.2-0.2,0.3-0.2c0.3-0.2,0.5-0.2,0.7,0   c0.1,0.1,0.3,0.2,0.4,0.4c0.5,0.5,0.6,1,0.4,1.7c-0.3,0.8-0.6,1.6-0.9,2.4c-0.1,0.2-0.1,0.4-0.2,0.6c0.1,0.1,0.2,0.1,0.2,0.1   c0.9-0.1,1.8-0.3,2.7-0.4c0.8-0.1,1.5,0.1,2,0.8c0.4,0.5,0.3,0.8-0.2,1.2c-1.4,1.2-2.8,2.3-4.2,3.4c-0.4,0.3-0.8,0.6-1.2,0.9   c-0.4,0.3-0.6,0.3-1-0.1c-0.2-0.2-0.4-0.4-0.6-0.7c-0.3-0.4-0.3-0.7,0.1-1c0.6-0.5,1.3-1,1.9-1.5c0.1,0,0.1-0.1,0.2-0.1   s0.1-0.1,0.1-0.2c0-0.1-0.1-0.1-0.2-0.1c-0.3,0-0.6,0-0.9,0.1c-0.2,0-0.4,0-0.7,0c-0.5-0.1-0.8-0.5-0.8-1c0-0.2,0.1-0.5,0.1-0.7   C1146.7,811.8,1146.9,811.4,1146.9,811C1147,811,1147,811,1146.9,811C1147,811,1146.9,811,1146.9,811L1146.9,811z"
+   id="path1727" />
+	<path
+   class="st94"
+   d="M1131,785.2c0.5,0.1,0.9,0.3,1.4,0.5c0.8,0.4,1.6,0.8,2.5,1.1c2.3,0.8,4.7,1,7.1,0.8c2.4-0.1,4.7-0.8,6.8-1.9   c1.4-0.7,2.8-1.2,4.3-1.5c2.7-0.6,5.4-0.6,8.2-0.1c0.8,0.2,1.6,0.3,2.4,0.6s1.5,0.6,2.3,0.9c1.4,0.7,2.8,1.3,4.3,1.6   c1.9,0.4,3.8,0.5,5.7,0.4c1.1-0.1,2.2-0.2,3.3-0.5c0.4-0.1,0.4,0,0.4,0.3c0,0.5,0,0.6-0.5,0.7c-3.7,0.8-7.4,0.8-11-0.5   c-0.9-0.3-1.8-0.7-2.6-1.2c-1.2-0.6-2.5-1.1-3.9-1.4c-1.8-0.4-3.6-0.5-5.4-0.4c-2.4,0.1-4.6,0.7-6.7,1.8c-1.2,0.6-2.5,1.2-3.9,1.5   c-2.1,0.6-4.3,0.7-6.5,0.6c-2.4-0.1-4.6-0.7-6.8-1.8c-0.4-0.2-0.7-0.3-1.1-0.5c-0.2-0.1-0.3-0.2-0.3-0.5   C1131.1,785.6,1131,785.4,1131,785.2L1131,785.2z"
+   id="path1729" />
+	<path
+   class="st94"
+   d="M1193.5,746.7c-0.2,0-0.3,0-0.5,0c-0.7,0-1.1-0.4-1.3-1c-0.2-0.6-0.4-1.3-0.6-1.9c-0.2-0.5-0.4-0.7-0.9-0.7   c-0.2,0-0.4,0.1-0.4,0.3c-0.1,0.4-0.2,0.9-0.3,1.3c0,0.1,0,0.1,0,0.2c-0.1,0.4-0.3,0.8-0.8,0.9c-0.6,0.1-1.1-0.1-1.5-0.5   c-0.2-0.2-0.1-0.4-0.1-0.6c0.1-0.5,0.2-1,0.3-1.5c0.3-1.8,0.7-3.6,1.1-5.4c0.2-0.9,0.3-0.9,1.1-0.8c1,0.2,2,0.3,2.9,0.6   c0.4,0.1,0.8,0.2,1.2,0.4c1.1,0.5,1.6,1.3,1.6,2.5c0,0.7-0.2,1.4-0.7,2c-0.2,0.2-0.4,0.3-0.7,0.5c-0.5,0.3-0.6,0.4-0.4,0.9   c0.2,0.6,0.4,1.3,0.6,1.9c0,0.1,0.1,0.3,0.1,0.4c0.1,0.3-0.1,0.5-0.4,0.5C1193.7,746.7,1193.6,746.7,1193.5,746.7L1193.5,746.7z    M1191.5,741.2c0.2,0,0.3,0,0.5,0c0.4,0,0.7-0.2,0.8-0.5c0.1-0.4,0.1-0.7-0.3-0.9c-0.5-0.4-1.1-0.5-1.7-0.4c-0.2,0-0.3,0.1-0.4,0.2   c-0.3,0.3-0.2,0.7-0.1,1.1s0.4,0.6,0.8,0.6C1191.3,741.2,1191.4,741.2,1191.5,741.2L1191.5,741.2z"
+   id="path1731" />
+	<path
+   class="st94"
+   d="M1172.1,827.1c0.2-0.2,0.2-0.4,0.2-0.6c0.2-0.8,0.4-1.6,0.7-2.5c0.2-0.8,0.4-0.9,1.2-0.7   c0.3,0.1,0.5,0.2,0.8,0.2c0.3,0.1,0.4,0.3,0.3,0.6c0,0.2-0.1,0.4-0.1,0.6c-0.5,1.9-1.1,3.9-1.6,5.8c-0.1,0.2-0.1,0.5-0.2,0.7   c-0.1,0.3-0.2,0.4-0.6,0.4c-0.3,0-0.5-0.1-0.8-0.1c-0.4-0.1-0.7-0.3-0.9-0.7c-0.1-0.2-0.1-0.3-0.2-0.5c-0.4-1.1-0.7-2.2-1.1-3.3   c-0.1-0.1-0.1-0.3-0.2-0.4c-0.2,0-0.1,0.1-0.2,0.2c-0.2,0.9-0.5,1.8-0.7,2.6c-0.2,0.9-0.4,1-1.3,0.7c-0.2,0-0.3-0.1-0.5-0.2   c-0.5-0.2-0.6-0.4-0.5-0.9s0.2-0.9,0.4-1.3c0.5-1.8,1.1-3.6,1.5-5.4c0.1-0.5,0.2-0.5,0.7-0.5c0.9,0,1.4,0.5,1.7,1.3   c0.4,1.2,0.8,2.3,1.2,3.4C1172,826.8,1172,827,1172.1,827.1z"
+   id="path1733" />
+	<path
+   class="st94"
+   d="M1216.8,807.1c1.5,0,2.6,0.9,2.8,2.4c0.2,0.9,0.2,0.9,1,1c0.6,0.1,1.2,0.2,1.8,0.3c0.4,0.1,0.5,0.3,0.3,0.6   c-0.3,0.5-0.6,1-1.2,1.2c-0.4,0.2-0.8,0.1-1.2,0c-0.4-0.2-0.9-0.2-1.4-0.3c-0.3-0.1-0.6,0-0.8,0.2c-0.3,0.3-0.3,0.5,0.1,0.8   s0.9,0.7,1.3,1s0.4,0.5,0.2,0.9c-0.2,0.3-0.4,0.5-0.6,0.8c-0.3,0.4-0.6,0.4-1,0.1c-0.6-0.5-1.2-1-1.8-1.4c-1.1-0.8-2.2-1.7-3.3-2.6   c-0.1,0-0.1-0.1-0.2-0.1c-0.6-0.5-0.7-0.8-0.2-1.4c0.7-0.9,1.4-1.8,2.1-2.6c0.3-0.4,0.7-0.7,1.2-0.9   C1216.3,807.2,1216.6,807.1,1216.8,807.1L1216.8,807.1z M1217.5,810.2c0-0.3-0.1-0.5-0.4-0.6c-0.2-0.2-0.4-0.2-0.7-0.1   c-0.5,0.3-0.9,0.7-1.2,1.2c-0.1,0.2-0.1,0.3,0,0.4c0.2,0.3,0.5,0.5,0.8,0.7c0.2,0.1,0.3,0.1,0.4,0c0.3-0.3,0.5-0.6,0.7-0.9   C1217.3,810.6,1217.5,810.4,1217.5,810.2L1217.5,810.2z"
+   id="path1735" />
+	<path
+   class="st94"
+   d="M1173.4,746.3c-0.4,0-0.5,0-0.6-0.4c-0.1-0.6-0.2-1.3-0.4-1.9c-0.3-1.7-0.6-3.4-0.9-5.1c0-0.1,0-0.2,0-0.3   c0-0.5,0.1-0.8,0.7-0.8c1.1-0.2,2.2-0.4,3.3-0.5c0.5-0.1,1-0.2,1.5-0.3c0.7-0.1,0.8,0,0.9,0.6c0.1,0.2,0.1,0.5,0.1,0.7   c0,0.4-0.1,0.6-0.5,0.7c-0.4,0.1-0.9,0.2-1.3,0.2c-0.5,0.1-1,0.2-1.6,0.3s-0.8,0.6-0.4,1.1c0.2,0.2,0.4,0.2,0.6,0.2   c0.6-0.1,1.1-0.2,1.7-0.3c0.3-0.1,0.7-0.2,1-0.2s0.5,0.1,0.6,0.4c0.1,0.3,0.2,0.7,0.2,1c0,0.4-0.1,0.5-0.5,0.6   c-0.7,0.1-1.4,0.2-2.1,0.4c-0.2,0-0.4,0-0.6,0.1c-0.3,0.1-0.4,0.2-0.4,0.6c0,0.1,0,0.1,0,0.2c0.1,0.5,0.2,0.6,0.7,0.5   c0.8-0.1,1.7-0.3,2.5-0.4c0.2,0,0.5-0.1,0.7-0.1s0.4,0.1,0.4,0.3c0.1,0.4,0.2,0.7,0.2,1.1c0,0.3-0.1,0.4-0.3,0.5   c-0.2,0.1-0.4,0.1-0.6,0.1c-1.6,0.3-3.1,0.6-4.7,0.8C1173.6,746.3,1173.5,746.3,1173.4,746.3L1173.4,746.3z"
+   id="path1737" />
+	<path
+   class="st94"
+   d="M1196.9,830.5c-1.4,0-2.6-0.7-3.2-2.2c-0.3-0.8-0.6-1.6-0.8-2.5c-0.2-0.9,0-1.8,0.7-2.5   c1.1-1.3,3.1-1.9,4.8-1.3c0.6,0.2,1,0.5,1.3,1c0.2,0.3,0.2,0.5-0.2,0.7c-0.8,0.3-1.6,0.5-2.5,0.2c-0.9-0.4-1.9,0.4-1.8,1.4   s0.4,1.9,0.9,2.7c0.3,0.4,0.7,0.6,1.3,0.5c0.5-0.1,0.8-0.3,1.1-0.7c0.1-0.1,0.1-0.2,0.2-0.3c0.1-0.2,0.1-0.3,0-0.5s-0.3-0.1-0.5,0   c-0.1,0-0.2,0.1-0.3,0.1c-0.3,0-0.6-0.1-0.7-0.4c-0.1-0.3-0.2-0.5-0.2-0.8c-0.1-0.3,0-0.5,0.3-0.6c0.5-0.2,1-0.4,1.5-0.6   c0.3-0.1,0.5-0.2,0.8-0.3c0.4-0.1,0.6,0,0.7,0.3c0.3,0.7,0.6,1.4,0.6,2.2c0.1,0.7-0.1,1.4-0.6,2   C1199.5,829.9,1198.4,830.5,1196.9,830.5z"
+   id="path1739" />
+	<path
+   class="st94"
+   d="M1233.5,795.3c0,0.3-0.1,0.5-0.2,0.8s-0.1,0.3-0.4,0.2c-0.8-0.4-1.7-0.7-2.6-1c-1.4-0.5-2.8-0.7-4.2-0.7   c-1.9-0.1-3.8,0-5.7,0.5c-1.2,0.3-2.3,0.8-3.5,1.3c-1.8,0.9-3.8,1.6-5.8,1.9c-1.3,0.2-2.5,0.3-3.8,0.2c-1.2-0.1-2.3-0.2-3.5-0.4   h-0.1c-0.4-0.1-0.4-0.2-0.2-0.5c0.1-0.2,0.2-0.4,0.3-0.6c0.1-0.2,0.3-0.3,0.5-0.2c1.6,0.3,3.2,0.4,4.8,0.3c2.2-0.1,4.4-0.6,6.4-1.6   c1.2-0.6,2.4-1.1,3.6-1.5c2.2-0.8,4.4-0.9,6.7-0.9c2.4,0.1,4.8,0.6,7,1.6c0.1,0,0.2,0.1,0.3,0.1   C1233.5,794.9,1233.5,794.9,1233.5,795.3L1233.5,795.3z"
+   id="path1741" />
+	<path
+   class="st94"
+   d="M1209.4,816.5c0,0.2-0.2,0.4-0.3,0.5c-0.7,0.5-1.5,1-2.2,1.5c-0.1,0-0.2,0.1-0.2,0.2   c-0.1,0.1-0.2,0.2-0.1,0.4c0.1,0.1,0.1,0.3,0.2,0.4c0.3,0.3,0.4,0.3,0.7,0.1c0.6-0.5,1.3-0.9,1.9-1.4c0.1-0.1,0.2-0.1,0.3-0.2   c0.2-0.1,0.4-0.1,0.6,0c0.3,0.3,0.6,0.6,0.7,1c0.1,0.2,0.1,0.4-0.1,0.6c-0.2,0.1-0.3,0.2-0.5,0.4c-0.6,0.4-1.1,0.8-1.7,1.2   c-0.5,0.4-0.4,0.9,0.1,1.2c0.2,0.1,0.3,0,0.5-0.1c0.8-0.5,1.6-1.1,2.3-1.6c0.1-0.1,0.2-0.1,0.3-0.2c0.2-0.1,0.3-0.1,0.5,0.1   c0.3,0.3,0.5,0.7,0.7,1c0.1,0.2,0.1,0.4-0.1,0.5c-0.1,0.1-0.3,0.3-0.4,0.4c-1.2,0.9-2.5,1.8-3.7,2.6c-0.8,0.6-0.9,0.3-1.3-0.2   c-1.3-1.8-2.5-3.6-3.8-5.4c0,0-0.1-0.1-0.1-0.2c-0.3-0.5-0.3-0.7,0.2-1c0.9-0.7,1.8-1.3,2.8-2c0.4-0.3,0.8-0.5,1.2-0.8   c0.5-0.3,0.7-0.3,1,0.2c0.1,0.2,0.2,0.3,0.3,0.5C1209.4,816.2,1209.4,816.4,1209.4,816.5L1209.4,816.5z"
+   id="path1743" />
+	<path
+   class="st94"
+   d="M1158.4,825.2c0.1-0.4-0.1-0.6-0.5-0.8c-0.5-0.3-1.1-0.7-1.6-1c-0.4-0.3-0.5-0.3-0.9,0   c-0.1,0.1-0.2,0.1-0.3,0.2c-0.3,0.2-0.6,0.2-0.9,0c-0.4-0.2-0.7-0.4-1-0.7c-0.3-0.2-0.3-0.4,0-0.7c0.5-0.4,1.1-0.8,1.6-1.3   c1.4-1.1,2.9-2.2,4.3-3.3c0.6-0.4,0.7-0.4,1.3-0.1c0.3,0.2,0.6,0.3,0.9,0.5c0.6,0.4,0.7,0.7,0.5,1.4c-0.6,2.1-1,4.3-1.6,6.4   c-0.1,0.2-0.1,0.4-0.1,0.6c0,0.4-0.4,0.5-0.7,0.5c-0.3,0-0.6-0.2-0.8-0.5C1158.6,826.2,1158.4,825.7,1158.4,825.2L1158.4,825.2z    M1159.5,820.2c-0.2,0-0.3,0.2-0.4,0.2c-0.3,0.2-0.5,0.5-0.9,0.6c-0.1,0-0.2,0.2-0.3,0.3c-0.2,0.2-0.2,0.5,0.1,0.7   c0.2,0.2,0.5,0.3,0.7,0.5c0.2,0.1,0.3,0,0.3-0.2s0.2-0.4,0.2-0.7C1159.4,821.2,1159.5,820.7,1159.5,820.2L1159.5,820.2z"
+   id="path1745" />
+	<path
+   class="st94"
+   d="M1184.2,824.1c0.6,0,1,0.2,1.3,0.7c0.2,0.3,0.3,0.7,0.5,1c0.8,2,1.5,4,2.3,6c0,0.1,0.1,0.2,0.1,0.3   c0,0.2,0,0.3-0.2,0.4c-0.5,0.1-1,0.1-1.5,0.1c-0.3,0-0.5-0.2-0.6-0.4c-0.1-0.1-0.1-0.3-0.1-0.4c-0.1-0.2-0.3-0.4-0.6-0.4   c-0.8,0-1.5,0-2.3,0c-0.2,0-0.4,0.1-0.5,0.4c-0.2,0.6-1.3,1.2-2,1.1c-0.3-0.1-0.5-0.2-0.4-0.6c0-0.1,0.1-0.3,0.1-0.4   c0.7-2.2,1.4-4.4,2.1-6.7c0.2-0.7,0.5-0.9,1.3-1C1183.8,824.2,1184,824.2,1184.2,824.1L1184.2,824.1z M1184.1,826.9L1184.1,826.9   c-0.3,0.7-0.5,1.3-0.7,2c0,0.1,0,0.1,0,0.2c0,0.2,0.1,0.3,0.3,0.4c0.3,0,0.6,0,0.9,0c0.2,0,0.3-0.2,0.2-0.4   C1184.6,828.3,1184.4,827.6,1184.1,826.9z"
+   id="path1747" />
+	<path
+   class="st94"
+   d="M1156.1,746.5c-0.1-1.1,0.4-2,1.3-2.7c1-0.9,2.2-1.2,3.6-1.1c0.2,0,0.3,0.1,0.5,0.2c0.4,0.2,0.9,0.4,1.3,0.8   c0.3,0.4,0.3,0.7-0.2,1c-0.2,0.1-0.4,0.3-0.7,0.3c-0.4,0.2-0.9,0.2-1.3,0s-0.8-0.2-1.2,0c-0.9,0.3-1.2,1.1-0.8,2   c0.3,0.7,0.8,1.4,1.2,2c0.5,0.6,1.1,0.7,1.8,0.4c0.6-0.3,0.9-0.7,0.9-1.3c0.1-0.5,0.3-0.8,0.5-1.1s0.6-0.5,1-0.6   c0.2,0,0.5,0.2,0.6,0.5c0.2,0.7,0.2,1.4,0,2.1c-0.7,1.8-2.9,3.1-4.8,2.7c-0.8-0.2-1.4-0.5-1.9-1.2c-0.4-0.5-0.8-1-1.1-1.6   c-0.2-0.4-0.5-0.9-0.6-1.3C1156,747.2,1156.1,746.8,1156.1,746.5L1156.1,746.5z"
+   id="path1749" />
+	<path
+   class="st94"
+   d="M1132.2,795c0.6,0.2,1.2,0.5,1.8,0.8c1.5,0.7,3.1,1,4.8,1.2c1.3,0.1,2.5,0.1,3.8,0c1.8-0.2,3.6-0.7,5.3-1.4   c1.3-0.6,2.6-1.2,3.9-1.7c1.9-0.6,3.9-0.8,5.9-0.8c0.3,0,0.6,0,0.9,0c0.5,0,0.6,0.1,0.6,0.6c0,0.1,0,0.2,0,0.4c0,0.5,0,0.5-0.5,0.5   c-1.2,0-2.5,0-3.8,0.1c-1.7,0.2-3.3,0.7-4.8,1.5c-1.1,0.5-2.2,1-3.4,1.5c-1.8,0.6-3.7,0.8-5.6,0.9c-2.6,0.1-5.1-0.3-7.5-1.3   c-0.7-0.3-1.2-0.6-1.2-1.4C1132.3,795.5,1132,795.3,1132.2,795L1132.2,795z"
+   id="path1751" />
+	<path
+   class="st94"
+   d="M1174.4,780.4c-3,0.1-5.8-0.6-8.5-1.9c-2.8-1.4-5.7-2.1-8.8-2c-2.6,0.1-5.1,0.6-7.4,1.8   c-1.2,0.6-2.3,1.1-3.6,1.5c-1.9,0.6-3.9,0.8-6,0.7c-2.6,0-5-0.6-7.4-1.7c-0.3-0.2-0.7-0.3-1-0.5c-0.2-0.1-0.3-0.2-0.3-0.4   c0-0.3,0.1-0.4,0.4-0.3c1.6,0.8,3.2,1.5,4.9,1.8c1.6,0.3,3.2,0.4,4.8,0.3c1.4,0,2.8-0.2,4.2-0.7c1.1-0.3,2.2-0.8,3.3-1.3   c2.5-1.2,5.1-2,7.9-2c1.4,0,2.8,0,4.1,0.2c1.8,0.3,3.6,1,5.2,1.8s3.2,1.4,5,1.7c1.6,0.3,3.2,0.3,4.9,0.2c1.1-0.1,2.2-0.2,3.2-0.5   c0.1,0,0.3-0.2,0.4,0.1c0.1,0.2,0,0.4-0.2,0.5c-0.1,0-0.2,0-0.3,0.1c-1.3,0.3-2.7,0.5-4.1,0.5   C1174.9,780.4,1174.6,780.4,1174.4,780.4L1174.4,780.4z"
+   id="path1753" />
+	<path
+   class="st94"
+   d="M1204.9,787.4c0.6,0,1.1,0.1,1.7,0.2c3.3,0.3,6.5-0.3,9.5-1.7c1.3-0.7,2.7-1.2,4.1-1.6   c1.9-0.5,3.8-0.6,5.7-0.5c0.8,0,1.7,0.1,2.5,0.2c0.3,0,0.6,0.2,0.9,0.2c1.7,0.3,3.3,1,4.8,1.8c0.4,0.2,0.6,0.7,0.5,1.1   c-0.1,0.2-0.1,0.2-0.3,0.1c-0.5-0.2-1-0.5-1.5-0.7c-2.2-1.1-4.6-1.6-7.1-1.7c-2.6-0.1-5.1,0.3-7.5,1.3c-0.9,0.4-1.8,0.9-2.8,1.3   c-2.3,0.9-4.7,1.4-7.2,1.3c-0.8,0-1.6,0-2.4-0.1c-0.5,0-0.6-0.1-0.7-0.6C1205,787.8,1204.8,787.6,1204.9,787.4L1204.9,787.4z"
+   id="path1755" />
+	<path
+   class="st94"
+   d="M1211.1,746.1c0,0.4-0.6,1.2-0.9,1.3c-0.2,0.1-0.3,0-0.5-0.1c-0.4-0.2-0.7-0.4-1.1-0.6s-0.6-0.1-0.8,0.2   c-0.2,0.3-0.4,0.6-0.6,0.9c-0.7,1.1-1.4,2.2-2.2,3.4c-0.4,0.7-0.6,0.7-1.3,0.3c-0.2-0.1-0.4-0.3-0.6-0.4c-0.4-0.3-0.5-0.5-0.2-1   c0.7-1.1,1.4-2.2,2.1-3.3c0.3-0.5,0.6-0.9,0.8-1.3c0.1-0.2,0.1-0.3-0.1-0.5s-0.4-0.3-0.6-0.4c-0.2-0.1-0.5-0.2-0.7-0.4   c-0.3-0.2-0.3-0.5-0.2-0.8c0.1-0.3,0.3-0.6,0.5-0.8s0.4-0.2,0.7-0.1c0.1,0,0.2,0.1,0.4,0.2c1.6,1,3.1,2,4.7,3   c0.1,0.1,0.2,0.2,0.4,0.3C1211,745.8,1211.1,745.9,1211.1,746.1L1211.1,746.1z"
+   id="path1757" />
+	<path
+   class="st94"
+   d="M1234.4,778.6c0,0.2-0.1,0.3-0.2,0.2c-0.4-0.2-0.8-0.4-1.3-0.6c-1.2-0.5-2.4-1-3.7-1.3   c-1.7-0.4-3.4-0.4-5.2-0.4c-2.6,0.1-4.9,0.8-7.2,1.9c-1.7,0.8-3.4,1.5-5.3,1.8c-1.6,0.3-3.3,0.3-4.9,0.2c-2.4-0.1-4.7-0.9-6.9-1.9   c-1.1-0.5-2.1-1-3.3-1.3c-0.1,0-0.1,0-0.2-0.1c-0.2-0.1-0.2-0.2-0.2-0.5c0.1-0.2,0.2-0.2,0.4-0.1c1.2,0.3,2.3,0.8,3.4,1.4   c1.6,0.8,3.3,1.4,5.1,1.7c1.7,0.3,3.4,0.3,5.2,0.2c1.4-0.1,2.8-0.4,4.2-0.8c1-0.3,1.9-0.8,2.9-1.3c2.6-1.2,5.3-1.8,8.2-1.8   c1.9,0,3.8,0.2,5.6,0.8c1.1,0.3,2.1,0.9,3.1,1.3C1234.2,778.2,1234.4,778.4,1234.4,778.6L1234.4,778.6z"
+   id="path1759" />
+	<path
+   class="st94"
+   d="M1202.3,786.7c-0.3,0.5-0.6,0.6-1.1,0.5c-0.2,0-0.5-0.1-0.7-0.2c-0.7-0.3-1.4-0.6-2.1-1   c-2.1-1-4.4-1.4-6.7-1.4c-1.6,0-3.1,0-4.7,0.4c-0.3,0.1-0.3,0-0.4-0.3v-0.1c0-0.5,0-0.6,0.6-0.7c1.8-0.3,3.5-0.5,5.3-0.4   c0.8,0,1.6,0.1,2.4,0.3s1.5,0.3,2.2,0.6c0.7,0.2,1.4,0.5,2.1,0.9c0.9,0.4,1.8,0.8,2.7,1.2C1202,786.6,1202.2,786.6,1202.3,786.7   L1202.3,786.7z"
+   id="path1761" />
+	<path
+   class="st94"
+   d="M1191.2,793c1.7,0,3.3,0.2,4.9,0.5c0.5,0.1,0.7,0.5,1,0.9c0,0,0,0.1,0,0.2c-0.1,0.3-0.6,0.5-0.9,0.4   c-1.9-0.5-3.9-0.7-5.9-0.6c-1,0-2,0.2-3,0.4c-0.1,0-0.2,0-0.2,0c-0.3,0.1-0.4,0-0.4-0.3c0-0.1,0-0.3,0-0.4c0-0.6,0.1-0.7,0.7-0.8   c1.2-0.2,2.4-0.3,3.6-0.4C1191,793,1191.1,793,1191.2,793L1191.2,793z"
+   id="path1763" />
+	<path
+   class="st94"
+   d="M1172.5,797c0.3,0,0.7,0,1,0c1.9,0.1,3.9-0.1,5.8-0.6c0.3-0.1,0.4-0.1,0.4,0.3c0.1,0.9,0,1-0.9,1.3   c-0.8,0.3-1.7,0.3-2.6,0.2c-1.1-0.2-2.1-0.5-3.1-0.8C1172.9,797.3,1172.6,797.2,1172.5,797L1172.5,797z"
+   id="path1765" />
+	<path
+   class="st67"
+   d="M1179.3,765c-0.1-2.1,1.5-3.7,3.5-3.8c1.9-0.1,3.6,1.5,3.7,3.4c0.1,2.1-1.5,3.7-3.3,3.8c-1,0-2-0.2-2.7-1   C1179.7,766.8,1179.3,766,1179.3,765L1179.3,765z"
+   id="path1767" />
+	<path
+   class="st67"
+   d="M1146.9,811L1146.9,811C1147,811,1147,811.1,1146.9,811C1146.9,811.1,1146.9,811.1,1146.9,811L1146.9,811z"
+   id="path1769" />
+	<path
+   class="st67"
+   d="M1191.6,741.2c-0.1,0-0.3,0-0.4,0c-0.4,0-0.7-0.2-0.8-0.6c-0.1-0.4-0.1-0.8,0.1-1.1c0.1-0.1,0.2-0.2,0.4-0.2   c0.6-0.1,1.2,0,1.7,0.4c0.3,0.3,0.4,0.6,0.3,0.9c-0.1,0.4-0.4,0.5-0.8,0.5C1191.9,741.3,1191.8,741.3,1191.6,741.2L1191.6,741.2z"
+   id="path1771" />
+	<path
+   class="st67"
+   d="M1217.5,810.2c-0.1,0.2-0.2,0.5-0.3,0.7c-0.2,0.3-0.4,0.6-0.7,0.9c-0.1,0.1-0.3,0.2-0.4,0   c-0.3-0.2-0.6-0.5-0.8-0.7c-0.1-0.1-0.1-0.2,0-0.4c0.3-0.5,0.7-0.9,1.2-1.2c0.2-0.1,0.5-0.1,0.7,0.1   C1217.4,809.7,1217.5,809.9,1217.5,810.2L1217.5,810.2z"
+   id="path1773" />
+	<path
+   class="st67"
+   d="M1159.5,820.2c0,0.5-0.1,1-0.3,1.5c-0.1,0.2-0.2,0.4-0.2,0.7c0,0.2-0.2,0.3-0.3,0.2c-0.2-0.2-0.5-0.3-0.7-0.5   s-0.2-0.4-0.1-0.7c0.1-0.1,0.2-0.2,0.3-0.3c0.3-0.2,0.6-0.4,0.9-0.6C1159.3,820.4,1159.4,820.3,1159.5,820.2L1159.5,820.2z"
+   id="path1775" />
+	<path
+   class="st67"
+   d="M1184.1,826.9c0.3,0.7,0.5,1.4,0.8,2.1c0.1,0.2,0,0.3-0.2,0.4c-0.3,0.1-0.6,0.1-0.9,0c-0.2,0-0.3-0.2-0.3-0.4   c0-0.1,0-0.1,0-0.2c0.2-0.7,0.4-1.3,0.6-2C1184.1,826.9,1184.1,826.9,1184.1,826.9z"
+   id="path1777" />
+</g>
+<g
+   aria-label="Continuous"
+   transform="matrix(-8.074733e-04 -1 1 -8.074733e-04 111.0354 262.3661)"
+   id="text1781"
+   class="st3 st95 st96"
+   style="font-size:36px;font-family:Poppins-SemiBold;fill:#ffffff"><path
+     d="m 23.185547,-24.222656 v 3.74414 q -1.792969,-1.669921 -3.832031,-2.496093 -2.021485,-0.826172 -4.306641,-0.826172 -4.5,0 -6.890625,2.759765 -2.390625,2.742188 -2.390625,7.945313 0,5.1855468 2.390625,7.9453124 2.390625,2.7421875 6.890625,2.7421875 2.285156,0 4.306641,-0.8261719 2.039062,-0.8261719 3.832031,-2.4960937 v 3.7089843 q -1.863281,1.26562503 -3.955078,1.89843753 -2.074219,0.63281249 -4.394531,0.63281249 -5.9589849,0 -9.3867193,-3.63867192 -3.4277343,-3.6562499 -3.4277343,-9.9667967 0,-6.328125 3.4277343,-9.966797 3.4277344,-3.65625 9.3867193,-3.65625 2.355468,0 4.429687,0.632813 2.091797,0.615234 3.919922,1.863281 z"
+     id="path9660" /><path
+     d="m 36.158203,-17.419922 q -2.601562,0 -4.113281,2.039063 -1.511719,2.021484 -1.511719,5.5546871 0,3.5332032 1.494141,5.5722657 1.511718,2.0214843 4.130859,2.0214843 2.583984,0 4.095703,-2.0390625 1.511719,-2.0390625 1.511719,-5.5546875 0,-3.4980471 -1.511719,-5.5371091 -1.511719,-2.056641 -4.095703,-2.056641 z m 0,-2.742187 q 4.21875,0 6.626953,2.742187 2.408203,2.742188 2.408203,7.5937501 0,4.8339844 -2.408203,7.59375 -2.408203,2.74218752 -6.626953,2.74218752 -4.236328,0 -6.644531,-2.74218752 -2.390625,-2.7597656 -2.390625,-7.59375 0,-4.8515621 2.390625,-7.5937501 2.408203,-2.742187 6.644531,-2.742187 z"
+     id="path9662" /><path
+     d="M 66.919922,-11.882813 V 0 h -3.234375 v -11.777344 q 0,-2.794922 -1.089844,-4.183594 -1.089844,-1.388671 -3.269531,-1.388671 -2.619141,0 -4.13086,1.669921 -1.511718,1.669922 -1.511718,4.552735 V 0 h -3.251953 v -19.6875 h 3.251953 v 3.058594 q 1.160156,-1.775391 2.724609,-2.654297 1.582031,-0.878906 3.638672,-0.878906 3.392578,0 5.132812,2.109375 1.740235,2.091796 1.740235,6.169921 z"
+     id="path9664" /><path
+     d="m 76.570312,-25.277344 v 5.589844 h 6.66211 v 2.513672 h -6.66211 v 10.6874999 q 0,2.4082031 0.650391,3.09375 0.667969,0.6855468 2.689453,0.6855468 h 3.322266 V 0 h -3.322266 q -3.74414,0 -5.167969,-1.3886719 -1.423828,-1.40625 -1.423828,-5.0976562 V -17.173828 H 70.945312 V -19.6875 h 2.373047 v -5.589844 z"
+     id="path9666" /><path
+     d="m 87.486328,-19.6875 h 3.234375 V 0 h -3.234375 z m 0,-7.664062 h 3.234375 v 4.095703 h -3.234375 z"
+     id="path9668" /><path
+     d="M 113.85352,-11.882813 V 0 h -3.23438 v -11.777344 q 0,-2.794922 -1.08984,-4.183594 -1.08985,-1.388671 -3.26953,-1.388671 -2.61914,0 -4.13086,1.669921 -1.51172,1.669922 -1.51172,4.552735 V 0 h -3.251956 v -19.6875 h 3.251956 v 3.058594 q 1.16015,-1.775391 2.72461,-2.654297 1.58203,-0.878906 3.63867,-0.878906 3.39258,0 5.13281,2.109375 1.74024,2.091796 1.74024,6.169921 z"
+     id="path9670" /><path
+     d="M 119.9707,-7.7695312 V -19.6875 h 3.23438 v 11.7949219 q 0,2.7949219 1.08984,4.2011718 1.08985,1.3886719 3.26953,1.3886719 2.61914,0 4.13086,-1.6699219 1.5293,-1.6699218 1.5293,-4.5527343 V -19.6875 h 3.23437 V 0 h -3.23437 v -3.0234375 q -1.17774,1.7929688 -2.74219,2.671875 -1.54687,0.86132812 -3.60351,0.86132812 -3.39258,0 -5.15039,-2.10937502 -1.75782,-2.109375 -1.75782,-6.1699218 z m 8.13867,-12.3925778 z"
+     id="path9672" /><path
+     d="m 150.75,-17.419922 q -2.60156,0 -4.11328,2.039063 -1.51172,2.021484 -1.51172,5.5546871 0,3.5332032 1.49414,5.5722657 1.51172,2.0214843 4.13086,2.0214843 2.58398,0 4.0957,-2.0390625 1.51172,-2.0390625 1.51172,-5.5546875 0,-3.4980471 -1.51172,-5.5371091 -1.51172,-2.056641 -4.0957,-2.056641 z m 0,-2.742187 q 4.21875,0 6.62695,2.742187 2.40821,2.742188 2.40821,7.5937501 0,4.8339844 -2.40821,7.59375 -2.4082,2.74218752 -6.62695,2.74218752 -4.23633,0 -6.64453,-2.74218752 -2.39063,-2.7597656 -2.39063,-7.59375 0,-4.8515621 2.39063,-7.5937501 2.4082,-2.742187 6.64453,-2.742187 z"
+     id="path9674" /><path
+     d="M 164.8125,-7.7695312 V -19.6875 h 3.23437 v 11.7949219 q 0,2.7949219 1.08985,4.2011718 1.08984,1.3886719 3.26953,1.3886719 2.61914,0 4.13086,-1.6699219 1.5293,-1.6699218 1.5293,-4.5527343 V -19.6875 h 3.23437 V 0 h -3.23437 v -3.0234375 q -1.17774,1.7929688 -2.74219,2.671875 -1.54688,0.86132812 -3.60352,0.86132812 -3.39258,0 -5.15039,-2.10937502 -1.75781,-2.109375 -1.75781,-6.1699218 z m 8.13867,-12.3925778 z"
+     id="path9676" /><path
+     d="m 200.51367,-19.107422 v 3.058594 q -1.37109,-0.703125 -2.84765,-1.054688 -1.47657,-0.351562 -3.0586,-0.351562 -2.4082,0 -3.62109,0.738281 -1.19531,0.738281 -1.19531,2.214844 0,1.125 0.86132,1.77539 0.86133,0.632813 3.46289,1.212891 l 1.10743,0.246094 q 3.44531,0.738281 4.88671,2.0917967 1.45899,1.3359376 1.45899,3.7441407 0,2.7421875 -2.17969,4.3417969 -2.16211,1.59960932 -5.95898,1.59960932 -1.58203,0 -3.30469,-0.31640625 -1.70508,-0.29882812 -3.60352,-0.91406249 V -4.0605469 q 1.79297,0.9316406 3.53321,1.40625 1.74023,0.4570313 3.44531,0.4570313 2.28516,0 3.51562,-0.7734375 1.23047,-0.7910157 1.23047,-2.2148438 0,-1.3183593 -0.89648,-2.0214843 -0.87891,-0.703125 -3.88477,-1.3535157 l -1.125,-0.2636719 q -3.00586,-0.6328125 -4.34179,-1.9335942 -1.33594,-1.318359 -1.33594,-3.603515 0,-2.777344 1.96875,-4.289063 1.96875,-1.511718 5.58984,-1.511718 1.79297,0 3.375,0.263672 1.58203,0.263671 2.91797,0.791015 z"
+     id="path9678" /></g>
+<g
+   aria-label="Delivery"
+   transform="matrix(-8.074733e-04 -1 1 -8.074733e-04 154.2094 230.2314)"
+   id="text1783"
+   class="st3 st95 st96"
+   style="font-size:36px;font-family:Poppins-SemiBold;fill:#ffffff"><path
+     d="m 7.0839844,-23.326172 v 20.4082032 h 4.2890626 q 5.43164,0 7.945312,-2.4609374 2.53125,-2.4609375 2.53125,-7.7695318 0,-5.273437 -2.53125,-7.716796 -2.513672,-2.460938 -7.945312,-2.460938 z m -3.5507813,-2.917969 h 7.2949219 q 7.628906,0 11.197266,3.181641 3.568359,3.164063 3.568359,9.914062 0,6.7851568 -3.585938,9.9667974 Q 18.421875,0 10.828125,0 H 3.5332031 Z"
+     id="path9681" /><path
+     d="m 47.953125,-10.652344 v 1.5820315 H 33.082031 q 0.210938,3.3398438 2.003906,5.0976562 1.810547,1.7402344 5.027344,1.7402344 1.863281,0 3.603516,-0.4570312 1.757812,-0.4570313 3.480469,-1.3710938 v 3.0585938 q -1.740235,0.73828122 -3.56836,1.12499997 -1.828125,0.38671875 -3.708984,0.38671875 -4.710938,0 -7.470703,-2.74218752 -2.742188,-2.7421875 -2.742188,-7.4179687 0,-4.8339844 2.601563,-7.6640624 2.61914,-2.847656 7.048828,-2.847656 3.972656,0 6.27539,2.566406 2.320313,2.548828 2.320313,6.943359 z m -3.234375,-0.949219 q -0.03516,-2.654296 -1.494141,-4.236328 -1.441406,-1.582031 -3.832031,-1.582031 -2.707031,0 -4.341797,1.529297 -1.617187,1.529297 -1.863281,4.306641 z"
+     id="path9683" /><path
+     d="m 53.261719,-27.351562 h 3.234375 V 0 h -3.234375 z"
+     id="path9685" /><path
+     d="m 63.263672,-19.6875 h 3.234375 V 0 h -3.234375 z m 0,-7.664062 h 3.234375 v 4.095703 h -3.234375 z"
+     id="path9687" /><path
+     d="m 70.945312,-19.6875 h 3.427735 L 80.525391,-3.1640625 86.677734,-19.6875 h 3.427735 L 82.722656,0 h -4.394531 z"
+     id="path9689" /><path
+     d="m 111.41016,-10.652344 v 1.5820315 H 96.539062 q 0.210938,3.3398438 2.003907,5.0976562 1.810551,1.7402344 5.027341,1.7402344 1.86328,0 3.60352,-0.4570312 1.75781,-0.4570313 3.48047,-1.3710938 v 3.0585938 q -1.74024,0.73828122 -3.56836,1.12499997 -1.82813,0.38671875 -3.70899,0.38671875 -4.710934,0 -7.4707,-2.74218752 -2.742188,-2.7421875 -2.742188,-7.4179687 0,-4.8339844 2.601563,-7.6640624 2.619141,-2.847656 7.048825,-2.847656 3.97266,0 6.27539,2.566406 2.32032,2.548828 2.32032,6.943359 z m -3.23438,-0.949219 q -0.0352,-2.654296 -1.49414,-4.236328 -1.44141,-1.582031 -3.83203,-1.582031 -2.70703,0 -4.341798,1.529297 -1.617187,1.529297 -1.863281,4.306641 z"
+     id="path9691" /><path
+     d="m 128.12695,-16.664062 q -0.54492,-0.316407 -1.19531,-0.457032 -0.63281,-0.158203 -1.40625,-0.158203 -2.74219,0 -4.21875,1.792969 -1.45898,1.77539 -1.45898,5.115234 V 0 h -3.25196 v -19.6875 h 3.25196 v 3.058594 q 1.01953,-1.792969 2.65429,-2.654297 1.63477,-0.878906 3.97266,-0.878906 0.33398,0 0.73828,0.05273 0.4043,0.03516 0.89648,0.123047 z"
+     id="path9693" /><path
+     d="m 139.71094,1.828125 q -1.3711,3.515625 -2.67188,4.5878906 -1.30078,1.0722656 -3.48047,1.0722656 h -2.58398 V 4.78125 h 1.89844 q 1.33593,0 2.07422,-0.6328125 0.73828,-0.6328125 1.63476,-2.9882813 L 137.16211,-0.31640625 129.19922,-19.6875 h 3.42773 l 6.15235,15.3984375 6.15234,-15.3984375 h 3.42773 z"
+     id="path9695" /></g>
+<g
+   aria-label="Security"
+   transform="matrix(-8.074733e-04 -1 1 -8.074733e-04 128.5162 569.7411)"
+   id="text1785"
+   class="st3 st95 st96"
+   style="font-size:36px;font-family:Poppins-SemiBold;fill:#ffffff"><path
+     d="m 19.265625,-25.382812 v 3.46289 q -2.021484,-0.966797 -3.814453,-1.441406 -1.792969,-0.474609 -3.462891,-0.474609 -2.9003904,0 -4.4824216,1.125 -1.5644532,1.125 -1.5644532,3.199218 0,1.740235 1.0371094,2.636719 1.0546875,0.878906 3.9726564,1.423828 l 2.144531,0.439453 q 3.972656,0.75586 5.853516,2.671875 1.898437,1.898438 1.898437,5.0976565 0,3.8144531 -2.566406,5.7832031 -2.548828,1.96875002 -7.488281,1.96875002 -1.8632815,0 -3.9726565,-0.421875 -2.0917969,-0.421875 -4.3417969,-1.24804682 v -3.65625 q 2.1621094,1.2128906 4.2363281,1.8281249 2.0742188,0.6152344 4.0781253,0.6152344 3.041015,0 4.693359,-1.1953125 1.652344,-1.1953125 1.652344,-3.4101562 0,-1.9335938 -1.195313,-3.0234374 -1.177734,-1.089844 -3.884765,-1.634766 l -2.1621096,-0.421875 q -3.9726563,-0.791015 -5.7480469,-2.478515 -1.7753906,-1.6875 -1.7753906,-4.69336 0,-3.480468 2.4433593,-5.484375 2.4609375,-2.003906 6.7675778,-2.003906 1.845704,0 3.761719,0.333984 1.916016,0.333985 3.919922,1.001954 z"
+     id="path9923" /><path
+     d="m 43.083984,-10.652344 v 1.5820315 H 28.212891 q 0.210937,3.3398438 2.003906,5.0976562 1.810547,1.7402344 5.027344,1.7402344 1.863281,0 3.603515,-0.4570312 1.757813,-0.4570313 3.480469,-1.3710938 v 3.0585938 q -1.740234,0.73828122 -3.568359,1.12499997 -1.828125,0.38671875 -3.708985,0.38671875 -4.710937,0 -7.470703,-2.74218752 -2.742187,-2.7421875 -2.742187,-7.4179687 0,-4.8339844 2.601562,-7.6640624 2.619141,-2.847656 7.048828,-2.847656 3.972656,0 6.275391,2.566406 2.320312,2.548828 2.320312,6.943359 z m -3.234375,-0.949219 q -0.03516,-2.654296 -1.49414,-4.236328 -1.441407,-1.582031 -3.832032,-1.582031 -2.707031,0 -4.341796,1.529297 -1.617188,1.529297 -1.863282,4.306641 z"
+     id="path9925" /><path
+     d="m 62.560547,-18.931641 v 3.023438 q -1.371094,-0.755859 -2.759766,-1.125 -1.371094,-0.386719 -2.777344,-0.386719 -3.146484,0 -4.886718,2.003906 -1.740235,1.986328 -1.740235,5.5898441 0,3.6035157 1.740235,5.6074219 1.740234,1.9863281 4.886718,1.9863281 1.40625,0 2.777344,-0.3691406 1.388672,-0.3867188 2.759766,-1.1425781 v 2.98828123 q -1.353516,0.6328125 -2.8125,0.94921874 -1.441406,0.31640625 -3.076172,0.31640625 -4.447266,0 -7.066406,-2.79492192 -2.619141,-2.7949218 -2.619141,-7.5410156 0,-4.8164061 2.636719,-7.5761721 2.654297,-2.759765 7.259765,-2.759765 1.494141,0 2.917969,0.316406 1.423828,0.298828 2.759766,0.914062 z"
+     id="path9927" /><path
+     d="M 67.851562,-7.7695312 V -19.6875 h 3.234375 v 11.7949219 q 0,2.7949219 1.089844,4.2011718 1.089844,1.3886719 3.269531,1.3886719 2.619141,0 4.13086,-1.6699219 1.529297,-1.6699218 1.529297,-4.5527343 V -19.6875 h 3.234375 V 0 h -3.234375 v -3.0234375 q -1.177735,1.7929688 -2.742188,2.671875 -1.546875,0.86132812 -3.603515,0.86132812 -3.392579,0 -5.150391,-2.10937502 -1.757813,-2.109375 -1.757813,-6.1699218 z m 8.138672,-12.3925778 z"
+     id="path9929" /><path
+     d="m 102.41016,-16.664062 q -0.54493,-0.316407 -1.19532,-0.457032 -0.63281,-0.158203 -1.406246,-0.158203 -2.742188,0 -4.21875,1.792969 -1.458985,1.77539 -1.458985,5.115234 V 0 h -3.251953 v -19.6875 h 3.251953 v 3.058594 q 1.019532,-1.792969 2.654297,-2.654297 1.634766,-0.878906 3.972654,-0.878906 0.33399,0 0.73828,0.05273 0.4043,0.03516 0.89649,0.123047 z"
+     id="path9931" /><path
+     d="m 105.80273,-19.6875 h 3.23438 V 0 h -3.23438 z m 0,-7.664062 h 3.23438 v 4.095703 h -3.23438 z"
+     id="path9933" /><path
+     d="m 119.00391,-25.277344 v 5.589844 h 6.66211 v 2.513672 h -6.66211 v 10.6874999 q 0,2.4082031 0.65039,3.09375 0.66797,0.6855468 2.68945,0.6855468 h 3.32227 V 0 h -3.32227 q -3.74414,0 -5.16797,-1.3886719 -1.42383,-1.40625 -1.42383,-5.0976562 V -17.173828 h -2.37304 V -19.6875 h 2.37304 v -5.589844 z"
+     id="path9935" /><path
+     d="m 138.11133,1.828125 q -1.3711,3.515625 -2.67188,4.5878906 -1.30078,1.0722656 -3.48047,1.0722656 H 129.375 V 4.78125 h 1.89844 q 1.33593,0 2.07422,-0.6328125 0.73828,-0.6328125 1.63476,-2.9882813 L 135.5625,-0.31640625 127.59961,-19.6875 h 3.42773 l 6.15235,15.3984375 6.15234,-15.3984375 h 3.42774 z"
+     id="path9937" /></g>
+<g
+   aria-label="Disaster"
+   transform="matrix(-8.074733e-04 -1 1 -8.074733e-04 103.4904 898.5986)"
+   id="text1787"
+   class="st3 st95 st96"
+   style="font-size:36px;font-family:Poppins-SemiBold;fill:#ffffff"><path
+     d="m 7.0839844,-23.326172 v 20.4082032 h 4.2890626 q 5.43164,0 7.945312,-2.4609374 2.53125,-2.4609375 2.53125,-7.7695318 0,-5.273437 -2.53125,-7.716796 -2.513672,-2.460938 -7.945312,-2.460938 z m -3.5507813,-2.917969 h 7.2949219 q 7.628906,0 11.197266,3.181641 3.568359,3.164063 3.568359,9.914062 0,6.7851568 -3.585938,9.9667974 Q 18.421875,0 10.828125,0 H 3.5332031 Z"
+     id="path9889" /><path
+     d="m 31.113281,-19.6875 h 3.234375 V 0 h -3.234375 z m 0,-7.664062 h 3.234375 v 4.095703 h -3.234375 z"
+     id="path9891" /><path
+     d="m 53.666016,-19.107422 v 3.058594 q -1.371094,-0.703125 -2.847657,-1.054688 -1.476562,-0.351562 -3.058593,-0.351562 -2.408204,0 -3.621094,0.738281 -1.195313,0.738281 -1.195313,2.214844 0,1.125 0.861328,1.77539 0.861329,0.632813 3.462891,1.212891 l 1.107422,0.246094 q 3.445312,0.738281 4.886719,2.0917967 1.458984,1.3359376 1.458984,3.7441407 0,2.7421875 -2.179687,4.3417969 -2.16211,1.59960932 -5.958985,1.59960932 -1.582031,0 -3.304687,-0.31640625 -1.705078,-0.29882812 -3.603516,-0.91406249 V -4.0605469 q 1.792969,0.9316406 3.533203,1.40625 1.740235,0.4570313 3.445313,0.4570313 2.285156,0 3.515625,-0.7734375 1.230468,-0.7910157 1.230468,-2.2148438 0,-1.3183593 -0.896484,-2.0214843 -0.878906,-0.703125 -3.884766,-1.3535157 l -1.125,-0.2636719 q -3.005859,-0.6328125 -4.341796,-1.9335942 -1.335938,-1.318359 -1.335938,-3.603515 0,-2.777344 1.96875,-4.289063 1.96875,-1.511718 5.589844,-1.511718 1.792969,0 3.375,0.263672 1.582031,0.263671 2.917969,0.791015 z"
+     id="path9893" /><path
+     d="m 68.818359,-9.8964844 q -3.919922,0 -5.43164,0.8964844 -1.511719,0.8964844 -1.511719,3.0585938 0,1.7226562 1.125,2.7421874 1.142578,1.0019532 3.09375,1.0019532 2.689453,0 4.306641,-1.8984375 1.634765,-1.9160156 1.634765,-5.0800782 v -0.7207031 z m 6.451172,-1.3359376 V 0 h -3.234375 v -2.9882813 q -1.107422,1.7929688 -2.759765,2.65429692 -1.652344,0.84375 -4.042969,0.84375 -3.023438,0 -4.816406,-1.68750002 -1.775391,-1.7050781 -1.775391,-4.5527343 0,-3.3222657 2.214844,-5.0097653 2.232422,-1.6875 6.644531,-1.6875 h 4.535156 v -0.316407 q 0,-2.232422 -1.476562,-3.445312 -1.458985,-1.230469 -4.113282,-1.230469 -1.6875,0 -3.287109,0.404297 -1.599609,0.404297 -3.076172,1.212891 v -2.988282 q 1.775391,-0.685546 3.445313,-1.019531 1.669922,-0.351562 3.251953,-0.351562 4.271484,0 6.380859,2.214843 2.109375,2.214844 2.109375,6.714844 z"
+     id="path9895" /><path
+     d="m 94.482422,-19.107422 v 3.058594 q -1.371094,-0.703125 -2.847656,-1.054688 -1.476563,-0.351562 -3.058594,-0.351562 -2.408203,0 -3.621094,0.738281 -1.195312,0.738281 -1.195312,2.214844 0,1.125 0.861328,1.77539 0.861328,0.632813 3.46289,1.212891 l 1.107422,0.246094 q 3.445313,0.738281 4.886719,2.0917967 1.458984,1.3359376 1.458984,3.7441407 0,2.7421875 -2.179687,4.3417969 -2.16211,1.59960932 -5.958985,1.59960932 -1.582031,0 -3.304687,-0.31640625 -1.705078,-0.29882812 -3.603516,-0.91406249 V -4.0605469 q 1.792969,0.9316406 3.533203,1.40625 1.740235,0.4570313 3.445313,0.4570313 2.285156,0 3.515625,-0.7734375 1.230469,-0.7910157 1.230469,-2.2148438 0,-1.3183593 -0.896485,-2.0214843 -0.878906,-0.703125 -3.884765,-1.3535157 l -1.125,-0.2636719 q -3.00586,-0.6328125 -4.341797,-1.9335942 -1.335938,-1.318359 -1.335938,-3.603515 0,-2.777344 1.96875,-4.289063 1.96875,-1.511718 5.589844,-1.511718 1.792969,0 3.375,0.263672 1.582031,0.263671 2.917969,0.791015 z"
+     id="path9897" /><path
+     d="m 103.88672,-25.277344 v 5.589844 h 6.66211 v 2.513672 h -6.66211 v 10.6874999 q 0,2.4082031 0.65039,3.09375 0.66797,0.6855468 2.68945,0.6855468 h 3.32227 V 0 h -3.32227 q -3.74414,0 -5.16797,-1.3886719 -1.42382,-1.40625 -1.42382,-5.0976562 V -17.173828 H 98.261719 V -19.6875 h 2.373051 v -5.589844 z"
+     id="path9899" /><path
+     d="m 131.64258,-10.652344 v 1.5820315 h -14.8711 q 0.21094,3.3398438 2.00391,5.0976562 1.81055,1.7402344 5.02734,1.7402344 1.86329,0 3.60352,-0.4570312 1.75781,-0.4570313 3.48047,-1.3710938 v 3.0585938 q -1.74024,0.73828122 -3.56836,1.12499997 -1.82813,0.38671875 -3.70898,0.38671875 -4.71094,0 -7.47071,-2.74218752 -2.74219,-2.7421875 -2.74219,-7.4179687 0,-4.8339844 2.60157,-7.6640624 2.61914,-2.847656 7.04883,-2.847656 3.97265,0 6.27539,2.566406 2.32031,2.548828 2.32031,6.943359 z m -3.23438,-0.949219 q -0.0351,-2.654296 -1.49414,-4.236328 -1.4414,-1.582031 -3.83203,-1.582031 -2.70703,0 -4.3418,1.529297 -1.61718,1.529297 -1.86328,4.306641 z"
+     id="path9901" /><path
+     d="m 148.35937,-16.664062 q -0.54492,-0.316407 -1.19531,-0.457032 -0.63281,-0.158203 -1.40625,-0.158203 -2.74219,0 -4.21875,1.792969 -1.45898,1.77539 -1.45898,5.115234 V 0 h -3.25196 v -19.6875 h 3.25196 v 3.058594 q 1.01953,-1.792969 2.65429,-2.654297 1.63477,-0.878906 3.97266,-0.878906 0.33399,0 0.73828,0.05273 0.4043,0.03516 0.89649,0.123047 z"
+     id="path9903" /></g>
+<g
+   aria-label="Recovery"
+   transform="matrix(-8.074733e-04 -1 1 -8.074733e-04 146.6984 908.4638)"
+   id="text1789"
+   class="st3 st95 st96"
+   style="font-size:36px;font-family:Poppins-SemiBold;fill:#ffffff"><path
+     d="m 15.978516,-12.304688 q 1.142578,0.386719 2.214843,1.652344 1.089844,1.2656252 2.179688,3.480469 L 23.976562,0 h -3.814453 l -3.357422,-6.7324219 q -1.300781,-2.6367187 -2.531249,-3.4980471 -1.212891,-0.861328 -3.322266,-0.861328 H 7.0839844 V 0 H 3.5332031 v -26.244141 h 8.0156249 q 4.5,0 6.714844,1.88086 2.214844,1.880859 2.214844,5.677734 0,2.478516 -1.160157,4.113281 -1.142578,1.634766 -3.339843,2.267578 z M 7.0839844,-23.326172 v 9.316406 h 4.4648436 q 2.566406,0 3.867188,-1.177734 1.318359,-1.195312 1.318359,-3.498047 0,-2.302734 -1.318359,-3.46289 -1.300782,-1.177735 -3.867188,-1.177735 z"
+     id="path9906" /><path
+     d="m 43.628906,-10.652344 v 1.5820315 H 28.757812 q 0.210938,3.3398438 2.003907,5.0976562 1.810547,1.7402344 5.027343,1.7402344 1.863282,0 3.603516,-0.4570312 1.757813,-0.4570313 3.480469,-1.3710938 v 3.0585938 q -1.740235,0.73828122 -3.56836,1.12499997 -1.828125,0.38671875 -3.708984,0.38671875 -4.710937,0 -7.470703,-2.74218752 -2.742188,-2.7421875 -2.742188,-7.4179687 0,-4.8339844 2.601563,-7.6640624 2.619141,-2.847656 7.048828,-2.847656 3.972656,0 6.275391,2.566406 2.320312,2.548828 2.320312,6.943359 z m -3.234375,-0.949219 q -0.03516,-2.654296 -1.49414,-4.236328 -1.441407,-1.582031 -3.832032,-1.582031 -2.707031,0 -4.341797,1.529297 -1.617187,1.529297 -1.863281,4.306641 z"
+     id="path9908" /><path
+     d="m 63.105469,-18.931641 v 3.023438 q -1.371094,-0.755859 -2.759766,-1.125 -1.371094,-0.386719 -2.777344,-0.386719 -3.146484,0 -4.886718,2.003906 -1.740235,1.986328 -1.740235,5.5898441 0,3.6035157 1.740235,5.6074219 1.740234,1.9863281 4.886718,1.9863281 1.40625,0 2.777344,-0.3691406 1.388672,-0.3867188 2.759766,-1.1425781 v 2.98828123 q -1.353516,0.6328125 -2.8125,0.94921874 -1.441407,0.31640625 -3.076172,0.31640625 -4.447266,0 -7.066406,-2.79492192 -2.619141,-2.7949218 -2.619141,-7.5410156 0,-4.8164061 2.636719,-7.5761721 2.654297,-2.759765 7.259765,-2.759765 1.494141,0 2.917969,0.316406 1.423828,0.298828 2.759766,0.914062 z"
+     id="path9910" /><path
+     d="m 76.359375,-17.419922 q -2.601563,0 -4.113281,2.039063 -1.511719,2.021484 -1.511719,5.5546871 0,3.5332032 1.494141,5.5722657 1.511718,2.0214843 4.130859,2.0214843 2.583984,0 4.095703,-2.0390625 1.511719,-2.0390625 1.511719,-5.5546875 0,-3.4980471 -1.511719,-5.5371091 -1.511719,-2.056641 -4.095703,-2.056641 z m 0,-2.742187 q 4.21875,0 6.626953,2.742187 2.408203,2.742188 2.408203,7.5937501 0,4.8339844 -2.408203,7.59375 -2.408203,2.74218752 -6.626953,2.74218752 -4.236328,0 -6.644531,-2.74218752 -2.390625,-2.7597656 -2.390625,-7.59375 0,-4.8515621 2.390625,-7.5937501 2.408203,-2.742187 6.644531,-2.742187 z"
+     id="path9912" /><path
+     d="m 88.435547,-19.6875 h 3.427734 L 98.015625,-3.1640625 104.16797,-19.6875 h 3.42773 L 100.21289,0 h -4.394531 z"
+     id="path9914" /><path
+     d="m 128.90039,-10.652344 v 1.5820315 H 114.0293 q 0.21093,3.3398438 2.0039,5.0976562 1.81055,1.7402344 5.02735,1.7402344 1.86328,0 3.60351,-0.4570312 1.75782,-0.4570313 3.48047,-1.3710938 v 3.0585938 q -1.74023,0.73828122 -3.56836,1.12499997 -1.82812,0.38671875 -3.70898,0.38671875 -4.71094,0 -7.47071,-2.74218752 -2.74218,-2.7421875 -2.74218,-7.4179687 0,-4.8339844 2.60156,-7.6640624 2.61914,-2.847656 7.04883,-2.847656 3.97265,0 6.27539,2.566406 2.32031,2.548828 2.32031,6.943359 z m -3.23437,-0.949219 q -0.0352,-2.654296 -1.49414,-4.236328 -1.44141,-1.582031 -3.83204,-1.582031 -2.70703,0 -4.34179,1.529297 -1.61719,1.529297 -1.86328,4.306641 z"
+     id="path9916" /><path
+     d="m 145.61719,-16.664062 q -0.54492,-0.316407 -1.19532,-0.457032 -0.63281,-0.158203 -1.40625,-0.158203 -2.74218,0 -4.21875,1.792969 -1.45898,1.77539 -1.45898,5.115234 V 0 h -3.25195 v -19.6875 h 3.25195 v 3.058594 q 1.01953,-1.792969 2.6543,-2.654297 1.63476,-0.878906 3.97265,-0.878906 0.33399,0 0.73828,0.05273 0.4043,0.03516 0.89649,0.123047 z"
+     id="path9918" /><path
+     d="m 157.20117,1.828125 q -1.37109,3.515625 -2.67187,4.5878906 -1.30078,1.0722656 -3.48047,1.0722656 h -2.58399 V 4.78125 h 1.89844 q 1.33594,0 2.07422,-0.6328125 0.73828,-0.6328125 1.63477,-2.9882813 L 154.65234,-0.31640625 146.68945,-19.6875 h 3.42774 l 6.15234,15.3984375 6.15234,-15.3984375 h 3.42774 z"
+     id="path9920" /></g>
+<g
+   aria-label="Observability"
+   transform="matrix(-8.074733e-04 -1 1 -8.074733e-04 107.1761 1275.0145)"
+   id="text1791"
+   class="st3 st95 st96"
+   style="font-size:36px;font-family:Poppins-SemiBold;fill:#ffffff"><path
+     d="m 14.185547,-23.835937 q -3.867188,0 -6.1523439,2.882812 -2.2675781,2.882813 -2.2675781,7.857422 0,4.9570311 2.2675781,7.8398436 2.2851559,2.8828125 6.1523439,2.8828125 3.867187,0 6.117187,-2.8828125 2.267578,-2.8828125 2.267578,-7.8398436 0,-4.974609 -2.267578,-7.857422 -2.25,-2.882812 -6.117187,-2.882812 z m 0,-2.882813 q 5.519531,0 8.824219,3.708984 3.304687,3.691407 3.304687,9.914063 0,6.205078 -3.304687,9.9140624 -3.304688,3.69140622 -8.824219,3.69140622 -5.5371095,0 -8.8593751,-3.69140622 -3.3046875,-3.6914063 -3.3046875,-9.9140624 0,-6.222656 3.3046875,-9.914063 3.3222656,-3.708984 8.8593751,-3.708984 z"
+     id="path9853" /><path
+     d="m 45.861328,-9.8261719 q 0,-3.5683591 -1.476562,-5.5898441 -1.458985,-2.039062 -4.025391,-2.039062 -2.566406,0 -4.042969,2.039062 -1.458984,2.021485 -1.458984,5.5898441 0,3.5683594 1.458984,5.6074219 1.476563,2.0214844 4.042969,2.0214844 2.566406,0 4.025391,-2.0214844 1.476562,-2.0390625 1.476562,-5.6074219 z M 34.857422,-16.699219 q 1.019531,-1.757812 2.566406,-2.601562 1.564453,-0.861328 3.726563,-0.861328 3.585937,0 5.818359,2.847656 2.25,2.847656 2.25,7.4882811 0,4.640625 -2.25,7.4882813 -2.232422,2.84765622 -5.818359,2.84765622 -2.16211,0 -3.726563,-0.84375 Q 35.876953,-1.1953125 34.857422,-2.953125 V 0 h -3.251953 v -27.351562 h 3.251953 z"
+     id="path9855" /><path
+     d="m 67.130859,-19.107422 v 3.058594 q -1.371093,-0.703125 -2.847656,-1.054688 -1.476562,-0.351562 -3.058594,-0.351562 -2.408203,0 -3.621093,0.738281 -1.195313,0.738281 -1.195313,2.214844 0,1.125 0.861328,1.77539 0.861328,0.632813 3.462891,1.212891 l 1.107422,0.246094 q 3.445312,0.738281 4.886718,2.0917967 1.458985,1.3359376 1.458985,3.7441407 0,2.7421875 -2.179688,4.3417969 -2.162109,1.59960932 -5.958984,1.59960932 -1.582031,0 -3.304688,-0.31640625 -1.705078,-0.29882812 -3.603515,-0.91406249 V -4.0605469 q 1.792969,0.9316406 3.533203,1.40625 1.740234,0.4570313 3.445312,0.4570313 2.285157,0 3.515625,-0.7734375 1.230469,-0.7910157 1.230469,-2.2148438 0,-1.3183593 -0.896484,-2.0214843 -0.878906,-0.703125 -3.884766,-1.3535157 l -1.125,-0.2636719 q -3.005859,-0.6328125 -4.341797,-1.9335942 -1.335937,-1.318359 -1.335937,-3.603515 0,-2.777344 1.96875,-4.289063 1.96875,-1.511718 5.589844,-1.511718 1.792968,0 3.375,0.263672 1.582031,0.263671 2.917968,0.791015 z"
+     id="path9857" /><path
+     d="m 90.175781,-10.652344 v 1.5820315 H 75.304687 q 0.210938,3.3398438 2.003907,5.0976562 1.810547,1.7402344 5.027343,1.7402344 1.863282,0 3.603516,-0.4570312 1.757813,-0.4570313 3.480469,-1.3710938 v 3.0585938 q -1.740235,0.73828122 -3.56836,1.12499997 -1.828125,0.38671875 -3.708984,0.38671875 -4.710937,0 -7.470703,-2.74218752 -2.742188,-2.7421875 -2.742188,-7.4179687 0,-4.8339844 2.601563,-7.6640624 2.619141,-2.847656 7.048828,-2.847656 3.972656,0 6.275391,2.566406 2.320312,2.548828 2.320312,6.943359 z m -3.234375,-0.949219 q -0.03516,-2.654296 -1.49414,-4.236328 -1.441407,-1.582031 -3.832032,-1.582031 -2.707031,0 -4.341797,1.529297 -1.617187,1.529297 -1.863281,4.306641 z"
+     id="path9859" /><path
+     d="m 106.89258,-16.664062 q -0.54492,-0.316407 -1.19531,-0.457032 -0.63282,-0.158203 -1.40625,-0.158203 -2.74219,0 -4.21875,1.792969 -1.458989,1.77539 -1.458989,5.115234 V 0 h -3.251953 v -19.6875 h 3.251953 v 3.058594 q 1.019531,-1.792969 2.654299,-2.654297 1.63476,-0.878906 3.97265,-0.878906 0.33399,0 0.73829,0.05273 0.40429,0.03516 0.89648,0.123047 z"
+     id="path9861" /><path
+     d="m 107.96484,-19.6875 h 3.42774 l 6.15234,16.5234375 6.15235,-16.5234375 H 127.125 L 119.74219,0 h -4.39453 z"
+     id="path9863" /><path
+     d="m 140.53711,-9.8964844 q -3.91992,0 -5.43164,0.8964844 -1.51172,0.8964844 -1.51172,3.0585938 0,1.7226562 1.125,2.7421874 1.14258,1.0019532 3.09375,1.0019532 2.68945,0 4.30664,-1.8984375 1.63477,-1.9160156 1.63477,-5.0800782 v -0.7207031 z m 6.45117,-1.3359376 V 0 h -3.23437 v -2.9882813 q -1.10743,1.7929688 -2.75977,2.65429692 -1.65234,0.84375 -4.04297,0.84375 -3.02344,0 -4.8164,-1.68750002 -1.7754,-1.7050781 -1.7754,-4.5527343 0,-3.3222657 2.21485,-5.0097653 2.23242,-1.6875 6.64453,-1.6875 h 4.53516 v -0.316407 q 0,-2.232422 -1.47657,-3.445312 -1.45898,-1.230469 -4.11328,-1.230469 -1.6875,0 -3.28711,0.404297 -1.59961,0.404297 -3.07617,1.212891 v -2.988282 q 1.77539,-0.685546 3.44531,-1.019531 1.66993,-0.351562 3.25196,-0.351562 4.27148,0 6.38086,2.214843 2.10937,2.214844 2.10937,6.714844 z"
+     id="path9865" /><path
+     d="m 167.7832,-9.8261719 q 0,-3.5683591 -1.47656,-5.5898441 -1.45898,-2.039062 -4.02539,-2.039062 -2.56641,0 -4.04297,2.039062 -1.45898,2.021485 -1.45898,5.5898441 0,3.5683594 1.45898,5.6074219 1.47656,2.0214844 4.04297,2.0214844 2.56641,0 4.02539,-2.0214844 1.47656,-2.0390625 1.47656,-5.6074219 z m -11.0039,-6.8730471 q 1.01953,-1.757812 2.5664,-2.601562 1.56446,-0.861328 3.72657,-0.861328 3.58593,0 5.81835,2.847656 2.25,2.847656 2.25,7.4882811 0,4.640625 -2.25,7.4882813 -2.23242,2.84765622 -5.81835,2.84765622 -2.16211,0 -3.72657,-0.84375 -1.54687,-0.86132812 -2.5664,-2.61914062 V 0 h -3.25196 v -27.351562 h 3.25196 z"
+     id="path9867" /><path
+     d="m 176.50195,-19.6875 h 3.23438 V 0 h -3.23438 z m 0,-7.664062 h 3.23438 v 4.095703 h -3.23438 z"
+     id="path9869" /><path
+     d="m 186.50391,-27.351562 h 3.23437 V 0 h -3.23437 z"
+     id="path9871" /><path
+     d="m 196.50586,-19.6875 h 3.23437 V 0 h -3.23437 z m 0,-7.664062 h 3.23437 v 4.095703 h -3.23437 z"
+     id="path9873" /><path
+     d="m 209.70703,-25.277344 v 5.589844 h 6.66211 v 2.513672 h -6.66211 v 10.6874999 q 0,2.4082031 0.65039,3.09375 0.66797,0.6855468 2.68945,0.6855468 h 3.32227 V 0 h -3.32227 q -3.74414,0 -5.16796,-1.3886719 -1.42383,-1.40625 -1.42383,-5.0976562 V -17.173828 h -2.37305 V -19.6875 h 2.37305 v -5.589844 z"
+     id="path9875" /><path
+     d="m 228.81445,1.828125 q -1.37109,3.515625 -2.67187,4.5878906 -1.30078,1.0722656 -3.48047,1.0722656 h -2.58399 V 4.78125 h 1.89844 q 1.33594,0 2.07422,-0.6328125 0.73828,-0.6328125 1.63477,-2.9882813 L 226.26562,-0.31640625 218.30273,-19.6875 h 3.42774 l 6.15234,15.3984375 6.15235,-15.3984375 h 3.42773 z"
+     id="path9877" /></g>
+<g
+   aria-label="Logs"
+   transform="matrix(-8.074733e-04 -1 1 -8.074733e-04 150.3109 1194.1796)"
+   id="text1793"
+   class="st3 st95 st96"
+   style="font-size:36px;font-family:Poppins-SemiBold;fill:#ffffff"><path
+     d="M 3.5332031,-26.244141 H 7.0839844 V -2.9882813 H 19.863281 V 0 H 3.5332031 Z"
+     id="path9880" /><path
+     d="m 30.445312,-17.419922 q -2.601562,0 -4.113281,2.039063 -1.511719,2.021484 -1.511719,5.5546871 0,3.5332032 1.494141,5.5722657 1.511719,2.0214843 4.130859,2.0214843 2.583985,0 4.095704,-2.0390625 1.511718,-2.0390625 1.511718,-5.5546875 0,-3.4980471 -1.511718,-5.5371091 -1.511719,-2.056641 -4.095704,-2.056641 z m 0,-2.742187 q 4.21875,0 6.626954,2.742187 2.408203,2.742188 2.408203,7.5937501 0,4.8339844 -2.408203,7.59375 -2.408204,2.74218752 -6.626954,2.74218752 -4.236328,0 -6.644531,-2.74218752 -2.390625,-2.7597656 -2.390625,-7.59375 0,-4.8515621 2.390625,-7.5937501 2.408203,-2.742187 6.644531,-2.742187 z"
+     id="path9882" /><path
+     d="m 57.796875,-10.072266 q 0,-3.515625 -1.458984,-5.449218 -1.441407,-1.933594 -4.060547,-1.933594 -2.601563,0 -4.060547,1.933594 -1.441406,1.933593 -1.441406,5.449218 0,3.4980473 1.441406,5.431641 1.458984,1.9335937 4.060547,1.9335937 2.61914,0 4.060547,-1.9335937 1.458984,-1.9335937 1.458984,-5.431641 z m 3.234375,7.6289066 q 0,5.0273438 -2.232422,7.4707031 -2.232422,2.4609375 -6.837891,2.4609375 -1.705078,0 -3.216796,-0.2636718 Q 47.232422,6.9785156 45.808594,6.4511719 V 3.3046875 q 1.423828,0.7734375 2.8125,1.1425781 1.388672,0.3691406 2.830078,0.3691406 3.18164,0 4.763672,-1.6699218 1.582031,-1.6523438 1.582031,-5.0097656 V -3.4628906 Q 56.794922,-1.7226562 55.230469,-0.86132813 53.666016,0 51.486328,0 q -3.621094,0 -5.835937,-2.7597656 -2.214844,-2.7597656 -2.214844,-7.3125004 0,-4.570312 2.214844,-7.330078 2.214843,-2.759765 5.835937,-2.759765 2.179688,0 3.744141,0.861328 1.564453,0.861328 2.566406,2.601562 V -19.6875 h 3.234375 z"
+     id="path9884" /><path
+     d="m 80.244141,-19.107422 v 3.058594 q -1.371094,-0.703125 -2.847657,-1.054688 -1.476562,-0.351562 -3.058593,-0.351562 -2.408204,0 -3.621094,0.738281 -1.195313,0.738281 -1.195313,2.214844 0,1.125 0.861328,1.77539 0.861329,0.632813 3.462891,1.212891 l 1.107422,0.246094 q 3.445312,0.738281 4.886719,2.0917967 1.458984,1.3359376 1.458984,3.7441407 0,2.7421875 -2.179687,4.3417969 -2.16211,1.59960932 -5.958985,1.59960932 -1.582031,0 -3.304687,-0.31640625 -1.705078,-0.29882812 -3.603516,-0.91406249 V -4.0605469 q 1.792969,0.9316406 3.533203,1.40625 1.740235,0.4570313 3.445313,0.4570313 2.285156,0 3.515625,-0.7734375 1.230468,-0.7910157 1.230468,-2.2148438 0,-1.3183593 -0.896484,-2.0214843 -0.878906,-0.703125 -3.884766,-1.3535157 l -1.125,-0.2636719 q -3.005859,-0.6328125 -4.341796,-1.9335942 -1.335938,-1.318359 -1.335938,-3.603515 0,-2.777344 1.96875,-4.289063 1.96875,-1.511718 5.589844,-1.511718 1.792969,0 3.375,0.263672 1.582031,0.263671 2.917969,0.791015 z"
+     id="path9886" /></g>
+<g
+   aria-label="Observability"
+   transform="matrix(-8.074733e-04 -1 1 -8.074733e-04 107.7619 1611.6639)"
+   id="text1795"
+   class="st3 st95 st96"
+   style="font-size:36px;font-family:Poppins-SemiBold;fill:#ffffff"><path
+     d="m 14.185547,-23.835937 q -3.867188,0 -6.1523439,2.882812 -2.2675781,2.882813 -2.2675781,7.857422 0,4.9570311 2.2675781,7.8398436 2.2851559,2.8828125 6.1523439,2.8828125 3.867187,0 6.117187,-2.8828125 2.267578,-2.8828125 2.267578,-7.8398436 0,-4.974609 -2.267578,-7.857422 -2.25,-2.882812 -6.117187,-2.882812 z m 0,-2.882813 q 5.519531,0 8.824219,3.708984 3.304687,3.691407 3.304687,9.914063 0,6.205078 -3.304687,9.9140624 -3.304688,3.69140622 -8.824219,3.69140622 -5.5371095,0 -8.8593751,-3.69140622 -3.3046875,-3.6914063 -3.3046875,-9.9140624 0,-6.222656 3.3046875,-9.914063 3.3222656,-3.708984 8.8593751,-3.708984 z"
+     id="path9811" /><path
+     d="m 45.861328,-9.8261719 q 0,-3.5683591 -1.476562,-5.5898441 -1.458985,-2.039062 -4.025391,-2.039062 -2.566406,0 -4.042969,2.039062 -1.458984,2.021485 -1.458984,5.5898441 0,3.5683594 1.458984,5.6074219 1.476563,2.0214844 4.042969,2.0214844 2.566406,0 4.025391,-2.0214844 1.476562,-2.0390625 1.476562,-5.6074219 z M 34.857422,-16.699219 q 1.019531,-1.757812 2.566406,-2.601562 1.564453,-0.861328 3.726563,-0.861328 3.585937,0 5.818359,2.847656 2.25,2.847656 2.25,7.4882811 0,4.640625 -2.25,7.4882813 -2.232422,2.84765622 -5.818359,2.84765622 -2.16211,0 -3.726563,-0.84375 Q 35.876953,-1.1953125 34.857422,-2.953125 V 0 h -3.251953 v -27.351562 h 3.251953 z"
+     id="path9813" /><path
+     d="m 67.130859,-19.107422 v 3.058594 q -1.371093,-0.703125 -2.847656,-1.054688 -1.476562,-0.351562 -3.058594,-0.351562 -2.408203,0 -3.621093,0.738281 -1.195313,0.738281 -1.195313,2.214844 0,1.125 0.861328,1.77539 0.861328,0.632813 3.462891,1.212891 l 1.107422,0.246094 q 3.445312,0.738281 4.886718,2.0917967 1.458985,1.3359376 1.458985,3.7441407 0,2.7421875 -2.179688,4.3417969 -2.162109,1.59960932 -5.958984,1.59960932 -1.582031,0 -3.304688,-0.31640625 -1.705078,-0.29882812 -3.603515,-0.91406249 V -4.0605469 q 1.792969,0.9316406 3.533203,1.40625 1.740234,0.4570313 3.445312,0.4570313 2.285157,0 3.515625,-0.7734375 1.230469,-0.7910157 1.230469,-2.2148438 0,-1.3183593 -0.896484,-2.0214843 -0.878906,-0.703125 -3.884766,-1.3535157 l -1.125,-0.2636719 q -3.005859,-0.6328125 -4.341797,-1.9335942 -1.335937,-1.318359 -1.335937,-3.603515 0,-2.777344 1.96875,-4.289063 1.96875,-1.511718 5.589844,-1.511718 1.792968,0 3.375,0.263672 1.582031,0.263671 2.917968,0.791015 z"
+     id="path9815" /><path
+     d="m 90.175781,-10.652344 v 1.5820315 H 75.304687 q 0.210938,3.3398438 2.003907,5.0976562 1.810547,1.7402344 5.027343,1.7402344 1.863282,0 3.603516,-0.4570312 1.757813,-0.4570313 3.480469,-1.3710938 v 3.0585938 q -1.740235,0.73828122 -3.56836,1.12499997 -1.828125,0.38671875 -3.708984,0.38671875 -4.710937,0 -7.470703,-2.74218752 -2.742188,-2.7421875 -2.742188,-7.4179687 0,-4.8339844 2.601563,-7.6640624 2.619141,-2.847656 7.048828,-2.847656 3.972656,0 6.275391,2.566406 2.320312,2.548828 2.320312,6.943359 z m -3.234375,-0.949219 q -0.03516,-2.654296 -1.49414,-4.236328 -1.441407,-1.582031 -3.832032,-1.582031 -2.707031,0 -4.341797,1.529297 -1.617187,1.529297 -1.863281,4.306641 z"
+     id="path9817" /><path
+     d="m 106.89258,-16.664062 q -0.54492,-0.316407 -1.19531,-0.457032 -0.63282,-0.158203 -1.40625,-0.158203 -2.74219,0 -4.21875,1.792969 -1.458989,1.77539 -1.458989,5.115234 V 0 h -3.251953 v -19.6875 h 3.251953 v 3.058594 q 1.019531,-1.792969 2.654299,-2.654297 1.63476,-0.878906 3.97265,-0.878906 0.33399,0 0.73829,0.05273 0.40429,0.03516 0.89648,0.123047 z"
+     id="path9819" /><path
+     d="m 107.96484,-19.6875 h 3.42774 l 6.15234,16.5234375 6.15235,-16.5234375 H 127.125 L 119.74219,0 h -4.39453 z"
+     id="path9821" /><path
+     d="m 140.53711,-9.8964844 q -3.91992,0 -5.43164,0.8964844 -1.51172,0.8964844 -1.51172,3.0585938 0,1.7226562 1.125,2.7421874 1.14258,1.0019532 3.09375,1.0019532 2.68945,0 4.30664,-1.8984375 1.63477,-1.9160156 1.63477,-5.0800782 v -0.7207031 z m 6.45117,-1.3359376 V 0 h -3.23437 v -2.9882813 q -1.10743,1.7929688 -2.75977,2.65429692 -1.65234,0.84375 -4.04297,0.84375 -3.02344,0 -4.8164,-1.68750002 -1.7754,-1.7050781 -1.7754,-4.5527343 0,-3.3222657 2.21485,-5.0097653 2.23242,-1.6875 6.64453,-1.6875 h 4.53516 v -0.316407 q 0,-2.232422 -1.47657,-3.445312 -1.45898,-1.230469 -4.11328,-1.230469 -1.6875,0 -3.28711,0.404297 -1.59961,0.404297 -3.07617,1.212891 v -2.988282 q 1.77539,-0.685546 3.44531,-1.019531 1.66993,-0.351562 3.25196,-0.351562 4.27148,0 6.38086,2.214843 2.10937,2.214844 2.10937,6.714844 z"
+     id="path9823" /><path
+     d="m 167.7832,-9.8261719 q 0,-3.5683591 -1.47656,-5.5898441 -1.45898,-2.039062 -4.02539,-2.039062 -2.56641,0 -4.04297,2.039062 -1.45898,2.021485 -1.45898,5.5898441 0,3.5683594 1.45898,5.6074219 1.47656,2.0214844 4.04297,2.0214844 2.56641,0 4.02539,-2.0214844 1.47656,-2.0390625 1.47656,-5.6074219 z m -11.0039,-6.8730471 q 1.01953,-1.757812 2.5664,-2.601562 1.56446,-0.861328 3.72657,-0.861328 3.58593,0 5.81835,2.847656 2.25,2.847656 2.25,7.4882811 0,4.640625 -2.25,7.4882813 -2.23242,2.84765622 -5.81835,2.84765622 -2.16211,0 -3.72657,-0.84375 -1.54687,-0.86132812 -2.5664,-2.61914062 V 0 h -3.25196 v -27.351562 h 3.25196 z"
+     id="path9825" /><path
+     d="m 176.50195,-19.6875 h 3.23438 V 0 h -3.23438 z m 0,-7.664062 h 3.23438 v 4.095703 h -3.23438 z"
+     id="path9827" /><path
+     d="m 186.50391,-27.351562 h 3.23437 V 0 h -3.23437 z"
+     id="path9829" /><path
+     d="m 196.50586,-19.6875 h 3.23437 V 0 h -3.23437 z m 0,-7.664062 h 3.23437 v 4.095703 h -3.23437 z"
+     id="path9831" /><path
+     d="m 209.70703,-25.277344 v 5.589844 h 6.66211 v 2.513672 h -6.66211 v 10.6874999 q 0,2.4082031 0.65039,3.09375 0.66797,0.6855468 2.68945,0.6855468 h 3.32227 V 0 h -3.32227 q -3.74414,0 -5.16796,-1.3886719 -1.42383,-1.40625 -1.42383,-5.0976562 V -17.173828 h -2.37305 V -19.6875 h 2.37305 v -5.589844 z"
+     id="path9833" /><path
+     d="m 228.81445,1.828125 q -1.37109,3.515625 -2.67187,4.5878906 -1.30078,1.0722656 -3.48047,1.0722656 h -2.58399 V 4.78125 h 1.89844 q 1.33594,0 2.07422,-0.6328125 0.73828,-0.6328125 1.63477,-2.9882813 L 226.26562,-0.31640625 218.30273,-19.6875 h 3.42774 l 6.15234,15.3984375 6.15235,-15.3984375 h 3.42773 z"
+     id="path9835" /></g>
+<g
+   aria-label="Metrics"
+   transform="matrix(-8.074733e-04 -1 1 -8.074733e-04 150.9172 1556.2303)"
+   id="text1797"
+   class="st3 st95 st96"
+   style="font-size:36px;font-family:Poppins-SemiBold;fill:#ffffff"><path
+     d="m 3.5332031,-26.244141 h 5.2910157 l 6.6972652,17.8593754 6.732422,-17.8593754 h 5.291016 V 0 H 24.082031 V -23.044922 L 17.314453,-5.0449219 H 13.746094 L 6.9785156,-23.044922 V 0 H 3.5332031 Z"
+     id="path9838" /><path
+     d="m 51.292969,-10.652344 v 1.5820315 H 36.421875 q 0.210937,3.3398438 2.003906,5.0976562 1.810547,1.7402344 5.027344,1.7402344 1.863281,0 3.603516,-0.4570312 1.757812,-0.4570313 3.480468,-1.3710938 v 3.0585938 q -1.740234,0.73828122 -3.568359,1.12499997 -1.828125,0.38671875 -3.708984,0.38671875 -4.710938,0 -7.470704,-2.74218752 -2.742187,-2.7421875 -2.742187,-7.4179687 0,-4.8339844 2.601562,-7.6640624 2.619141,-2.847656 7.048829,-2.847656 3.972656,0 6.27539,2.566406 2.320313,2.548828 2.320313,6.943359 z m -3.234375,-0.949219 q -0.03516,-2.654296 -1.494141,-4.236328 -1.441406,-1.582031 -3.832031,-1.582031 -2.707031,0 -4.341797,1.529297 -1.617188,1.529297 -1.863281,4.306641 z"
+     id="path9840" /><path
+     d="m 59.800781,-25.277344 v 5.589844 h 6.66211 v 2.513672 h -6.66211 v 10.6874999 q 0,2.4082031 0.650391,3.09375 0.667969,0.6855468 2.689453,0.6855468 h 3.322266 V 0 h -3.322266 q -3.744141,0 -5.167969,-1.3886719 -1.423828,-1.40625 -1.423828,-5.0976562 V -17.173828 H 54.175781 V -19.6875 h 2.373047 v -5.589844 z"
+     id="path9842" /><path
+     d="m 82.125,-16.664062 q -0.544922,-0.316407 -1.195313,-0.457032 -0.632812,-0.158203 -1.40625,-0.158203 -2.742187,0 -4.21875,1.792969 -1.458984,1.77539 -1.458984,5.115234 V 0 H 70.59375 v -19.6875 h 3.251953 v 3.058594 q 1.019531,-1.792969 2.654297,-2.654297 1.634766,-0.878906 3.972656,-0.878906 0.333985,0 0.738281,0.05273 0.404297,0.03516 0.896485,0.123047 z"
+     id="path9844" /><path
+     d="m 85.517578,-19.6875 h 3.234375 V 0 h -3.234375 z m 0,-7.664062 h 3.234375 v 4.095703 h -3.234375 z"
+     id="path9846" /><path
+     d="m 109.6875,-18.931641 v 3.023438 q -1.37109,-0.755859 -2.75977,-1.125 -1.37109,-0.386719 -2.77734,-0.386719 -3.14648,0 -4.886718,2.003906 -1.740235,1.986328 -1.740235,5.5898441 0,3.6035157 1.740235,5.6074219 1.740238,1.9863281 4.886718,1.9863281 1.40625,0 2.77734,-0.3691406 1.38868,-0.3867188 2.75977,-1.1425781 v 2.98828123 q -1.35352,0.6328125 -2.8125,0.94921874 -1.44141,0.31640625 -3.07617,0.31640625 -4.447268,0 -7.066408,-2.79492192 -2.619141,-2.7949218 -2.619141,-7.5410156 0,-4.8164061 2.636719,-7.5761721 2.654297,-2.759765 7.25977,-2.759765 1.49414,0 2.91796,0.316406 1.42383,0.298828 2.75977,0.914062 z"
+     id="path9848" /><path
+     d="m 127.86328,-19.107422 v 3.058594 q -1.37109,-0.703125 -2.84765,-1.054688 -1.47657,-0.351562 -3.0586,-0.351562 -2.4082,0 -3.62109,0.738281 -1.19531,0.738281 -1.19531,2.214844 0,1.125 0.86132,1.77539 0.86133,0.632813 3.46289,1.212891 l 1.10743,0.246094 q 3.44531,0.738281 4.88671,2.0917967 1.45899,1.3359376 1.45899,3.7441407 0,2.7421875 -2.17969,4.3417969 -2.16211,1.59960932 -5.95898,1.59960932 -1.58203,0 -3.30469,-0.31640625 -1.70508,-0.29882812 -3.60352,-0.91406249 V -4.0605469 q 1.79297,0.9316406 3.53321,1.40625 1.74023,0.4570313 3.44531,0.4570313 2.28516,0 3.51562,-0.7734375 1.23047,-0.7910157 1.23047,-2.2148438 0,-1.3183593 -0.89648,-2.0214843 -0.87891,-0.703125 -3.88477,-1.3535157 l -1.125,-0.2636719 q -3.00586,-0.6328125 -4.34179,-1.9335942 -1.33594,-1.318359 -1.33594,-3.603515 0,-2.777344 1.96875,-4.289063 1.96875,-1.511718 5.58984,-1.511718 1.79297,0 3.375,0.263672 1.58203,0.263671 2.91797,0.791015 z"
+     id="path9850" /></g>
+<g
+   aria-label="Async"
+   transform="matrix(-8.074733e-04 -1 1 -8.074733e-04 616.4101 210.4404)"
+   id="text1799"
+   class="st3 st95 st97"
+   style="font-size:34px;font-family:Poppins-SemiBold;fill:#ffffff"><path
+     d="M 11.621094,-21.482422 7.0722656,-9.1474609 H 16.186523 Z M 9.7285156,-24.786133 H 13.530273 L 22.976562,0 H 19.490234 L 17.232422,-6.3583984 H 6.0595703 L 3.8017578,0 H 0.265625 Z"
+     id="path11228" /><path
+     d="m 38.316406,-18.045898 v 2.888671 q -1.294922,-0.664062 -2.689453,-0.996093 -1.394531,-0.332032 -2.888672,-0.332032 -2.274414,0 -3.419922,0.697266 -1.128906,0.697266 -1.128906,2.091797 0,1.0625 0.813477,1.676758 0.813476,0.597656 3.270507,1.145508 l 1.045899,0.232421 q 3.253906,0.6972661 4.615234,1.9755864 1.37793,1.2617187 1.37793,3.5361328 0,2.5898437 -2.058594,4.1005859 -2.041992,1.51074221 -5.627929,1.51074221 -1.494141,0 -3.121094,-0.29882812 -1.610352,-0.28222656 -3.403321,-0.86328125 V -3.8349609 q 1.69336,0.8798828 3.336915,1.328125 1.643554,0.4316406 3.253906,0.4316406 2.158203,0 3.320312,-0.7304688 1.16211,-0.7470703 1.16211,-2.0917968 0,-1.2451172 -0.84668,-1.9091797 -0.830078,-0.6640625 -3.668945,-1.2783203 l -1.0625,-0.2490235 q -2.838868,-0.5976562 -4.100586,-1.8261716 -1.261719,-1.245117 -1.261719,-3.403321 0,-2.623046 1.859375,-4.050781 1.859375,-1.427734 5.279297,-1.427734 1.693359,0 3.1875,0.249023 1.49414,0.249024 2.755859,0.747071 z"
+     id="path11230" /><path
+     d="M 51.913086,1.7265625 Q 50.618164,5.046875 49.389648,6.0595703 48.161133,7.0722656 46.102539,7.0722656 h -2.44043 V 4.515625 h 1.792969 q 1.261719,0 1.958984,-0.5976562 0.697266,-0.5976563 1.543946,-2.8222657 L 49.505859,-0.29882813 41.985352,-18.59375 h 3.237304 L 51.033203,-4.0507812 56.84375,-18.59375 h 3.237305 z"
+     id="path11232" /><path
+     d="M 79.753906,-11.222656 V 0 h -3.054687 v -11.123047 q 0,-2.639648 -1.029297,-3.951172 -1.029297,-1.311523 -3.087891,-1.311523 -2.473633,0 -3.901367,1.577148 -1.427734,1.577149 -1.427734,4.299805 V 0 h -3.071289 v -18.59375 h 3.071289 v 2.888672 q 1.095703,-1.676758 2.573242,-2.506836 1.49414,-0.830078 3.436523,-0.830078 3.204102,0 4.847657,1.992187 1.643554,1.975586 1.643554,5.827149 z"
+     id="path11234" /><path
+     d="m 99.227539,-17.879883 v 2.855469 q -1.294922,-0.713867 -2.606445,-1.0625 -1.294922,-0.365234 -2.623047,-0.365234 -2.97168,0 -4.615235,1.892578 -1.643554,1.875976 -1.643554,5.2792966 0,3.4033203 1.643554,5.2958984 1.643555,1.8759766 4.615235,1.8759766 1.328125,0 2.623047,-0.3486329 1.311523,-0.3652343 2.606445,-1.0791015 v 2.82226561 q -1.27832,0.59765625 -2.65625,0.89648438 -1.361328,0.29882812 -2.905273,0.29882812 -4.200196,0 -6.673829,-2.63964841 -2.473632,-2.6396485 -2.473632,-7.1220703 0,-4.5488286 2.490234,-7.1552736 2.506836,-2.606445 6.856445,-2.606445 1.411133,0 2.75586,0.298828 1.344726,0.282227 2.606445,0.863281 z"
+     id="path11236" /></g>
+<g
+   aria-label="Communication"
+   transform="matrix(-8.074733e-04 -1 1 -8.074733e-04 657.2817 299.1074)"
+   id="text1801"
+   class="st3 st95 st97"
+   style="font-size:34px;font-family:Poppins-SemiBold;fill:#ffffff"><path
+     d="m 21.897461,-22.876953 v 3.536133 q -1.693359,-1.577149 -3.619141,-2.357422 -1.909179,-0.780274 -4.067382,-0.780274 -4.2500005,0 -6.507813,2.606446 -2.2578125,2.589843 -2.2578125,7.503906 0,4.8974609 2.2578125,7.5039062 2.2578125,2.5898437 6.507813,2.5898437 2.158203,0 4.067382,-0.7802734 1.925782,-0.7802734 3.619141,-2.3574219 v 3.5029297 q -1.759766,1.19531251 -3.735352,1.79296876 -1.958984,0.59765625 -4.15039,0.59765625 -5.6279299,0 -8.8652346,-3.43652341 -3.2373047,-3.453125 -3.2373047,-9.4130859 0,-5.976563 3.2373047,-9.413086 3.2373047,-3.453125 8.8652346,-3.453125 2.224609,0 4.183593,0.597656 1.975586,0.581055 3.702149,1.759766 z"
+     id="path11201" /><path
+     d="m 34.149414,-16.452148 q -2.457031,0 -3.884766,1.925781 -1.427734,1.909179 -1.427734,5.2460936 0,3.336914 1.411133,5.2626953 1.427734,1.9091797 3.901367,1.9091797 2.44043,0 3.868164,-1.9257813 1.427734,-1.9257812 1.427734,-5.2460937 0,-3.3037106 -1.427734,-5.2294926 -1.427734,-1.942382 -3.868164,-1.942382 z m 0,-2.589844 q 3.984375,0 6.258789,2.589844 2.274414,2.589843 2.274414,7.1718746 0,4.5654297 -2.274414,7.171875 -2.274414,2.58984371 -6.258789,2.58984371 -4.000977,0 -6.275391,-2.58984371 -2.257812,-2.6064453 -2.257812,-7.171875 0,-4.5820316 2.257812,-7.1718746 2.274414,-2.589844 6.275391,-2.589844 z"
+     id="path11203" /><path
+     d="m 62.222656,-15.024414 q 1.145508,-2.058594 2.739258,-3.038086 1.59375,-0.979492 3.751953,-0.979492 2.905274,0 4.482422,2.041992 1.577148,2.025391 1.577148,5.777344 V 0 h -3.071289 v -11.123047 q 0,-2.672851 -0.946289,-3.967773 -0.946289,-1.294922 -2.888672,-1.294922 -2.374023,0 -3.751953,1.577148 -1.377929,1.577149 -1.377929,4.299805 V 0 h -3.071289 v -11.123047 q 0,-2.689453 -0.946289,-3.967773 -0.94629,-1.294922 -2.921875,-1.294922 -2.340821,0 -3.71875,1.59375 -1.37793,1.577148 -1.37793,4.283203 V 0 h -3.071289 v -18.59375 h 3.071289 v 2.888672 q 1.045898,-1.709961 2.506836,-2.523438 1.460937,-0.813476 3.469726,-0.813476 2.025391,0 3.436524,1.029297 1.427734,1.029297 2.108398,2.988281 z"
+     id="path11205" /><path
+     d="m 95.342773,-15.024414 q 1.145508,-2.058594 2.739258,-3.038086 1.59375,-0.979492 3.751949,-0.979492 2.90528,0 4.48243,2.041992 1.57714,2.025391 1.57714,5.777344 V 0 h -3.07128 v -11.123047 q 0,-2.672851 -0.94629,-3.967773 -0.94629,-1.294922 -2.88868,-1.294922 -2.374019,0 -3.751948,1.577148 -1.37793,1.577149 -1.37793,4.299805 V 0 h -3.071289 v -11.123047 q 0,-2.689453 -0.946289,-3.967773 -0.946289,-1.294922 -2.921875,-1.294922 -2.340821,0 -3.71875,1.59375 -1.37793,1.577148 -1.37793,4.283203 V 0 H 80.75 v -18.59375 h 3.071289 v 2.888672 q 1.045898,-1.709961 2.506836,-2.523438 1.460937,-0.813476 3.469727,-0.813476 2.02539,0 3.436523,1.029297 1.427734,1.029297 2.108398,2.988281 z"
+     id="path11207" /><path
+     d="M 113.6709,-7.3378906 V -18.59375 h 3.05469 v 11.1396484 q 0,2.6396485 1.02929,3.9677735 1.0293,1.3115234 3.08789,1.3115234 2.47364,0 3.90137,-1.5771484 1.44434,-1.5771485 1.44434,-4.2998047 V -18.59375 h 3.05468 V 0 h -3.05468 v -2.8554688 q -1.11231,1.6933594 -2.58985,2.52343755 -1.46093,0.81347656 -3.40332,0.81347656 -3.2041,0 -4.86426,-1.99218751 -1.66015,-1.9921875 -1.66015,-5.8271484 z m 7.68652,-11.7041014 z"
+     id="path11209" /><path
+     d="M 150.99121,-11.222656 V 0 h -3.05469 v -11.123047 q 0,-2.639648 -1.02929,-3.951172 -1.0293,-1.311523 -3.08789,-1.311523 -2.47364,0 -3.90137,1.577148 -1.42774,1.577149 -1.42774,4.299805 V 0 h -3.07128 v -18.59375 h 3.07128 v 2.888672 q 1.09571,-1.676758 2.57325,-2.506836 1.49414,-0.830078 3.43652,-0.830078 3.2041,0 4.84766,1.992187 1.64355,1.975586 1.64355,5.827149 z"
+     id="path11211" /><path
+     d="m 157.08398,-18.59375 h 3.05469 V 0 h -3.05469 z m 0,-7.238281 h 3.05469 v 3.868164 h -3.05469 z"
+     id="path11213" /><path
+     d="m 179.91113,-17.879883 v 2.855469 q -1.29492,-0.713867 -2.60644,-1.0625 -1.29492,-0.365234 -2.62305,-0.365234 -2.97168,0 -4.61523,1.892578 -1.64356,1.875976 -1.64356,5.2792966 0,3.4033203 1.64356,5.2958984 1.64355,1.8759766 4.61523,1.8759766 1.32813,0 2.62305,-0.3486329 1.31152,-0.3652343 2.60644,-1.0791015 v 2.82226561 q -1.27832,0.59765625 -2.65625,0.89648438 -1.36133,0.29882812 -2.90527,0.29882812 -4.2002,0 -6.67383,-2.63964841 -2.47363,-2.6396485 -2.47363,-7.1220703 0,-4.5488286 2.49023,-7.1552736 2.50684,-2.606445 6.85645,-2.606445 1.41113,0 2.75586,0.298828 1.34472,0.282227 2.60644,0.863281 z"
+     id="path11215" /><path
+     d="m 193.67383,-9.3466797 q -3.70215,0 -5.12988,0.8466797 -1.42774,0.8466797 -1.42774,2.8886719 0,1.6269531 1.0625,2.5898437 1.0791,0.9462891 2.92188,0.9462891 2.54003,0 4.06738,-1.7929688 1.54394,-1.8095703 1.54394,-4.7978515 v -0.6806641 z m 6.09277,-1.2617183 V 0 h -3.05469 v -2.8222656 q -1.04589,1.6933594 -2.60644,2.50683591 -1.56055,0.796875 -3.81836,0.796875 -2.85547,0 -4.54883,-1.59375001 -1.67676,-1.6103516 -1.67676,-4.2998047 0,-3.1376953 2.0918,-4.7314456 2.1084,-1.59375 6.27539,-1.59375 h 4.2832 v -0.298828 q 0,-2.108398 -1.39453,-3.253906 -1.37793,-1.162109 -3.88476,-1.162109 -1.59375,0 -3.1045,0.381836 -1.51074,0.381835 -2.90527,1.145507 v -2.822265 q 1.67676,-0.647461 3.25391,-0.962891 1.57715,-0.332031 3.07129,-0.332031 4.03418,0 6.02636,2.091797 1.99219,2.091797 1.99219,6.341797 z"
+     id="path11217" /><path
+     d="m 209.08008,-23.873047 v 5.279297 h 6.29199 v 2.374023 h -6.29199 v 10.0937504 q 0,2.2744141 0.61426,2.921875 0.63086,0.647461 2.54003,0.647461 h 3.1377 V 0 h -3.1377 q -3.53613,0 -4.88085,-1.3115234 -1.34473,-1.328125 -1.34473,-4.8144532 V -16.219727 h -2.24121 v -2.374023 h 2.24121 v -5.279297 z"
+     id="path11219" /><path
+     d="m 219.38965,-18.59375 h 3.05469 V 0 h -3.05469 z m 0,-7.238281 h 3.05469 v 3.868164 h -3.05469 z"
+     id="path11221" /><path
+     d="m 236.04102,-16.452148 q -2.45704,0 -3.88477,1.925781 -1.42773,1.909179 -1.42773,5.2460936 0,3.336914 1.41113,5.2626953 1.42773,1.9091797 3.90137,1.9091797 2.44043,0 3.86816,-1.9257813 1.42773,-1.9257812 1.42773,-5.2460937 0,-3.3037106 -1.42773,-5.2294926 -1.42773,-1.942382 -3.86816,-1.942382 z m 0,-2.589844 q 3.98437,0 6.25878,2.589844 2.27442,2.589843 2.27442,7.1718746 0,4.5654297 -2.27442,7.171875 -2.27441,2.58984371 -6.25878,2.58984371 -4.00098,0 -6.2754,-2.58984371 -2.25781,-2.6064453 -2.25781,-7.171875 0,-4.5820316 2.25781,-7.1718746 2.27442,-2.589844 6.2754,-2.589844 z"
+     id="path11223" /><path
+     d="M 265.09375,-11.222656 V 0 h -3.05469 v -11.123047 q 0,-2.639648 -1.02929,-3.951172 -1.0293,-1.311523 -3.0879,-1.311523 -2.47363,0 -3.90136,1.577148 -1.42774,1.577149 -1.42774,4.299805 V 0 h -3.07129 v -18.59375 h 3.07129 v 2.888672 q 1.09571,-1.676758 2.57325,-2.506836 1.49414,-0.830078 3.43652,-0.830078 3.2041,0 4.84766,1.992187 1.64355,1.975586 1.64355,5.827149 z"
+     id="path11225" /></g>
+<g
+   aria-label="Data Storage"
+   transform="matrix(-8.074733e-04 -1 1 -8.074733e-04 1155.9829 280.9023)"
+   id="text1803"
+   class="st3 st95 st96"
+   style="font-size:36px;font-family:Poppins-SemiBold;fill:#ffffff"><path
+     d="m 7.0839844,-23.326172 v 20.4082032 h 4.2890626 q 5.43164,0 7.945312,-2.4609374 2.53125,-2.4609375 2.53125,-7.7695318 0,-5.273437 -2.53125,-7.716796 -2.513672,-2.460938 -7.945312,-2.460938 z m -3.5507813,-2.917969 h 7.2949219 q 7.628906,0 11.197266,3.181641 3.568359,3.164063 3.568359,9.914062 0,6.7851568 -3.585938,9.9667974 Q 18.421875,0 10.828125,0 H 3.5332031 Z"
+     id="path11178" /><path
+     d="m 40.060547,-9.8964844 q -3.919922,0 -5.431641,0.8964844 -1.511719,0.8964844 -1.511719,3.0585938 0,1.7226562 1.125,2.7421874 1.142579,1.0019532 3.09375,1.0019532 2.689454,0 4.306641,-1.8984375 1.634766,-1.9160156 1.634766,-5.0800782 v -0.7207031 z m 6.451172,-1.3359376 V 0 h -3.234375 v -2.9882813 q -1.107422,1.7929688 -2.759766,2.65429692 -1.652344,0.84375 -4.042969,0.84375 -3.023437,0 -4.816406,-1.68750002 -1.775391,-1.7050781 -1.775391,-4.5527343 0,-3.3222657 2.214844,-5.0097653 2.232422,-1.6875 6.644531,-1.6875 h 4.535157 v -0.316407 q 0,-2.232422 -1.476563,-3.445312 -1.458984,-1.230469 -4.113281,-1.230469 -1.6875,0 -3.287109,0.404297 -1.59961,0.404297 -3.076172,1.212891 v -2.988282 q 1.77539,-0.685546 3.445312,-1.019531 1.669922,-0.351562 3.251953,-0.351562 4.271485,0 6.38086,2.214843 2.109375,2.214844 2.109375,6.714844 z"
+     id="path11180" /><path
+     d="m 56.373047,-25.277344 v 5.589844 h 6.662109 v 2.513672 h -6.662109 v 10.6874999 q 0,2.4082031 0.65039,3.09375 0.667969,0.6855468 2.689454,0.6855468 h 3.322265 V 0 h -3.322265 q -3.744141,0 -5.167969,-1.3886719 -1.423828,-1.40625 -1.423828,-5.0976562 V -17.173828 H 50.748047 V -19.6875 h 2.373047 v -5.589844 z"
+     id="path11182" /><path
+     d="m 76.236328,-9.8964844 q -3.919922,0 -5.431641,0.8964844 -1.511718,0.8964844 -1.511718,3.0585938 0,1.7226562 1.125,2.7421874 1.142578,1.0019532 3.09375,1.0019532 2.689453,0 4.30664,-1.8984375 1.634766,-1.9160156 1.634766,-5.0800782 V -9.8964844 Z M 82.6875,-11.232422 V 0 h -3.234375 v -2.9882813 q -1.107422,1.7929688 -2.759766,2.65429692 -1.652343,0.84375 -4.042968,0.84375 -3.023438,0 -4.816407,-1.68750002 -1.77539,-1.7050781 -1.77539,-4.5527343 0,-3.3222657 2.214843,-5.0097653 2.232422,-1.6875 6.644532,-1.6875 h 4.535156 v -0.316407 q 0,-2.232422 -1.476563,-3.445312 -1.458984,-1.230469 -4.113281,-1.230469 -1.6875,0 -3.287109,0.404297 -1.59961,0.404297 -3.076172,1.212891 v -2.988282 q 1.775391,-0.685546 3.445312,-1.019531 1.669922,-0.351562 3.251954,-0.351562 4.271484,0 6.380859,2.214843 2.109375,2.214844 2.109375,6.714844 z"
+     id="path11184" /><path
+     d="m 116.66602,-25.382812 v 3.46289 q -2.02149,-0.966797 -3.81446,-1.441406 -1.79297,-0.474609 -3.46289,-0.474609 -2.90039,0 -4.48242,1.125 -1.56445,1.125 -1.56445,3.199218 0,1.740235 1.03711,2.636719 1.05468,0.878906 3.97265,1.423828 l 2.14453,0.439453 q 3.97266,0.75586 5.85352,2.671875 1.89844,1.898438 1.89844,5.0976565 0,3.8144531 -2.56641,5.7832031 -2.54883,1.96875002 -7.48828,1.96875002 -1.86328,0 -3.97266,-0.421875 -2.09179,-0.421875 -4.341794,-1.24804682 v -3.65625 q 2.162114,1.2128906 4.236324,1.8281249 2.07422,0.6152344 4.07813,0.6152344 3.04102,0 4.69336,-1.1953125 1.65234,-1.1953125 1.65234,-3.4101562 0,-1.9335938 -1.19531,-3.0234374 -1.17773,-1.089844 -3.88477,-1.634766 l -2.1621,-0.421875 q -3.97266,-0.791015 -5.74805,-2.478515 -1.775393,-1.6875 -1.775393,-4.69336 0,-3.480468 2.443363,-5.484375 2.46093,-2.003906 6.76758,-2.003906 1.8457,0 3.76171,0.333984 1.91602,0.333985 3.91993,1.001954 z"
+     id="path11186" /><path
+     d="m 126.84375,-25.277344 v 5.589844 h 6.66211 v 2.513672 h -6.66211 v 10.6874999 q 0,2.4082031 0.65039,3.09375 0.66797,0.6855468 2.68945,0.6855468 h 3.32227 V 0 h -3.32227 q -3.74414,0 -5.16796,-1.3886719 -1.42383,-1.40625 -1.42383,-5.0976562 V -17.173828 h -2.37305 V -19.6875 h 2.37305 v -5.589844 z"
+     id="path11188" /><path
+     d="m 145.38867,-17.419922 q -2.60156,0 -4.11328,2.039063 -1.51172,2.021484 -1.51172,5.5546871 0,3.5332032 1.49414,5.5722657 1.51172,2.0214843 4.13086,2.0214843 2.58399,0 4.0957,-2.0390625 1.51172,-2.0390625 1.51172,-5.5546875 0,-3.4980471 -1.51172,-5.5371091 -1.51171,-2.056641 -4.0957,-2.056641 z m 0,-2.742187 q 4.21875,0 6.62695,2.742187 2.40821,2.742188 2.40821,7.5937501 0,4.8339844 -2.40821,7.59375 -2.4082,2.74218752 -6.62695,2.74218752 -4.23633,0 -6.64453,-2.74218752 -2.39062,-2.7597656 -2.39062,-7.59375 0,-4.8515621 2.39062,-7.5937501 2.4082,-2.742187 6.64453,-2.742187 z"
+     id="path11190" /><path
+     d="m 171.19336,-16.664062 q -0.54492,-0.316407 -1.19531,-0.457032 -0.63282,-0.158203 -1.40625,-0.158203 -2.74219,0 -4.21875,1.792969 -1.45899,1.77539 -1.45899,5.115234 V 0 h -3.25195 v -19.6875 h 3.25195 v 3.058594 q 1.01953,-1.792969 2.6543,-2.654297 1.63476,-0.878906 3.97266,-0.878906 0.33398,0 0.73828,0.05273 0.40429,0.03516 0.89648,0.123047 z"
+     id="path11192" /><path
+     d="m 183.5332,-9.8964844 q -3.91992,0 -5.43164,0.8964844 -1.51172,0.8964844 -1.51172,3.0585938 0,1.7226562 1.125,2.7421874 1.14258,1.0019532 3.09375,1.0019532 2.68946,0 4.30664,-1.8984375 1.63477,-1.9160156 1.63477,-5.0800782 v -0.7207031 z m 6.45117,-1.3359376 V 0 H 186.75 v -2.9882813 q -1.10742,1.7929688 -2.75977,2.65429692 -1.65234,0.84375 -4.04296,0.84375 -3.02344,0 -4.81641,-1.68750002 -1.77539,-1.7050781 -1.77539,-4.5527343 0,-3.3222657 2.21484,-5.0097653 2.23242,-1.6875 6.64453,-1.6875 H 186.75 v -0.316407 q 0,-2.232422 -1.47656,-3.445312 -1.45899,-1.230469 -4.11328,-1.230469 -1.6875,0 -3.28711,0.404297 -1.59961,0.404297 -3.07618,1.212891 v -2.988282 q 1.7754,-0.685546 3.44532,-1.019531 1.66992,-0.351562 3.25195,-0.351562 4.27148,0 6.38086,2.214843 2.10937,2.214844 2.10937,6.714844 z"
+     id="path11194" /><path
+     d="m 209.60156,-10.072266 q 0,-3.515625 -1.45898,-5.449218 -1.44141,-1.933594 -4.06055,-1.933594 -2.60156,0 -4.06055,1.933594 -1.4414,1.933593 -1.4414,5.449218 0,3.4980473 1.4414,5.431641 1.45899,1.9335937 4.06055,1.9335937 2.61914,0 4.06055,-1.9335937 1.45898,-1.9335937 1.45898,-5.431641 z m 3.23438,7.6289066 q 0,5.0273438 -2.23242,7.4707031 -2.23243,2.4609375 -6.8379,2.4609375 -1.70507,0 -3.21679,-0.2636718 -1.51172,-0.2460938 -2.93555,-0.7734375 V 3.3046875 q 1.42383,0.7734375 2.8125,1.1425781 1.38867,0.3691406 2.83008,0.3691406 3.18164,0 4.76367,-1.6699218 1.58203,-1.6523438 1.58203,-5.0097656 v -1.5996094 q -1.00195,1.7402344 -2.5664,2.60156247 Q 205.4707,0 203.29102,0 q -3.6211,0 -5.83594,-2.7597656 -2.21485,-2.7597656 -2.21485,-7.3125004 0,-4.570312 2.21485,-7.330078 2.21484,-2.759765 5.83594,-2.759765 2.17968,0 3.74414,0.861328 1.56445,0.861328 2.5664,2.601562 V -19.6875 h 3.23438 z"
+     id="path11196" /><path
+     d="m 236.33789,-10.652344 v 1.5820315 H 221.4668 q 0.21093,3.3398438 2.0039,5.0976562 1.81055,1.7402344 5.02735,1.7402344 1.86328,0 3.60351,-0.4570312 1.75781,-0.4570313 3.48047,-1.3710938 v 3.0585938 q -1.74023,0.73828122 -3.56836,1.12499997 -1.82812,0.38671875 -3.70898,0.38671875 -4.71094,0 -7.47071,-2.74218752 -2.74218,-2.7421875 -2.74218,-7.4179687 0,-4.8339844 2.60156,-7.6640624 2.61914,-2.847656 7.04883,-2.847656 3.97265,0 6.27539,2.566406 2.32031,2.548828 2.32031,6.943359 z m -3.23437,-0.949219 q -0.0352,-2.654296 -1.49415,-4.236328 -1.4414,-1.582031 -3.83203,-1.582031 -2.70703,0 -4.34179,1.529297 -1.61719,1.529297 -1.86328,4.306641 z"
+     id="path11198" /></g>
+<g
+   aria-label="Cache"
+   transform="matrix(-8.074733e-04 -1 1 -8.074733e-04 1577.9285 552.2021)"
+   id="text1805"
+   class="st3 st95 st96"
+   style="font-size:36px;font-family:Poppins-SemiBold;fill:#ffffff"><path
+     d="m 23.185547,-24.222656 v 3.74414 q -1.792969,-1.669921 -3.832031,-2.496093 -2.021485,-0.826172 -4.306641,-0.826172 -4.5,0 -6.890625,2.759765 -2.390625,2.742188 -2.390625,7.945313 0,5.1855468 2.390625,7.9453124 2.390625,2.7421875 6.890625,2.7421875 2.285156,0 4.306641,-0.8261719 2.039062,-0.8261719 3.832031,-2.4960937 v 3.7089843 q -1.863281,1.26562503 -3.955078,1.89843753 -2.074219,0.63281249 -4.394531,0.63281249 -5.9589849,0 -9.3867193,-3.63867192 -3.4277343,-3.6562499 -3.4277343,-9.9667967 0,-6.328125 3.4277343,-9.966797 3.4277344,-3.65625 9.3867193,-3.65625 2.355468,0 4.429687,0.632813 2.091797,0.615234 3.919922,1.863281 z"
+     id="path11167" /><path
+     d="m 37.476562,-9.8964844 q -3.919921,0 -5.43164,0.8964844 -1.511719,0.8964844 -1.511719,3.0585938 0,1.7226562 1.125,2.7421874 1.142578,1.0019532 3.09375,1.0019532 2.689453,0 4.306641,-1.8984375 1.634765,-1.9160156 1.634765,-5.0800782 v -0.7207031 z m 6.451172,-1.3359376 V 0 h -3.234375 v -2.9882813 q -1.107422,1.7929688 -2.759765,2.65429692 -1.652344,0.84375 -4.042969,0.84375 -3.023438,0 -4.816406,-1.68750002 -1.775391,-1.7050781 -1.775391,-4.5527343 0,-3.3222657 2.214844,-5.0097653 2.232422,-1.6875 6.644531,-1.6875 h 4.535156 v -0.316407 q 0,-2.232422 -1.476562,-3.445312 -1.458985,-1.230469 -4.113281,-1.230469 -1.6875,0 -3.28711,0.404297 -1.599609,0.404297 -3.076172,1.212891 v -2.988282 q 1.775391,-0.685546 3.445313,-1.019531 1.669922,-0.351562 3.251953,-0.351562 4.271484,0 6.380859,2.214843 2.109375,2.214844 2.109375,6.714844 z"
+     id="path11169" /><path
+     d="m 64.757812,-18.931641 v 3.023438 q -1.371093,-0.755859 -2.759765,-1.125 -1.371094,-0.386719 -2.777344,-0.386719 -3.146484,0 -4.886719,2.003906 -1.740234,1.986328 -1.740234,5.5898441 0,3.6035157 1.740234,5.6074219 1.740235,1.9863281 4.886719,1.9863281 1.40625,0 2.777344,-0.3691406 1.388672,-0.3867188 2.759765,-1.1425781 v 2.98828123 q -1.353515,0.6328125 -2.8125,0.94921874 -1.441406,0.31640625 -3.076171,0.31640625 -4.447266,0 -7.066407,-2.79492192 -2.61914,-2.7949218 -2.61914,-7.5410156 0,-4.8164061 2.636718,-7.5761721 2.654297,-2.759765 7.259766,-2.759765 1.494141,0 2.917969,0.316406 1.423828,0.298828 2.759765,0.914062 z"
+     id="path11171" /><path
+     d="M 86.748047,-11.882813 V 0 h -3.234375 v -11.777344 q 0,-2.794922 -1.089844,-4.183594 -1.089844,-1.388671 -3.269531,-1.388671 -2.619141,0 -4.13086,1.669921 -1.511718,1.669922 -1.511718,4.552735 V 0 h -3.251953 v -27.351562 h 3.251953 v 10.722656 q 1.160156,-1.775391 2.724609,-2.654297 1.582031,-0.878906 3.638672,-0.878906 3.392578,0 5.132812,2.109375 1.740235,2.091796 1.740235,6.169921 z"
+     id="path11173" /><path
+     d="m 110.03906,-10.652344 v 1.5820315 H 95.167969 q 0.210937,3.3398438 2.003906,5.0976562 1.810547,1.7402344 5.027345,1.7402344 1.86328,0 3.60351,-0.4570312 1.75782,-0.4570313 3.48047,-1.3710938 v 3.0585938 q -1.74023,0.73828122 -3.56836,1.12499997 -1.82812,0.38671875 -3.70898,0.38671875 -4.710938,0 -7.470704,-2.74218752 -2.742187,-2.7421875 -2.742187,-7.4179687 0,-4.8339844 2.601562,-7.6640624 2.619141,-2.847656 7.048829,-2.847656 3.97266,0 6.27539,2.566406 2.32031,2.548828 2.32031,6.943359 z m -3.23437,-0.949219 q -0.0352,-2.654296 -1.49414,-4.236328 -1.44141,-1.582031 -3.83203,-1.582031 -2.707036,0 -4.341801,1.529297 -1.617188,1.529297 -1.863282,4.306641 z"
+     id="path11175" /></g>
+<g
+   aria-label="Network"
+   transform="matrix(-8.074733e-04 -1 1 -8.074733e-04 934.5479 899.1767)"
+   id="text1807"
+   class="st3 st95 st96"
+   style="font-size:36px;font-family:Poppins-SemiBold;fill:#ffffff"><path
+     d="m 3.5332031,-26.244141 h 4.78125 L 19.951172,-4.2890625 V -26.244141 h 3.445312 V 0 h -4.78125 L 6.9785156,-21.955078 V 0 H 3.5332031 Z"
+     id="path11152" /><path
+     d="m 47.162109,-10.652344 v 1.5820315 H 32.291016 q 0.210937,3.3398438 2.003906,5.0976562 1.810547,1.7402344 5.027344,1.7402344 1.863281,0 3.603515,-0.4570312 1.757813,-0.4570313 3.480469,-1.3710938 v 3.0585938 q -1.740234,0.73828122 -3.568359,1.12499997 -1.828125,0.38671875 -3.708985,0.38671875 -4.710937,0 -7.470703,-2.74218752 -2.742187,-2.7421875 -2.742187,-7.4179687 0,-4.8339844 2.601562,-7.6640624 2.619141,-2.847656 7.048828,-2.847656 3.972656,0 6.275391,2.566406 2.320312,2.548828 2.320312,6.943359 z m -3.234375,-0.949219 q -0.03516,-2.654296 -1.49414,-4.236328 -1.441407,-1.582031 -3.832032,-1.582031 -2.707031,0 -4.341796,1.529297 -1.617188,1.529297 -1.863282,4.306641 z"
+     id="path11154" /><path
+     d="m 55.669922,-25.277344 v 5.589844 h 6.662109 v 2.513672 h -6.662109 v 10.6874999 q 0,2.4082031 0.65039,3.09375 0.667969,0.6855468 2.689454,0.6855468 h 3.322265 V 0 h -3.322265 q -3.744141,0 -5.167969,-1.3886719 -1.423828,-1.40625 -1.423828,-5.0976562 V -17.173828 H 50.044922 V -19.6875 h 2.373047 v -5.589844 z"
+     id="path11156" /><path
+     d="m 64.705078,-19.6875 h 3.234375 l 4.042969,15.3632813 4.02539,-15.3632813 h 3.814454 L 83.865234,-4.3242187 87.890625,-19.6875 H 91.125 L 85.974609,0 H 82.160156 L 77.923828,-16.136719 73.669922,0 h -3.814453 z"
+     id="path11158" /><path
+     d="m 103.6582,-17.419922 q -2.60156,0 -4.113278,2.039063 -1.511719,2.021484 -1.511719,5.5546871 0,3.5332032 1.494141,5.5722657 1.511716,2.0214843 4.130856,2.0214843 2.58399,0 4.09571,-2.0390625 1.51172,-2.0390625 1.51172,-5.5546875 0,-3.4980471 -1.51172,-5.5371091 -1.51172,-2.056641 -4.09571,-2.056641 z m 0,-2.742187 q 4.21875,0 6.62696,2.742187 2.4082,2.742188 2.4082,7.5937501 0,4.8339844 -2.4082,7.59375 -2.40821,2.74218752 -6.62696,2.74218752 -4.236325,0 -6.644528,-2.74218752 -2.390625,-2.7597656 -2.390625,-7.59375 0,-4.8515621 2.390625,-7.5937501 2.408203,-2.742187 6.644528,-2.742187 z"
+     id="path11160" /><path
+     d="m 129.46289,-16.664062 q -0.54492,-0.316407 -1.19531,-0.457032 -0.63281,-0.158203 -1.40625,-0.158203 -2.74219,0 -4.21875,1.792969 -1.45899,1.77539 -1.45899,5.115234 V 0 h -3.25195 v -19.6875 h 3.25195 v 3.058594 q 1.01954,-1.792969 2.6543,-2.654297 1.63477,-0.878906 3.97266,-0.878906 0.33398,0 0.73828,0.05273 0.40429,0.03516 0.89648,0.123047 z"
+     id="path11162" /><path
+     d="m 132.73242,-27.351562 h 3.25195 v 16.154296 l 9.6504,-8.490234 h 4.13085 l -10.4414,9.210937 L 150.20508,0 h -4.21875 L 135.98437,-9.6152344 V 0 h -3.25195 z"
+     id="path11164" /></g>
+<g
+   aria-label="Container"
+   transform="matrix(-8.074733e-04 -1 1 -8.074733e-04 915.6073 1249.913)"
+   id="text1809"
+   class="st3 st95 st96"
+   style="font-size:36px;font-family:Poppins-SemiBold;fill:#ffffff"><path
+     d="m 23.185547,-24.222656 v 3.74414 q -1.792969,-1.669921 -3.832031,-2.496093 -2.021485,-0.826172 -4.306641,-0.826172 -4.5,0 -6.890625,2.759765 -2.390625,2.742188 -2.390625,7.945313 0,5.1855468 2.390625,7.9453124 2.390625,2.7421875 6.890625,2.7421875 2.285156,0 4.306641,-0.8261719 2.039062,-0.8261719 3.832031,-2.4960937 v 3.7089843 q -1.863281,1.26562503 -3.955078,1.89843753 -2.074219,0.63281249 -4.394531,0.63281249 -5.9589849,0 -9.3867193,-3.63867192 -3.4277343,-3.6562499 -3.4277343,-9.9667967 0,-6.328125 3.4277343,-9.966797 3.4277344,-3.65625 9.3867193,-3.65625 2.355468,0 4.429687,0.632813 2.091797,0.615234 3.919922,1.863281 z"
+     id="path11133" /><path
+     d="m 36.158203,-17.419922 q -2.601562,0 -4.113281,2.039063 -1.511719,2.021484 -1.511719,5.5546871 0,3.5332032 1.494141,5.5722657 1.511718,2.0214843 4.130859,2.0214843 2.583984,0 4.095703,-2.0390625 1.511719,-2.0390625 1.511719,-5.5546875 0,-3.4980471 -1.511719,-5.5371091 -1.511719,-2.056641 -4.095703,-2.056641 z m 0,-2.742187 q 4.21875,0 6.626953,2.742187 2.408203,2.742188 2.408203,7.5937501 0,4.8339844 -2.408203,7.59375 -2.408203,2.74218752 -6.626953,2.74218752 -4.236328,0 -6.644531,-2.74218752 -2.390625,-2.7597656 -2.390625,-7.59375 0,-4.8515621 2.390625,-7.5937501 2.408203,-2.742187 6.644531,-2.742187 z"
+     id="path11135" /><path
+     d="M 66.919922,-11.882813 V 0 h -3.234375 v -11.777344 q 0,-2.794922 -1.089844,-4.183594 -1.089844,-1.388671 -3.269531,-1.388671 -2.619141,0 -4.13086,1.669921 -1.511718,1.669922 -1.511718,4.552735 V 0 h -3.251953 v -19.6875 h 3.251953 v 3.058594 q 1.160156,-1.775391 2.724609,-2.654297 1.582031,-0.878906 3.638672,-0.878906 3.392578,0 5.132812,2.109375 1.740235,2.091796 1.740235,6.169921 z"
+     id="path11137" /><path
+     d="m 76.570312,-25.277344 v 5.589844 h 6.66211 v 2.513672 h -6.66211 v 10.6874999 q 0,2.4082031 0.650391,3.09375 0.667969,0.6855468 2.689453,0.6855468 h 3.322266 V 0 h -3.322266 q -3.74414,0 -5.167969,-1.3886719 -1.423828,-1.40625 -1.423828,-5.0976562 V -17.173828 H 70.945312 V -19.6875 h 2.373047 v -5.589844 z"
+     id="path11139" /><path
+     d="m 96.433594,-9.8964844 q -3.919922,0 -5.431641,0.8964844 -1.511719,0.8964844 -1.511719,3.0585938 0,1.7226562 1.125,2.7421874 1.142578,1.0019532 3.09375,1.0019532 2.689453,0 4.306641,-1.8984375 1.634766,-1.9160156 1.634766,-5.0800782 v -0.7207031 z m 6.451176,-1.3359376 V 0 h -3.234379 v -2.9882813 q -1.107422,1.7929688 -2.759766,2.65429692 -1.652344,0.84375 -4.042969,0.84375 -3.023437,0 -4.816406,-1.68750002 -1.775391,-1.7050781 -1.775391,-4.5527343 0,-3.3222657 2.214844,-5.0097653 2.232422,-1.6875 6.644531,-1.6875 h 4.535157 v -0.316407 q 0,-2.232422 -1.476563,-3.445312 -1.458984,-1.230469 -4.113281,-1.230469 -1.6875,0 -3.28711,0.404297 -1.599609,0.404297 -3.076171,1.212891 v -2.988282 q 1.77539,-0.685546 3.445312,-1.019531 1.669922,-0.351562 3.251953,-0.351562 4.271485,0 6.380859,2.214843 2.10938,2.214844 2.10938,6.714844 z"
+     id="path11141" /><path
+     d="m 109.54688,-19.6875 h 3.23437 V 0 h -3.23437 z m 0,-7.664062 h 3.23437 v 4.095703 h -3.23437 z"
+     id="path11143" /><path
+     d="M 135.91406,-11.882813 V 0 h -3.23437 v -11.777344 q 0,-2.794922 -1.08985,-4.183594 -1.08984,-1.388671 -3.26953,-1.388671 -2.61914,0 -4.13086,1.669921 -1.51172,1.669922 -1.51172,4.552735 V 0 h -3.25195 v -19.6875 h 3.25195 v 3.058594 q 1.16016,-1.775391 2.72461,-2.654297 1.58204,-0.878906 3.63868,-0.878906 3.39257,0 5.13281,2.109375 1.74023,2.091796 1.74023,6.169921 z"
+     id="path11145" /><path
+     d="m 159.20508,-10.652344 v 1.5820315 h -14.8711 q 0.21094,3.3398438 2.00391,5.0976562 1.81055,1.7402344 5.02734,1.7402344 1.86329,0 3.60352,-0.4570312 1.75781,-0.4570313 3.48047,-1.3710938 v 3.0585938 q -1.74024,0.73828122 -3.56836,1.12499997 -1.82813,0.38671875 -3.70899,0.38671875 -4.71093,0 -7.4707,-2.74218752 -2.74219,-2.7421875 -2.74219,-7.4179687 0,-4.8339844 2.60157,-7.6640624 2.61914,-2.847656 7.04882,-2.847656 3.97266,0 6.2754,2.566406 2.32031,2.548828 2.32031,6.943359 z m -3.23438,-0.949219 q -0.0351,-2.654296 -1.49414,-4.236328 -1.4414,-1.582031 -3.83203,-1.582031 -2.70703,0 -4.3418,1.529297 -1.61718,1.529297 -1.86328,4.306641 z"
+     id="path11147" /><path
+     d="m 175.92187,-16.664062 q -0.54492,-0.316407 -1.19531,-0.457032 -0.63281,-0.158203 -1.40625,-0.158203 -2.74219,0 -4.21875,1.792969 -1.45898,1.77539 -1.45898,5.115234 V 0 h -3.25196 v -19.6875 h 3.25196 v 3.058594 q 1.01953,-1.792969 2.65429,-2.654297 1.63477,-0.878906 3.97266,-0.878906 0.33399,0 0.73828,0.05273 0.4043,0.03516 0.89649,0.123047 z"
+     id="path11149" /></g>
+<g
+   aria-label="Engine"
+   transform="matrix(-8.074733e-04 -1 1 -8.074733e-04 958.7831 1219.8778)"
+   id="text1811"
+   class="st3 st95 st96"
+   style="font-size:36px;font-family:Poppins-SemiBold;fill:#ffffff"><path
+     d="M 3.5332031,-26.244141 H 20.126953 v 2.988282 H 7.0839844 v 7.769531 H 19.582031 v 2.988281 H 7.0839844 v 9.5097657 H 20.443359 V 0 H 3.5332031 Z"
+     id="path11120" /><path
+     d="M 42.503906,-11.882813 V 0 h -3.234375 v -11.777344 q 0,-2.794922 -1.089844,-4.183594 -1.089843,-1.388671 -3.269531,-1.388671 -2.61914,0 -4.130859,1.669921 -1.511719,1.669922 -1.511719,4.552735 V 0 h -3.251953 v -19.6875 h 3.251953 v 3.058594 q 1.160156,-1.775391 2.724609,-2.654297 1.582032,-0.878906 3.638672,-0.878906 3.392578,0 5.132813,2.109375 1.740234,2.091796 1.740234,6.169921 z"
+     id="path11122" /><path
+     d="m 61.910156,-10.072266 q 0,-3.515625 -1.458984,-5.449218 -1.441406,-1.933594 -4.060547,-1.933594 -2.601563,0 -4.060547,1.933594 -1.441406,1.933593 -1.441406,5.449218 0,3.4980473 1.441406,5.431641 1.458984,1.9335937 4.060547,1.9335937 2.619141,0 4.060547,-1.9335937 1.458984,-1.9335937 1.458984,-5.431641 z m 3.234375,7.6289066 q 0,5.0273438 -2.232422,7.4707031 -2.232422,2.4609375 -6.83789,2.4609375 -1.705078,0 -3.216797,-0.2636718 Q 51.345703,6.9785156 49.921875,6.4511719 V 3.3046875 q 1.423828,0.7734375 2.8125,1.1425781 1.388672,0.3691406 2.830078,0.3691406 3.181641,0 4.763672,-1.6699218 1.582031,-1.6523438 1.582031,-5.0097656 V -3.4628906 Q 60.908203,-1.7226562 59.34375,-0.86132813 57.779297,0 55.599609,0 q -3.621093,0 -5.835937,-2.7597656 -2.214844,-2.7597656 -2.214844,-7.3125004 0,-4.570312 2.214844,-7.330078 2.214844,-2.759765 5.835937,-2.759765 2.179688,0 3.744141,0.861328 1.564453,0.861328 2.566406,2.601562 V -19.6875 h 3.234375 z"
+     id="path11124" /><path
+     d="m 71.806641,-19.6875 h 3.234375 V 0 h -3.234375 z m 0,-7.664062 h 3.234375 v 4.095703 h -3.234375 z"
+     id="path11126" /><path
+     d="M 98.173828,-11.882813 V 0 h -3.234375 v -11.777344 q 0,-2.794922 -1.089844,-4.183594 -1.089843,-1.388671 -3.269531,-1.388671 -2.619141,0 -4.130859,1.669921 -1.511719,1.669922 -1.511719,4.552735 V 0 H 81.685547 V -19.6875 H 84.9375 v 3.058594 q 1.160156,-1.775391 2.724609,-2.654297 1.582032,-0.878906 3.638672,-0.878906 3.392578,0 5.132813,2.109375 1.740234,2.091796 1.740234,6.169921 z"
+     id="path11128" /><path
+     d="m 121.46484,-10.652344 v 1.5820315 h -14.87109 q 0.21094,3.3398438 2.00391,5.0976562 1.81054,1.7402344 5.02734,1.7402344 1.86328,0 3.60352,-0.4570312 1.75781,-0.4570313 3.48046,-1.3710938 v 3.0585938 q -1.74023,0.73828122 -3.56835,1.12499997 -1.82813,0.38671875 -3.70899,0.38671875 -4.71094,0 -7.4707,-2.74218752 -2.74219,-2.7421875 -2.74219,-7.4179687 0,-4.8339844 2.60156,-7.6640624 2.61914,-2.847656 7.04883,-2.847656 3.97266,0 6.27539,2.566406 2.32031,2.548828 2.32031,6.943359 z m -3.23437,-0.949219 q -0.0352,-2.654296 -1.49414,-4.236328 -1.44141,-1.582031 -3.83203,-1.582031 -2.70703,0 -4.3418,1.529297 -1.61719,1.529297 -1.86328,4.306641 z"
+     id="path11130" /></g>
+<g
+   aria-label="Observability"
+   transform="matrix(-8.074733e-04 -1 1 -8.074733e-04 1510.6593 1610.0682)"
+   id="text1813"
+   class="st3 st95 st96"
+   style="font-size:36px;font-family:Poppins-SemiBold;fill:#ffffff"><path
+     d="m 14.185547,-23.835937 q -3.867188,0 -6.1523439,2.882812 -2.2675781,2.882813 -2.2675781,7.857422 0,4.9570311 2.2675781,7.8398436 2.2851559,2.8828125 6.1523439,2.8828125 3.867187,0 6.117187,-2.8828125 2.267578,-2.8828125 2.267578,-7.8398436 0,-4.974609 -2.267578,-7.857422 -2.25,-2.882812 -6.117187,-2.882812 z m 0,-2.882813 q 5.519531,0 8.824219,3.708984 3.304687,3.691407 3.304687,9.914063 0,6.205078 -3.304687,9.9140624 -3.304688,3.69140622 -8.824219,3.69140622 -5.5371095,0 -8.8593751,-3.69140622 -3.3046875,-3.6914063 -3.3046875,-9.9140624 0,-6.222656 3.3046875,-9.914063 3.3222656,-3.708984 8.8593751,-3.708984 z"
+     id="path11093" /><path
+     d="m 45.861328,-9.8261719 q 0,-3.5683591 -1.476562,-5.5898441 -1.458985,-2.039062 -4.025391,-2.039062 -2.566406,0 -4.042969,2.039062 -1.458984,2.021485 -1.458984,5.5898441 0,3.5683594 1.458984,5.6074219 1.476563,2.0214844 4.042969,2.0214844 2.566406,0 4.025391,-2.0214844 1.476562,-2.0390625 1.476562,-5.6074219 z M 34.857422,-16.699219 q 1.019531,-1.757812 2.566406,-2.601562 1.564453,-0.861328 3.726563,-0.861328 3.585937,0 5.818359,2.847656 2.25,2.847656 2.25,7.4882811 0,4.640625 -2.25,7.4882813 -2.232422,2.84765622 -5.818359,2.84765622 -2.16211,0 -3.726563,-0.84375 Q 35.876953,-1.1953125 34.857422,-2.953125 V 0 h -3.251953 v -27.351562 h 3.251953 z"
+     id="path11095" /><path
+     d="m 67.130859,-19.107422 v 3.058594 q -1.371093,-0.703125 -2.847656,-1.054688 -1.476562,-0.351562 -3.058594,-0.351562 -2.408203,0 -3.621093,0.738281 -1.195313,0.738281 -1.195313,2.214844 0,1.125 0.861328,1.77539 0.861328,0.632813 3.462891,1.212891 l 1.107422,0.246094 q 3.445312,0.738281 4.886718,2.0917967 1.458985,1.3359376 1.458985,3.7441407 0,2.7421875 -2.179688,4.3417969 -2.162109,1.59960932 -5.958984,1.59960932 -1.582031,0 -3.304688,-0.31640625 -1.705078,-0.29882812 -3.603515,-0.91406249 V -4.0605469 q 1.792969,0.9316406 3.533203,1.40625 1.740234,0.4570313 3.445312,0.4570313 2.285157,0 3.515625,-0.7734375 1.230469,-0.7910157 1.230469,-2.2148438 0,-1.3183593 -0.896484,-2.0214843 -0.878906,-0.703125 -3.884766,-1.3535157 l -1.125,-0.2636719 q -3.005859,-0.6328125 -4.341797,-1.9335942 -1.335937,-1.318359 -1.335937,-3.603515 0,-2.777344 1.96875,-4.289063 1.96875,-1.511718 5.589844,-1.511718 1.792968,0 3.375,0.263672 1.582031,0.263671 2.917968,0.791015 z"
+     id="path11097" /><path
+     d="m 90.175781,-10.652344 v 1.5820315 H 75.304687 q 0.210938,3.3398438 2.003907,5.0976562 1.810547,1.7402344 5.027343,1.7402344 1.863282,0 3.603516,-0.4570312 1.757813,-0.4570313 3.480469,-1.3710938 v 3.0585938 q -1.740235,0.73828122 -3.56836,1.12499997 -1.828125,0.38671875 -3.708984,0.38671875 -4.710937,0 -7.470703,-2.74218752 -2.742188,-2.7421875 -2.742188,-7.4179687 0,-4.8339844 2.601563,-7.6640624 2.619141,-2.847656 7.048828,-2.847656 3.972656,0 6.275391,2.566406 2.320312,2.548828 2.320312,6.943359 z m -3.234375,-0.949219 q -0.03516,-2.654296 -1.49414,-4.236328 -1.441407,-1.582031 -3.832032,-1.582031 -2.707031,0 -4.341797,1.529297 -1.617187,1.529297 -1.863281,4.306641 z"
+     id="path11099" /><path
+     d="m 106.89258,-16.664062 q -0.54492,-0.316407 -1.19531,-0.457032 -0.63282,-0.158203 -1.40625,-0.158203 -2.74219,0 -4.21875,1.792969 -1.458989,1.77539 -1.458989,5.115234 V 0 h -3.251953 v -19.6875 h 3.251953 v 3.058594 q 1.019531,-1.792969 2.654299,-2.654297 1.63476,-0.878906 3.97265,-0.878906 0.33399,0 0.73829,0.05273 0.40429,0.03516 0.89648,0.123047 z"
+     id="path11101" /><path
+     d="m 107.96484,-19.6875 h 3.42774 l 6.15234,16.5234375 6.15235,-16.5234375 H 127.125 L 119.74219,0 h -4.39453 z"
+     id="path11103" /><path
+     d="m 140.53711,-9.8964844 q -3.91992,0 -5.43164,0.8964844 -1.51172,0.8964844 -1.51172,3.0585938 0,1.7226562 1.125,2.7421874 1.14258,1.0019532 3.09375,1.0019532 2.68945,0 4.30664,-1.8984375 1.63477,-1.9160156 1.63477,-5.0800782 v -0.7207031 z m 6.45117,-1.3359376 V 0 h -3.23437 v -2.9882813 q -1.10743,1.7929688 -2.75977,2.65429692 -1.65234,0.84375 -4.04297,0.84375 -3.02344,0 -4.8164,-1.68750002 -1.7754,-1.7050781 -1.7754,-4.5527343 0,-3.3222657 2.21485,-5.0097653 2.23242,-1.6875 6.64453,-1.6875 h 4.53516 v -0.316407 q 0,-2.232422 -1.47657,-3.445312 -1.45898,-1.230469 -4.11328,-1.230469 -1.6875,0 -3.28711,0.404297 -1.59961,0.404297 -3.07617,1.212891 v -2.988282 q 1.77539,-0.685546 3.44531,-1.019531 1.66993,-0.351562 3.25196,-0.351562 4.27148,0 6.38086,2.214843 2.10937,2.214844 2.10937,6.714844 z"
+     id="path11105" /><path
+     d="m 167.7832,-9.8261719 q 0,-3.5683591 -1.47656,-5.5898441 -1.45898,-2.039062 -4.02539,-2.039062 -2.56641,0 -4.04297,2.039062 -1.45898,2.021485 -1.45898,5.5898441 0,3.5683594 1.45898,5.6074219 1.47656,2.0214844 4.04297,2.0214844 2.56641,0 4.02539,-2.0214844 1.47656,-2.0390625 1.47656,-5.6074219 z m -11.0039,-6.8730471 q 1.01953,-1.757812 2.5664,-2.601562 1.56446,-0.861328 3.72657,-0.861328 3.58593,0 5.81835,2.847656 2.25,2.847656 2.25,7.4882811 0,4.640625 -2.25,7.4882813 -2.23242,2.84765622 -5.81835,2.84765622 -2.16211,0 -3.72657,-0.84375 -1.54687,-0.86132812 -2.5664,-2.61914062 V 0 h -3.25196 v -27.351562 h 3.25196 z"
+     id="path11107" /><path
+     d="m 176.50195,-19.6875 h 3.23438 V 0 h -3.23438 z m 0,-7.664062 h 3.23438 v 4.095703 h -3.23438 z"
+     id="path11109" /><path
+     d="m 186.50391,-27.351562 h 3.23437 V 0 h -3.23437 z"
+     id="path11111" /><path
+     d="m 196.50586,-19.6875 h 3.23437 V 0 h -3.23437 z m 0,-7.664062 h 3.23437 v 4.095703 h -3.23437 z"
+     id="path11113" /><path
+     d="m 209.70703,-25.277344 v 5.589844 h 6.66211 v 2.513672 h -6.66211 v 10.6874999 q 0,2.4082031 0.65039,3.09375 0.66797,0.6855468 2.68945,0.6855468 h 3.32227 V 0 h -3.32227 q -3.74414,0 -5.16796,-1.3886719 -1.42383,-1.40625 -1.42383,-5.0976562 V -17.173828 h -2.37305 V -19.6875 h 2.37305 v -5.589844 z"
+     id="path11115" /><path
+     d="m 228.81445,1.828125 q -1.37109,3.515625 -2.67187,4.5878906 -1.30078,1.0722656 -3.48047,1.0722656 h -2.58399 V 4.78125 h 1.89844 q 1.33594,0 2.07422,-0.6328125 0.73828,-0.6328125 1.63477,-2.9882813 L 226.26562,-0.31640625 218.30273,-19.6875 h 3.42774 l 6.15234,15.3984375 6.15235,-15.3984375 h 3.42773 z"
+     id="path11117" /></g>
+<g
+   aria-label="Traces"
+   transform="matrix(-8.074733e-04 -1 1 -8.074733e-04 1553.8101 1549.035)"
+   id="text1815"
+   class="st3 st95 st96"
+   style="font-size:36px;font-family:Poppins-SemiBold;fill:#ffffff"><path
+     d="M -0.10546875,-26.244141 H 22.095703 v 2.988282 H 12.779297 V 0 H 9.2109375 v -23.255859 h -9.31640625 z"
+     id="path11080" /><path
+     d="m 31.5,-16.664062 q -0.544922,-0.316407 -1.195313,-0.457032 -0.632812,-0.158203 -1.40625,-0.158203 -2.742187,0 -4.21875,1.792969 -1.458984,1.77539 -1.458984,5.115234 V 0 H 19.96875 v -19.6875 h 3.251953 v 3.058594 q 1.019531,-1.792969 2.654297,-2.654297 1.634766,-0.878906 3.972656,-0.878906 0.333985,0 0.738281,0.05273 0.404297,0.03516 0.896485,0.123047 z"
+     id="path11082" /><path
+     d="m 43.839844,-9.8964844 q -3.919922,0 -5.431641,0.8964844 -1.511719,0.8964844 -1.511719,3.0585938 0,1.7226562 1.125,2.7421874 1.142578,1.0019532 3.09375,1.0019532 2.689453,0 4.306641,-1.8984375 1.634766,-1.9160156 1.634766,-5.0800782 v -0.7207031 z m 6.451172,-1.3359376 V 0 h -3.234375 v -2.9882813 q -1.107422,1.7929688 -2.759766,2.65429692 -1.652344,0.84375 -4.042969,0.84375 -3.023437,0 -4.816406,-1.68750002 -1.775391,-1.7050781 -1.775391,-4.5527343 0,-3.3222657 2.214844,-5.0097653 2.232422,-1.6875 6.644531,-1.6875 h 4.535157 v -0.316407 q 0,-2.232422 -1.476563,-3.445312 -1.458984,-1.230469 -4.113281,-1.230469 -1.6875,0 -3.28711,0.404297 -1.599609,0.404297 -3.076171,1.212891 v -2.988282 q 1.77539,-0.685546 3.445312,-1.019531 1.669922,-0.351562 3.251953,-0.351562 4.271485,0 6.38086,2.214843 2.109375,2.214844 2.109375,6.714844 z"
+     id="path11084" /><path
+     d="m 71.121094,-18.931641 v 3.023438 q -1.371094,-0.755859 -2.759766,-1.125 -1.371094,-0.386719 -2.777344,-0.386719 -3.146484,0 -4.886718,2.003906 -1.740235,1.986328 -1.740235,5.5898441 0,3.6035157 1.740235,5.6074219 1.740234,1.9863281 4.886718,1.9863281 1.40625,0 2.777344,-0.3691406 1.388672,-0.3867188 2.759766,-1.1425781 v 2.98828123 q -1.353516,0.6328125 -2.8125,0.94921874 -1.441407,0.31640625 -3.076172,0.31640625 -4.447266,0 -7.066406,-2.79492192 -2.619141,-2.7949218 -2.619141,-7.5410156 0,-4.8164061 2.636719,-7.5761721 2.654297,-2.759765 7.259765,-2.759765 1.494141,0 2.917969,0.316406 1.423828,0.298828 2.759766,0.914062 z"
+     id="path11086" /><path
+     d="m 93.585937,-10.652344 v 1.5820315 H 78.714844 q 0.210937,3.3398438 2.003906,5.0976562 1.810547,1.7402344 5.027344,1.7402344 1.863281,0 3.603515,-0.4570312 1.757813,-0.4570313 3.480469,-1.3710938 v 3.0585938 q -1.740234,0.73828122 -3.568359,1.12499997 -1.828125,0.38671875 -3.708985,0.38671875 -4.710937,0 -7.470703,-2.74218752 -2.742187,-2.7421875 -2.742187,-7.4179687 0,-4.8339844 2.601562,-7.6640624 2.619141,-2.847656 7.048828,-2.847656 3.972657,0 6.275391,2.566406 2.320312,2.548828 2.320312,6.943359 z m -3.234375,-0.949219 q -0.03516,-2.654296 -1.49414,-4.236328 -1.441406,-1.582031 -3.832031,-1.582031 -2.707032,0 -4.341797,1.529297 -1.617188,1.529297 -1.863282,4.306641 z"
+     id="path11088" /><path
+     d="m 111.44531,-19.107422 v 3.058594 q -1.37109,-0.703125 -2.84765,-1.054688 -1.47657,-0.351562 -3.0586,-0.351562 -2.4082,0 -3.62109,0.738281 -1.19531,0.738281 -1.19531,2.214844 0,1.125 0.86132,1.77539 0.86133,0.632813 3.4629,1.212891 l 1.10742,0.246094 q 3.44531,0.738281 4.88672,2.0917967 1.45898,1.3359376 1.45898,3.7441407 0,2.7421875 -2.17969,4.3417969 -2.16211,1.59960932 -5.95898,1.59960932 -1.58203,0 -3.30469,-0.31640625 -1.705078,-0.29882812 -3.603515,-0.91406249 V -4.0605469 q 1.792969,0.9316406 3.533205,1.40625 1.74023,0.4570313 3.44531,0.4570313 2.28516,0 3.51563,-0.7734375 1.23046,-0.7910157 1.23046,-2.2148438 0,-1.3183593 -0.89648,-2.0214843 -0.87891,-0.703125 -3.88477,-1.3535157 l -1.125,-0.2636719 q -3.00585,-0.6328125 -4.341793,-1.9335942 -1.335937,-1.318359 -1.335937,-3.603515 0,-2.777344 1.96875,-4.289063 1.96875,-1.511718 5.58984,-1.511718 1.79297,0 3.375,0.263672 1.58204,0.263671 2.91797,0.791015 z"
+     id="path11090" /></g>
+<g
+   aria-label="*Additional service, not included in the base platform"
+   transform="matrix(1 0 0 1 24.3752 1689.1537)"
+   id="text1817"
+   class="st98 st95 st97"
+   style="font-size:34px;font-family:Poppins-SemiBold;fill:#303b54"><path
+     d="m 15.987305,-20.702148 -5.959961,3.220703 5.959961,3.237304 -0.962891,1.626953 -5.5781249,-3.370117 v 6.2587894 H 7.5537109 v -6.2587894 l -5.578125,3.370117 -0.9628906,-1.626953 5.9599609,-3.237304 -5.9599609,-3.220703 0.9628906,-1.643555 5.578125,3.370117 v -6.258789 h 1.8925782 v 6.258789 l 5.5781249,-3.370117 z"
+     id="path9716" /><path
+     d="m 28.621094,-21.482422 -4.548828,12.3349611 h 9.114257 z m -1.892578,-3.303711 h 3.801757 L 39.976562,0 H 36.490234 L 34.232422,-6.3583984 H 23.05957 L 20.801758,0 h -3.536133 z"
+     id="path9718" /><path
+     d="m 55.100586,-15.771484 v -10.060547 h 3.054687 V 0 h -3.054687 v -2.7890625 q -0.962891,1.6601563 -2.44043,2.47363281 -1.460937,0.796875 -3.519531,0.796875 -3.370117,0 -5.495117,-2.68945311 -2.108399,-2.6894531 -2.108399,-7.0722656 0,-4.3828126 2.108399,-7.0722656 2.125,-2.689453 5.495117,-2.689453 2.058594,0 3.519531,0.813476 1.477539,0.796875 2.44043,2.457032 z m -10.40918,6.4912106 q 0,3.3701172 1.37793,5.2958984 1.394531,1.9091797 3.818359,1.9091797 2.423828,0 3.81836,-1.9091797 1.394531,-1.9257812 1.394531,-5.2958984 0,-3.3701176 -1.394531,-5.2792966 -1.394532,-1.925782 -3.81836,-1.925782 -2.423828,0 -3.818359,1.925782 -1.37793,1.909179 -1.37793,5.2792966 z"
+     id="path9720" /><path
+     d="m 76.682617,-15.771484 v -10.060547 h 3.054688 V 0 h -3.054688 v -2.7890625 q -0.96289,1.6601563 -2.44043,2.47363281 -1.460937,0.796875 -3.519531,0.796875 -3.370117,0 -5.495117,-2.68945311 -2.108398,-2.6894531 -2.108398,-7.0722656 0,-4.3828126 2.108398,-7.0722656 2.125,-2.689453 5.495117,-2.689453 2.058594,0 3.519531,0.813476 1.47754,0.796875 2.44043,2.457032 z m -10.40918,6.4912106 q 0,3.3701172 1.37793,5.2958984 1.394531,1.9091797 3.81836,1.9091797 2.423828,0 3.818359,-1.9091797 1.394531,-1.9257812 1.394531,-5.2958984 0,-3.3701176 -1.394531,-5.2792966 -1.394531,-1.925782 -3.818359,-1.925782 -2.423829,0 -3.81836,1.925782 -1.37793,1.909179 -1.37793,5.2792966 z"
+     id="path9722" /><path
+     d="m 86.029297,-18.59375 h 3.054687 V 0 h -3.054687 z m 0,-7.238281 h 3.054687 v 3.868164 h -3.054687 z"
+     id="path9724" /><path
+     d="m 98.49707,-23.873047 v 5.279297 h 6.29199 v 2.374023 h -6.29199 v 10.0937504 q 0,2.2744141 0.614258,2.921875 0.630859,0.647461 2.540042,0.647461 h 3.13769 V 0 h -3.13769 q -3.536136,0 -4.880862,-1.3115234 -1.344727,-1.328125 -1.344727,-4.8144532 V -16.219727 H 93.18457 v -2.374023 h 2.241211 v -5.279297 z"
+     id="path9726" /><path
+     d="m 108.80664,-18.59375 h 3.05469 V 0 h -3.05469 z m 0,-7.238281 h 3.05469 v 3.868164 h -3.05469 z"
+     id="path9728" /><path
+     d="m 125.45801,-16.452148 q -2.45703,0 -3.88477,1.925781 -1.42773,1.909179 -1.42773,5.2460936 0,3.336914 1.41113,5.2626953 1.42774,1.9091797 3.90137,1.9091797 2.44043,0 3.86816,-1.9257813 1.42774,-1.9257812 1.42774,-5.2460937 0,-3.3037106 -1.42774,-5.2294926 -1.42773,-1.942382 -3.86816,-1.942382 z m 0,-2.589844 q 3.98437,0 6.25879,2.589844 2.27441,2.589843 2.27441,7.1718746 0,4.5654297 -2.27441,7.171875 -2.27442,2.58984371 -6.25879,2.58984371 -4.00098,0 -6.27539,-2.58984371 -2.25782,-2.6064453 -2.25782,-7.171875 0,-4.5820316 2.25782,-7.1718746 2.27441,-2.589844 6.27539,-2.589844 z"
+     id="path9730" /><path
+     d="M 154.51074,-11.222656 V 0 h -3.05469 v -11.123047 q 0,-2.639648 -1.02929,-3.951172 -1.0293,-1.311523 -3.08789,-1.311523 -2.47364,0 -3.90137,1.577148 -1.42773,1.577149 -1.42773,4.299805 V 0 h -3.07129 v -18.59375 h 3.07129 v 2.888672 q 1.0957,-1.676758 2.57324,-2.506836 1.49414,-0.830078 3.43652,-0.830078 3.2041,0 4.84766,1.992187 1.64355,1.975586 1.64355,5.827149 z"
+     id="path9732" /><path
+     d="m 169.05371,-9.3466797 q -3.70215,0 -5.12988,0.8466797 -1.42774,0.8466797 -1.42774,2.8886719 0,1.6269531 1.0625,2.5898437 1.07911,0.9462891 2.92188,0.9462891 2.54004,0 4.06738,-1.7929688 1.54395,-1.8095703 1.54395,-4.7978515 v -0.6806641 z m 6.09277,-1.2617183 V 0 h -3.05468 v -2.8222656 q -1.0459,1.6933594 -2.60645,2.50683591 -1.56055,0.796875 -3.81836,0.796875 -2.85547,0 -4.54883,-1.59375001 -1.67675,-1.6103516 -1.67675,-4.2998047 0,-3.1376953 2.09179,-4.7314456 2.1084,-1.59375 6.27539,-1.59375 h 4.28321 v -0.298828 q 0,-2.108398 -1.39453,-3.253906 -1.37793,-1.162109 -3.88477,-1.162109 -1.59375,0 -3.10449,0.381836 -1.51074,0.381835 -2.90528,1.145507 v -2.822265 q 1.67676,-0.647461 3.25391,-0.962891 1.57715,-0.332031 3.07129,-0.332031 4.03418,0 6.02637,2.091797 1.99218,2.091797 1.99218,6.341797 z"
+     id="path9734" /><path
+     d="m 181.43848,-25.832031 h 3.05468 V 0 h -3.05468 z"
+     id="path9736" /><path
+     d="m 213.5459,-18.045898 v 2.888671 q -1.29492,-0.664062 -2.68945,-0.996093 -1.39454,-0.332032 -2.88868,-0.332032 -2.27441,0 -3.41992,0.697266 -1.1289,0.697266 -1.1289,2.091797 0,1.0625 0.81347,1.676758 0.81348,0.597656 3.27051,1.145508 l 1.0459,0.232421 q 3.2539,0.6972661 4.61523,1.9755864 1.37793,1.2617187 1.37793,3.5361328 0,2.5898437 -2.05859,4.1005859 -2.04199,1.51074221 -5.62793,1.51074221 -1.49414,0 -3.1211,-0.29882812 -1.61035,-0.28222656 -3.40332,-0.86328125 V -3.8349609 q 1.69336,0.8798828 3.33692,1.328125 1.64355,0.4316406 3.2539,0.4316406 2.15821,0 3.32032,-0.7304688 1.16211,-0.7470703 1.16211,-2.0917968 0,-1.2451172 -0.84668,-1.9091797 -0.83008,-0.6640625 -3.66895,-1.2783203 l -1.0625,-0.2490235 q -2.83887,-0.5976562 -4.10058,-1.8261716 -1.26172,-1.245117 -1.26172,-3.403321 0,-2.623046 1.85937,-4.050781 1.85938,-1.427734 5.2793,-1.427734 1.69336,0 3.1875,0.249023 1.49414,0.249024 2.75586,0.747071 z"
+     id="path9738" /><path
+     d="m 235.31055,-10.060547 v 1.4941407 h -14.04493 q 0.19922,3.1542969 1.89258,4.8144532 1.70996,1.6435547 4.74805,1.6435547 1.75977,0 3.40332,-0.4316407 1.66016,-0.4316406 3.28711,-1.2949218 v 2.88867184 q -1.64356,0.69726562 -3.37012,1.0625 -1.72656,0.36523437 -3.50293,0.36523437 -4.44922,0 -7.05566,-2.58984371 -2.58985,-2.5898438 -2.58985,-7.0058594 0,-4.5654302 2.45704,-7.2382812 2.47363,-2.689453 6.65722,-2.689453 3.75196,0 5.92676,2.423828 2.19141,2.407226 2.19141,6.557617 z m -3.05469,-0.896484 q -0.0332,-2.506836 -1.41113,-4.000977 -1.36133,-1.49414 -3.61914,-1.49414 -2.55664,0 -4.10059,1.444335 -1.52734,1.444336 -1.75977,4.067383 z"
+     id="path9740" /><path
+     d="m 251.09863,-15.738281 q -0.51465,-0.298828 -1.1289,-0.431641 -0.59766,-0.149414 -1.32813,-0.149414 -2.58984,0 -3.98437,1.693359 -1.37793,1.676758 -1.37793,4.8310551 V 0 h -3.07129 v -18.59375 h 3.07129 v 2.888672 q 0.96289,-1.693359 2.50683,-2.506836 1.54395,-0.830078 3.75196,-0.830078 0.31543,0 0.69726,0.0498 0.38184,0.0332 0.84668,0.11621 z"
+     id="path9742" /><path
+     d="m 252.11133,-18.59375 h 3.2373 l 5.81055,15.6054687 5.81055,-15.6054687 h 3.2373 L 263.23437,0 h -4.15039 z"
+     id="path9744" /><path
+     d="m 274.42383,-18.59375 h 3.05469 V 0 h -3.05469 z m 0,-7.238281 h 3.05469 v 3.868164 h -3.05469 z"
+     id="path9746" /><path
+     d="m 297.25098,-17.879883 v 2.855469 q -1.29493,-0.713867 -2.60645,-1.0625 -1.29492,-0.365234 -2.62305,-0.365234 -2.97168,0 -4.61523,1.892578 -1.64355,1.875976 -1.64355,5.2792966 0,3.4033203 1.64355,5.2958984 1.64355,1.8759766 4.61523,1.8759766 1.32813,0 2.62305,-0.3486329 1.31152,-0.3652343 2.60645,-1.0791015 v 2.82226561 q -1.27832,0.59765625 -2.65625,0.89648438 -1.36133,0.29882812 -2.90528,0.29882812 -4.20019,0 -6.67383,-2.63964841 -2.47363,-2.6396485 -2.47363,-7.1220703 0,-4.5488286 2.49024,-7.1552736 2.50683,-2.606445 6.85644,-2.606445 1.41113,0 2.75586,0.298828 1.34473,0.282227 2.60645,0.863281 z"
+     id="path9748" /><path
+     d="m 318.46777,-10.060547 v 1.4941407 h -14.04492 q 0.19922,3.1542969 1.89258,4.8144532 1.70996,1.6435547 4.74805,1.6435547 1.75976,0 3.40332,-0.4316407 1.66015,-0.4316406 3.28711,-1.2949218 v 2.88867184 q -1.64356,0.69726562 -3.37012,1.0625 -1.72656,0.36523437 -3.50293,0.36523437 -4.44922,0 -7.05566,-2.58984371 -2.58985,-2.5898438 -2.58985,-7.0058594 0,-4.5654302 2.45703,-7.2382812 2.47364,-2.689453 6.65723,-2.689453 3.75195,0 5.92676,2.423828 2.1914,2.407226 2.1914,6.557617 z m -3.05468,-0.896484 q -0.0332,-2.506836 -1.41114,-4.000977 -1.36133,-1.49414 -3.61914,-1.49414 -2.55664,0 -4.10058,1.444335 -1.52735,1.444336 -1.75977,4.067383 z"
+     id="path9750" /><path
+     d="m 324.26172,-4.2167969 h 3.50293 v 2.8554688 l -2.72266,5.3125 h -2.1416 l 1.36133,-5.3125 z"
+     id="path9752" /><path
+     d="M 360.55273,-11.222656 V 0 h -3.05468 v -11.123047 q 0,-2.639648 -1.0293,-3.951172 -1.0293,-1.311523 -3.08789,-1.311523 -2.47363,0 -3.90137,1.577148 -1.42773,1.577149 -1.42773,4.299805 V 0 h -3.07129 v -18.59375 h 3.07129 v 2.888672 q 1.0957,-1.676758 2.57324,-2.506836 1.49414,-0.830078 3.43652,-0.830078 3.2041,0 4.84766,1.992187 1.64355,1.975586 1.64355,5.827149 z"
+     id="path9754" /><path
+     d="m 373.85059,-16.452148 q -2.45704,0 -3.88477,1.925781 -1.42773,1.909179 -1.42773,5.2460936 0,3.336914 1.41113,5.2626953 1.42773,1.9091797 3.90137,1.9091797 2.44043,0 3.86816,-1.9257813 1.42773,-1.9257812 1.42773,-5.2460937 0,-3.3037106 -1.42773,-5.2294926 -1.42773,-1.942382 -3.86816,-1.942382 z m 0,-2.589844 q 3.98437,0 6.25878,2.589844 2.27442,2.589843 2.27442,7.1718746 0,4.5654297 -2.27442,7.171875 -2.27441,2.58984371 -6.25878,2.58984371 -4.00098,0 -6.27539,-2.58984371 -2.25782,-2.6064453 -2.25782,-7.171875 0,-4.5820316 2.25782,-7.1718746 2.27441,-2.589844 6.27539,-2.589844 z"
+     id="path9756" /><path
+     d="m 390.46875,-23.873047 v 5.279297 h 6.29199 v 2.374023 h -6.29199 v 10.0937504 q 0,2.2744141 0.61426,2.921875 0.63086,0.647461 2.54004,0.647461 h 3.13769 V 0 h -3.13769 q -3.53614,0 -4.88086,-1.3115234 -1.34473,-1.328125 -1.34473,-4.8144532 V -16.219727 h -2.24121 v -2.374023 h 2.24121 v -5.279297 z"
+     id="path9758" /><path
+     d="m 411.58594,-18.59375 h 3.05468 V 0 h -3.05468 z m 0,-7.238281 h 3.05468 v 3.868164 h -3.05468 z"
+     id="path9760" /><path
+     d="M 436.48828,-11.222656 V 0 h -3.05469 v -11.123047 q 0,-2.639648 -1.02929,-3.951172 -1.0293,-1.311523 -3.08789,-1.311523 -2.47364,0 -3.90137,1.577148 -1.42774,1.577149 -1.42774,4.299805 V 0 h -3.07128 v -18.59375 h 3.07128 v 2.888672 q 1.09571,-1.676758 2.57325,-2.506836 1.49414,-0.830078 3.43652,-0.830078 3.2041,0 4.84766,1.992187 1.64355,1.975586 1.64355,5.827149 z"
+     id="path9762" /><path
+     d="m 455.96191,-17.879883 v 2.855469 q -1.29492,-0.713867 -2.60644,-1.0625 -1.29492,-0.365234 -2.62305,-0.365234 -2.97168,0 -4.61523,1.892578 -1.64356,1.875976 -1.64356,5.2792966 0,3.4033203 1.64356,5.2958984 1.64355,1.8759766 4.61523,1.8759766 1.32813,0 2.62305,-0.3486329 1.31152,-0.3652343 2.60644,-1.0791015 v 2.82226561 q -1.27832,0.59765625 -2.65625,0.89648438 -1.36132,0.29882812 -2.90527,0.29882812 -4.20019,0 -6.67383,-2.63964841 -2.47363,-2.6396485 -2.47363,-7.1220703 0,-4.5488286 2.49023,-7.1552736 2.50684,-2.606445 6.85645,-2.606445 1.41113,0 2.75586,0.298828 1.34473,0.282227 2.60644,0.863281 z"
+     id="path9764" /><path
+     d="m 461.27441,-25.832031 h 3.05469 V 0 h -3.05469 z"
+     id="path9766" /><path
+     d="M 470.40527,-7.3378906 V -18.59375 h 3.05469 v 11.1396484 q 0,2.6396485 1.0293,3.9677735 1.02929,1.3115234 3.08789,1.3115234 2.47363,0 3.90137,-1.5771484 1.44433,-1.5771485 1.44433,-4.2998047 V -18.59375 h 3.05469 V 0 h -3.05469 v -2.8554688 q -1.1123,1.6933594 -2.58984,2.52343755 -1.46094,0.81347656 -3.40332,0.81347656 -3.2041,0 -4.86426,-1.99218751 -1.66016,-1.9921875 -1.66016,-5.8271484 z m 7.68653,-11.7041014 z"
+     id="path9768" /><path
+     d="m 504.50488,-15.771484 v -10.060547 h 3.05469 V 0 h -3.05469 v -2.7890625 q -0.96289,1.6601563 -2.44043,2.47363281 -1.46093,0.796875 -3.51953,0.796875 -3.37012,0 -5.49512,-2.68945311 -2.10839,-2.6894531 -2.10839,-7.0722656 0,-4.3828126 2.10839,-7.0722656 2.125,-2.689453 5.49512,-2.689453 2.0586,0 3.51953,0.813476 1.47754,0.796875 2.44043,2.457032 z m -10.40918,6.4912106 q 0,3.3701172 1.37793,5.2958984 1.39453,1.9091797 3.81836,1.9091797 2.42383,0 3.81836,-1.9091797 1.39453,-1.9257812 1.39453,-5.2958984 0,-3.3701176 -1.39453,-5.2792966 -1.39453,-1.925782 -3.81836,-1.925782 -2.42383,0 -3.81836,1.925782 -1.37793,1.909179 -1.37793,5.2792966 z"
+     id="path9770" /><path
+     d="m 529.75586,-10.060547 v 1.4941407 h -14.04492 q 0.19922,3.1542969 1.89258,4.8144532 1.70996,1.6435547 4.74804,1.6435547 1.75977,0 3.40332,-0.4316407 1.66016,-0.4316406 3.28711,-1.2949218 v 2.88867184 q -1.64355,0.69726562 -3.37012,1.0625 -1.72656,0.36523437 -3.50292,0.36523437 -4.44922,0 -7.05567,-2.58984371 -2.58984,-2.5898438 -2.58984,-7.0058594 0,-4.5654302 2.45703,-7.2382812 2.47363,-2.689453 6.65723,-2.689453 3.75195,0 5.92675,2.423828 2.19141,2.407226 2.19141,6.557617 z m -3.05469,-0.896484 q -0.0332,-2.506836 -1.41113,-4.000977 -1.36133,-1.49414 -3.61914,-1.49414 -2.55664,0 -4.10059,1.444335 -1.52734,1.444336 -1.75976,4.067383 z"
+     id="path9772" /><path
+     d="m 547.00488,-15.771484 v -10.060547 h 3.05469 V 0 h -3.05469 v -2.7890625 q -0.96289,1.6601563 -2.44043,2.47363281 -1.46093,0.796875 -3.51953,0.796875 -3.37012,0 -5.49512,-2.68945311 -2.10839,-2.6894531 -2.10839,-7.0722656 0,-4.3828126 2.10839,-7.0722656 2.125,-2.689453 5.49512,-2.689453 2.0586,0 3.51953,0.813476 1.47754,0.796875 2.44043,2.457032 z m -10.40918,6.4912106 q 0,3.3701172 1.37793,5.2958984 1.39453,1.9091797 3.81836,1.9091797 2.42383,0 3.81836,-1.9091797 1.39453,-1.9257812 1.39453,-5.2958984 0,-3.3701176 -1.39453,-5.2792966 -1.39453,-1.925782 -3.81836,-1.925782 -2.42383,0 -3.81836,1.925782 -1.37793,1.909179 -1.37793,5.2792966 z"
+     id="path9774" /><path
+     d="m 567.15918,-18.59375 h 3.05469 V 0 h -3.05469 z m 0,-7.238281 h 3.05469 v 3.868164 h -3.05469 z"
+     id="path9776" /><path
+     d="M 592.06152,-11.222656 V 0 h -3.05468 v -11.123047 q 0,-2.639648 -1.0293,-3.951172 -1.0293,-1.311523 -3.08789,-1.311523 -2.47363,0 -3.90137,1.577148 -1.42773,1.577149 -1.42773,4.299805 V 0 h -3.07129 v -18.59375 h 3.07129 v 2.888672 q 1.0957,-1.676758 2.57324,-2.506836 1.49414,-0.830078 3.43652,-0.830078 3.2041,0 4.84766,1.992187 1.64355,1.975586 1.64355,5.827149 z"
+     id="path9778" /><path
+     d="m 611.9834,-23.873047 v 5.279297 h 6.29199 v 2.374023 h -6.29199 v 10.0937504 q 0,2.2744141 0.61426,2.921875 0.63086,0.647461 2.54004,0.647461 h 3.13769 V 0 h -3.13769 q -3.53614,0 -4.88086,-1.3115234 -1.34473,-1.328125 -1.34473,-4.8144532 V -16.219727 h -2.24121 v -2.374023 h 2.24121 v -5.279297 z"
+     id="path9780" /><path
+     d="M 637.74902,-11.222656 V 0 h -3.05468 v -11.123047 q 0,-2.639648 -1.0293,-3.951172 -1.0293,-1.311523 -3.08789,-1.311523 -2.47363,0 -3.90137,1.577148 -1.42773,1.577149 -1.42773,4.299805 V 0 h -3.07129 v -25.832031 h 3.07129 v 10.126953 q 1.0957,-1.676758 2.57324,-2.506836 1.49414,-0.830078 3.43652,-0.830078 3.2041,0 4.84766,1.992187 1.64355,1.975586 1.64355,5.827149 z"
+     id="path9782" /><path
+     d="m 659.74609,-10.060547 v 1.4941407 h -14.04492 q 0.19922,3.1542969 1.89258,4.8144532 1.70996,1.6435547 4.74805,1.6435547 1.75976,0 3.40332,-0.4316407 1.66015,-0.4316406 3.28711,-1.2949218 v 2.88867184 q -1.64356,0.69726562 -3.37012,1.0625 -1.72656,0.36523437 -3.50293,0.36523437 -4.44922,0 -7.05566,-2.58984371 -2.58985,-2.5898438 -2.58985,-7.0058594 0,-4.5654302 2.45703,-7.2382812 2.47364,-2.689453 6.65723,-2.689453 3.75195,0 5.92676,2.423828 2.1914,2.407226 2.1914,6.557617 z m -3.05468,-0.896484 q -0.0332,-2.506836 -1.41114,-4.000977 -1.36132,-1.49414 -3.61914,-1.49414 -2.55664,0 -4.10058,1.444335 -1.52735,1.444336 -1.75977,4.067383 z"
+     id="path9784" /><path
+     d="m 688.91504,-9.2802734 q 0,-3.3701176 -1.39453,-5.2792966 -1.37793,-1.925782 -3.80176,-1.925782 -2.42383,0 -3.81836,1.925782 -1.37793,1.909179 -1.37793,5.2792966 0,3.3701172 1.37793,5.2958984 1.39453,1.9091797 3.81836,1.9091797 2.42383,0 3.80176,-1.9091797 1.39453,-1.9257812 1.39453,-5.2958984 z m -10.39258,-6.4912106 q 0.96289,-1.660157 2.42383,-2.457032 1.47754,-0.813476 3.51953,-0.813476 3.38672,0 5.49512,2.689453 2.125,2.689453 2.125,7.0722656 0,4.3828125 -2.125,7.0722656 -2.1084,2.68945311 -5.49512,2.68945311 -2.04199,0 -3.51953,-0.796875 -1.46094,-0.81347651 -2.42383,-2.47363281 V 0 h -3.07129 v -25.832031 h 3.07129 z"
+     id="path9786" /><path
+     d="m 705.59961,-9.3466797 q -3.70215,0 -5.12988,0.8466797 -1.42774,0.8466797 -1.42774,2.8886719 0,1.6269531 1.0625,2.5898437 1.0791,0.9462891 2.92188,0.9462891 2.54004,0 4.06738,-1.7929688 1.54395,-1.8095703 1.54395,-4.7978515 v -0.6806641 z m 6.09277,-1.2617183 V 0 h -3.05468 v -2.8222656 q -1.0459,1.6933594 -2.60645,2.50683591 -1.56055,0.796875 -3.81836,0.796875 -2.85547,0 -4.54883,-1.59375001 -1.67676,-1.6103516 -1.67676,-4.2998047 0,-3.1376953 2.0918,-4.7314456 2.1084,-1.59375 6.27539,-1.59375 h 4.28321 v -0.298828 q 0,-2.108398 -1.39454,-3.253906 -1.37793,-1.162109 -3.88476,-1.162109 -1.59375,0 -3.10449,0.381836 -1.51075,0.381835 -2.90528,1.145507 v -2.822265 q 1.67676,-0.647461 3.25391,-0.962891 1.57715,-0.332031 3.07129,-0.332031 4.03418,0 6.02637,2.091797 1.99218,2.091797 1.99218,6.341797 z"
+     id="path9788" /><path
+     d="m 729.83789,-18.045898 v 2.888671 q -1.29492,-0.664062 -2.68945,-0.996093 -1.39453,-0.332032 -2.88867,-0.332032 -2.27442,0 -3.41993,0.697266 -1.1289,0.697266 -1.1289,2.091797 0,1.0625 0.81347,1.676758 0.81348,0.597656 3.27051,1.145508 l 1.0459,0.232421 q 3.25391,0.6972661 4.61523,1.9755864 1.37793,1.2617187 1.37793,3.5361328 0,2.5898437 -2.05859,4.1005859 -2.04199,1.51074221 -5.62793,1.51074221 -1.49414,0 -3.12109,-0.29882812 -1.61035,-0.28222656 -3.40332,-0.86328125 V -3.8349609 q 1.69336,0.8798828 3.33691,1.328125 1.64356,0.4316406 3.25391,0.4316406 2.1582,0 3.32031,-0.7304688 1.16211,-0.7470703 1.16211,-2.0917968 0,-1.2451172 -0.84668,-1.9091797 -0.83008,-0.6640625 -3.66895,-1.2783203 l -1.0625,-0.2490235 q -2.83886,-0.5976562 -4.10058,-1.8261716 -1.26172,-1.245117 -1.26172,-3.403321 0,-2.623046 1.85937,-4.050781 1.85938,-1.427734 5.2793,-1.427734 1.69336,0 3.1875,0.249023 1.49414,0.249024 2.75586,0.747071 z"
+     id="path9790" /><path
+     d="m 751.60254,-10.060547 v 1.4941407 h -14.04492 q 0.19922,3.1542969 1.89258,4.8144532 1.70996,1.6435547 4.74804,1.6435547 1.75977,0 3.40332,-0.4316407 1.66016,-0.4316406 3.28711,-1.2949218 v 2.88867184 q -1.64355,0.69726562 -3.37012,1.0625 -1.72656,0.36523437 -3.50293,0.36523437 -4.44921,0 -7.05566,-2.58984371 -2.58984,-2.5898438 -2.58984,-7.0058594 0,-4.5654302 2.45703,-7.2382812 2.47363,-2.689453 6.65722,-2.689453 3.75196,0 5.92676,2.423828 2.19141,2.407226 2.19141,6.557617 z m -3.05469,-0.896484 q -0.0332,-2.506836 -1.41113,-4.000977 -1.36133,-1.49414 -3.61914,-1.49414 -2.55664,0 -4.10059,1.444335 -1.52734,1.444336 -1.75976,4.067383 z"
+     id="path9792" /><path
+     d="m 770.37891,-2.7890625 v 9.8613281 h -3.07129 V -18.59375 h 3.07129 v 2.822266 q 0.96289,-1.660157 2.42382,-2.457032 1.47754,-0.813476 3.51954,-0.813476 3.38671,0 5.49511,2.689453 2.125,2.689453 2.125,7.0722656 0,4.3828125 -2.125,7.0722656 -2.1084,2.68945311 -5.49511,2.68945311 -2.042,0 -3.51954,-0.796875 -1.46093,-0.81347651 -2.42382,-2.47363281 z m 10.39257,-6.4912109 q 0,-3.3701176 -1.39453,-5.2792966 -1.37793,-1.925782 -3.80175,-1.925782 -2.42383,0 -3.81836,1.925782 -1.37793,1.909179 -1.37793,5.2792966 0,3.3701172 1.37793,5.2958984 1.39453,1.9091797 3.81836,1.9091797 2.42382,0 3.80175,-1.9091797 1.39453,-1.9257812 1.39453,-5.2958984 z"
+     id="path9794" /><path
+     d="m 789.00586,-25.832031 h 3.05469 V 0 h -3.05469 z"
+     id="path9796" /><path
+     d="m 806.90234,-9.3466797 q -3.70214,0 -5.12988,0.8466797 -1.42773,0.8466797 -1.42773,2.8886719 0,1.6269531 1.0625,2.5898437 1.0791,0.9462891 2.92187,0.9462891 2.54004,0 4.06738,-1.7929688 1.54395,-1.8095703 1.54395,-4.7978515 v -0.6806641 z m 6.09278,-1.2617183 V 0 h -3.05469 v -2.8222656 q -1.0459,1.6933594 -2.60645,2.50683591 -1.56054,0.796875 -3.81836,0.796875 -2.85546,0 -4.54882,-1.59375001 -1.67676,-1.6103516 -1.67676,-4.2998047 0,-3.1376953 2.0918,-4.7314456 2.10839,-1.59375 6.27539,-1.59375 h 4.2832 v -0.298828 q 0,-2.108398 -1.39453,-3.253906 -1.37793,-1.162109 -3.88477,-1.162109 -1.59375,0 -3.10449,0.381836 -1.51074,0.381835 -2.90527,1.145507 v -2.822265 q 1.67675,-0.647461 3.2539,-0.962891 1.57715,-0.332031 3.07129,-0.332031 4.03418,0 6.02637,2.091797 1.99219,2.091797 1.99219,6.341797 z"
+     id="path9798" /><path
+     d="m 822.30859,-23.873047 v 5.279297 h 6.292 v 2.374023 h -6.292 v 10.0937504 q 0,2.2744141 0.61426,2.921875 0.63086,0.647461 2.54004,0.647461 h 3.1377 V 0 h -3.1377 q -3.53613,0 -4.88086,-1.3115234 -1.34473,-1.328125 -1.34473,-4.8144532 V -16.219727 h -2.24121 v -2.374023 h 2.24121 v -5.279297 z"
+     id="path9800" /><path
+     d="m 842.03125,-25.832031 v 2.540039 h -2.92188 q -1.64355,0 -2.29101,0.664062 -0.63086,0.664063 -0.63086,2.390625 v 1.643555 h 5.03027 v 2.374023 H 836.1875 V 0 h -3.07129 v -16.219727 h -2.92187 v -2.374023 h 2.92187 v -1.294922 q 0,-3.104492 1.44434,-4.515625 1.44433,-1.427734 4.58203,-1.427734 z"
+     id="path9802" /><path
+     d="m 851.79297,-16.452148 q -2.45703,0 -3.88477,1.925781 -1.42773,1.909179 -1.42773,5.2460936 0,3.336914 1.41113,5.2626953 1.42774,1.9091797 3.90137,1.9091797 2.44043,0 3.86816,-1.9257813 1.42774,-1.9257812 1.42774,-5.2460937 0,-3.3037106 -1.42774,-5.2294926 -1.42773,-1.942382 -3.86816,-1.942382 z m 0,-2.589844 q 3.98437,0 6.25879,2.589844 2.27441,2.589843 2.27441,7.1718746 0,4.5654297 -2.27441,7.171875 -2.27442,2.58984371 -6.25879,2.58984371 -4.00098,0 -6.27539,-2.58984371 -2.25781,-2.6064453 -2.25781,-7.171875 0,-4.5820316 2.25781,-7.1718746 2.27441,-2.589844 6.27539,-2.589844 z"
+     id="path9804" /><path
+     d="m 876.16406,-15.738281 q -0.51465,-0.298828 -1.1289,-0.431641 -0.59766,-0.149414 -1.32813,-0.149414 -2.58984,0 -3.98437,1.693359 -1.37793,1.676758 -1.37793,4.8310551 V 0 h -3.07129 v -18.59375 h 3.07129 v 2.888672 q 0.96289,-1.693359 2.50683,-2.506836 1.54395,-0.830078 3.75196,-0.830078 0.31543,0 0.69726,0.0498 0.38184,0.0332 0.84668,0.11621 z"
+     id="path9806" /><path
+     d="m 893.24707,-15.024414 q 1.14551,-2.058594 2.73926,-3.038086 1.59375,-0.979492 3.75195,-0.979492 2.90527,0 4.48242,2.041992 1.57715,2.025391 1.57715,5.777344 V 0 h -3.07129 v -11.123047 q 0,-2.672851 -0.94629,-3.967773 -0.94629,-1.294922 -2.88867,-1.294922 -2.37402,0 -3.75195,1.577148 -1.37793,1.577149 -1.37793,4.299805 V 0 h -3.07129 v -11.123047 q 0,-2.689453 -0.94629,-3.967773 -0.94629,-1.294922 -2.92187,-1.294922 -2.34082,0 -3.71875,1.59375 -1.37793,1.577148 -1.37793,4.283203 V 0 h -3.07129 v -18.59375 h 3.07129 v 2.888672 q 1.04589,-1.709961 2.50683,-2.523438 1.46094,-0.813476 3.46973,-0.813476 2.02539,0 3.43652,1.029297 1.42774,1.029297 2.1084,2.988281 z"
+     id="path9808" /></g>
+<g
+   aria-label="Created by"
+   transform="matrix(1 0 0 1 1318.4773 1769.7598)"
+   id="text1819"
+   class="st98 st99 st97"
+   style="font-size:34px;font-family:RobotoMono-Bold;fill:#303b54"><path
+     d="m 21.897461,-22.876953 v 3.536133 q -1.693359,-1.577149 -3.619141,-2.357422 -1.909179,-0.780274 -4.067382,-0.780274 -4.2500005,0 -6.507813,2.606446 -2.2578125,2.589843 -2.2578125,7.503906 0,4.8974609 2.2578125,7.5039062 2.2578125,2.5898437 6.507813,2.5898437 2.158203,0 4.067382,-0.7802734 1.925782,-0.7802734 3.619141,-2.3574219 v 3.5029297 q -1.759766,1.19531251 -3.735352,1.79296876 -1.958984,0.59765625 -4.15039,0.59765625 -5.6279299,0 -8.8652346,-3.43652341 -3.2373047,-3.453125 -3.2373047,-9.4130859 0,-5.976563 3.2373047,-9.413086 3.2373047,-3.453125 8.8652346,-3.453125 2.224609,0 4.183593,0.597656 1.975586,0.581055 3.702149,1.759766 z"
+     id="path11061" /><path
+     d="m 37.71875,-15.738281 q -0.514648,-0.298828 -1.128906,-0.431641 -0.597657,-0.149414 -1.328125,-0.149414 -2.589844,0 -3.984375,1.693359 -1.37793,1.676758 -1.37793,4.8310551 V 0 h -3.071289 v -18.59375 h 3.071289 v 2.888672 q 0.962891,-1.693359 2.506836,-2.506836 1.543945,-0.830078 3.751953,-0.830078 0.31543,0 0.697266,0.0498 0.381836,0.0332 0.846679,0.11621 z"
+     id="path11063" /><path
+     d="m 56.080078,-10.060547 v 1.4941407 H 42.035156 q 0.199219,3.1542969 1.892578,4.8144532 1.709961,1.6435547 4.748047,1.6435547 1.759766,0 3.403321,-0.4316407 1.660156,-0.4316406 3.287109,-1.2949218 v 2.88867184 q -1.643555,0.69726562 -3.370117,1.0625 -1.726563,0.36523437 -3.50293,0.36523437 -4.449219,0 -7.055664,-2.58984371 -2.589844,-2.5898438 -2.589844,-7.0058594 0,-4.5654302 2.457031,-7.2382812 2.473633,-2.689453 6.657227,-2.689453 3.751953,0 5.926758,2.423828 2.191406,2.407226 2.191406,6.557617 z m -3.054687,-0.896484 q -0.0332,-2.506836 -1.411133,-4.000977 -1.361328,-1.49414 -3.619141,-1.49414 -2.55664,0 -4.100586,1.444335 -1.527344,1.444336 -1.759765,4.067383 z"
+     id="path11065" /><path
+     d="m 69.543945,-9.3466797 q -3.702148,0 -5.129883,0.8466797 -1.427734,0.8466797 -1.427734,2.8886719 0,1.6269531 1.0625,2.5898437 1.079102,0.9462891 2.921875,0.9462891 2.540039,0 4.067383,-1.7929688 1.543945,-1.8095703 1.543945,-4.7978515 v -0.6806641 z m 6.092774,-1.2617183 V 0 h -3.054688 v -2.8222656 q -1.045898,1.6933594 -2.606445,2.50683591 -1.560547,0.796875 -3.818359,0.796875 -2.855469,0 -4.548829,-1.59375001 -1.676757,-1.6103516 -1.676757,-4.2998047 0,-3.1376953 2.091796,-4.7314456 2.108399,-1.59375 6.275391,-1.59375 h 4.283203 v -0.298828 q 0,-2.108398 -1.394531,-3.253906 -1.37793,-1.162109 -3.884766,-1.162109 -1.59375,0 -3.104492,0.381836 -1.510742,0.381835 -2.905273,1.145507 v -2.822265 q 1.676758,-0.647461 3.253906,-0.962891 1.577148,-0.332031 3.071289,-0.332031 4.03418,0 6.026367,2.091797 1.992188,2.091797 1.992188,6.341797 z"
+     id="path11067" /><path
+     d="m 84.950195,-23.873047 v 5.279297 h 6.291992 v 2.374023 h -6.291992 v 10.0937504 q 0,2.2744141 0.614258,2.921875 0.630859,0.647461 2.540039,0.647461 h 3.137695 V 0 h -3.137695 q -3.536133,0 -4.880859,-1.3115234 -1.344727,-1.328125 -1.344727,-4.8144532 V -16.219727 h -2.241211 v -2.374023 h 2.241211 v -5.279297 z"
+     id="path11069" /><path
+     d="m 111.16406,-10.060547 v 1.4941407 H 97.119141 q 0.199218,3.1542969 1.892578,4.8144532 1.709961,1.6435547 4.748051,1.6435547 1.75976,0 3.40332,-0.4316407 1.66015,-0.4316406 3.28711,-1.2949218 v 2.88867184 q -1.64356,0.69726562 -3.37012,1.0625 -1.72656,0.36523437 -3.50293,0.36523437 -4.44922,0 -7.055666,-2.58984371 -2.589843,-2.5898438 -2.589843,-7.0058594 0,-4.5654302 2.457031,-7.2382812 2.473633,-2.689453 6.657228,-2.689453 3.75195,0 5.92676,2.423828 2.1914,2.407226 2.1914,6.557617 z m -3.05468,-0.896484 q -0.0332,-2.506836 -1.41114,-4.000977 -1.36133,-1.49414 -3.61914,-1.49414 -2.55664,0 -4.100584,1.444335 -1.527344,1.444336 -1.759766,4.067383 z"
+     id="path11071" /><path
+     d="m 128.41309,-15.771484 v -10.060547 h 3.05468 V 0 h -3.05468 v -2.7890625 q -0.96289,1.6601563 -2.44043,2.47363281 -1.46094,0.796875 -3.51953,0.796875 -3.37012,0 -5.49512,-2.68945311 -2.1084,-2.6894531 -2.1084,-7.0722656 0,-4.3828126 2.1084,-7.0722656 2.125,-2.689453 5.49512,-2.689453 2.05859,0 3.51953,0.813476 1.47754,0.796875 2.44043,2.457032 z m -10.40918,6.4912106 q 0,3.3701172 1.37793,5.2958984 1.39453,1.9091797 3.81836,1.9091797 2.42382,0 3.81835,-1.9091797 1.39454,-1.9257812 1.39454,-5.2958984 0,-3.3701176 -1.39454,-5.2792966 -1.39453,-1.925782 -3.81835,-1.925782 -2.42383,0 -3.81836,1.925782 -1.37793,1.909179 -1.37793,5.2792966 z"
+     id="path11073" /><path
+     d="m 161.91504,-9.2802734 q 0,-3.3701176 -1.39453,-5.2792966 -1.37793,-1.925782 -3.80176,-1.925782 -2.42383,0 -3.81836,1.925782 -1.37793,1.909179 -1.37793,5.2792966 0,3.3701172 1.37793,5.2958984 1.39453,1.9091797 3.81836,1.9091797 2.42383,0 3.80176,-1.9091797 1.39453,-1.9257812 1.39453,-5.2958984 z m -10.39258,-6.4912106 q 0.96289,-1.660157 2.42383,-2.457032 1.47754,-0.813476 3.51953,-0.813476 3.38672,0 5.49512,2.689453 2.125,2.689453 2.125,7.0722656 0,4.3828125 -2.125,7.0722656 -2.1084,2.68945311 -5.49512,2.68945311 -2.04199,0 -3.51953,-0.796875 -1.46094,-0.81347651 -2.42383,-2.47363281 V 0 h -3.07129 v -25.832031 h 3.07129 z"
+     id="path11075" /><path
+     d="m 177.88574,1.7265625 q -1.29492,3.3203125 -2.52344,4.3330078 -1.22851,1.0126953 -3.2871,1.0126953 h -2.44043 V 4.515625 h 1.79296 q 1.26172,0 1.95899,-0.5976562 0.69726,-0.5976563 1.54394,-2.8222657 l 0.54786,-1.39453123 -7.52051,-18.29492187 h 3.2373 l 5.81055,14.5429688 5.81055,-14.5429688 h 3.2373 z"
+     id="path11077" /></g>
 </svg>


### PR DESCRIPTION
We accidentally change the marchitecture diagram, with a different diagram.

This reverts commit e29bc1a438addd17da0ce04fed0b5fde4bbd6ebc.

⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](docs/glossary.md) and did my best to use those terms.
