### PR TITLE
Rank up application developer pages

### DIFF
--- a/ci/vale/styles/config/vocabularies/Elastisys/accept.txt
+++ b/ci/vale/styles/config/vocabularies/Elastisys/accept.txt
@@ -1,4 +1,5 @@
 # Brands, Organization and Project Names
+Alertmanager
 Atlassian
 Ceph
 Datatilsynet

--- a/docs/user-guide/additional-services/argocd.md
+++ b/docs/user-guide/additional-services/argocd.md
@@ -1,4 +1,6 @@
 ---
+search:
+  boost: 2
 tags:
   - BSI IT-Grundschutz APP.4.4.A2
   - BSI IT-Grundschutz APP.4.4.A10

--- a/docs/user-guide/additional-services/index.md
+++ b/docs/user-guide/additional-services/index.md
@@ -1,4 +1,6 @@
 ---
+search:
+  boost: 2
 tags:
   - BSI IT-Grundschutz APP.4.4.A16
 ---

--- a/docs/user-guide/additional-services/jaeger.md
+++ b/docs/user-guide/additional-services/jaeger.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: 2
+---
 # Jaeger™ (preview)
 
 !!! elastisys "For Elastisys Managed Services Customers"

--- a/docs/user-guide/additional-services/postgresql.md
+++ b/docs/user-guide/additional-services/postgresql.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: 2
+---
 # PostgreSQL®
 
 !!! elastisys "For Elastisys Managed Services Customers"

--- a/docs/user-guide/additional-services/rabbitmq.md
+++ b/docs/user-guide/additional-services/rabbitmq.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: 2
+---
 # RabbitMQ®
 
 !!! elastisys "For Elastisys Managed Services Customers"

--- a/docs/user-guide/additional-services/redis.md
+++ b/docs/user-guide/additional-services/redis.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: 2
+---
 # Redis™
 
 !!! elastisys "For Elastisys Managed Services Customers"

--- a/docs/user-guide/additional-services/timescaledb.md
+++ b/docs/user-guide/additional-services/timescaledb.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: 2
+---
 # TimescaleDB®
 
 !!! elastisys "For Elastisys Managed Services Customers"

--- a/docs/user-guide/alerts.md
+++ b/docs/user-guide/alerts.md
@@ -1,10 +1,12 @@
 ---
 description: Alerting on metrics with AlertManager in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
+search:
+  boost: 2
 tags:
   - ISO 27001 A.16 Information Security Incident Management
 ---
 
-# Alerts
+# Alerts via Alertmanager
 
 Compliant Kubernetes (CK8S) includes alerts via [Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/).
 

--- a/docs/user-guide/backup.md
+++ b/docs/user-guide/backup.md
@@ -1,5 +1,7 @@
 ---
 description: Backing up data in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
+search:
+  boost: 2
 tags:
   - ISO 27001 A.12.3.1 Information Backup
   - BSI IT-Grundschutz APP.4.4.A5

--- a/docs/user-guide/ci-cd.md
+++ b/docs/user-guide/ci-cd.md
@@ -1,5 +1,7 @@
 ---
 description: Integrating with CI/CD in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
+search:
+  boost: 2
 tags:
   - BSI IT-Grundschutz APP.4.4.A2
   - BSI IT-Grundschutz APP.4.4.A10

--- a/docs/user-guide/cluster-api.md
+++ b/docs/user-guide/cluster-api.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: 2
+---
 # Cluster API
 
 !!!note

--- a/docs/user-guide/continous-development.md
+++ b/docs/user-guide/continous-development.md
@@ -1,5 +1,7 @@
 ---
 description: How to use Continuous Development in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
+search:
+  boost: 2
 ---
 
 # Continuous Development

--- a/docs/user-guide/delegation.md
+++ b/docs/user-guide/delegation.md
@@ -1,5 +1,7 @@
 ---
 description: How to delegate and work with permissions in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
+search:
+  boost: 2
 tags:
   - ISO 27001 A.9.4.1 Information Access Restriction
   - BSI IT-Grundschutz APP.4.4.A3

--- a/docs/user-guide/demarcation.md
+++ b/docs/user-guide/demarcation.md
@@ -1,5 +1,7 @@
 ---
 description: The demarcation between what users can and cannot do in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
+search:
+  boost: 2
 tags:
   - BSI IT-Grundschutz APP.4.4.A3
   - HIPAA S13 - Information Access Management - Access Authorization - § 164.308(a)(4)(ii)(B)

--- a/docs/user-guide/deploy.md
+++ b/docs/user-guide/deploy.md
@@ -1,5 +1,7 @@
 ---
 description: Learn how to deploy your application on Elastisys Compliant Kubernetes, the security-hardened Kubernetes distribution
+search:
+  boost: 2
 ---
 
 # Step 2: Deploy

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -1,5 +1,7 @@
 ---
 description: FAQ for Application Developers on Elastisys Compliant Kubernetes, the security-hardened Kubernetes distribution
+search:
+  boost: 2
 tags:
   - HIPAA S47 - Access Control - Encryption and Decryption - § 164.312(a)(2)(iv)
   - MSBFS 2020:7 4 kap. 7 §

--- a/docs/user-guide/go-live.md
+++ b/docs/user-guide/go-live.md
@@ -1,5 +1,7 @@
 ---
 description: Checklist before going live on Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
+search:
+  boost: 2
 tags:
   - ISO 27001 A.17.1.3 Verify, Review & Evaluate Information Security Continuity
   - HIPAA S26 - Contingency Plan - Testing and Revision Procedure - § 164.308(a)(7)(ii)(D)

--- a/docs/user-guide/how-many-environments.md
+++ b/docs/user-guide/how-many-environments.md
@@ -1,4 +1,6 @@
 ---
+search:
+  boost: 2
 tags:
   - ISO 27001 A.12.1.4 Separation of Development, Testing & Operational Environments
   - HIPAA S12 - Information Access Management - Isolating Healthcare Clearinghouse Functions - § 164.308(a)(4)(ii)(A)

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,5 +1,7 @@
 ---
 description: Overview page for Application Developers in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
+search:
+  boost: 2
 ---
 
 # Application Developer Overview

--- a/docs/user-guide/kubernetes-api.md
+++ b/docs/user-guide/kubernetes-api.md
@@ -1,5 +1,7 @@
 ---
 description: How access to the Kubernetes API works in Elastisys Compliant Kubernetes, the security-hardened Kubernetes distribution
+search:
+  boost: 2
 tags:
   - HIPAA S44 - Access Control - Unique User Identification - § 164.312(a)(2)(i)
   - HSLF-FS 2016:40 4 kap. 2 § Styrning av behörigheter

--- a/docs/user-guide/kubernetes-ui.md
+++ b/docs/user-guide/kubernetes-ui.md
@@ -1,5 +1,7 @@
 ---
 description: How to work with Monokle or VSCode and Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
+search:
+  boost: 2
 ---
 
 # Kubernetes UI

--- a/docs/user-guide/log-based-alerts.md
+++ b/docs/user-guide/log-based-alerts.md
@@ -1,5 +1,7 @@
 ---
 description: How to work with log-based alerting in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
+search:
+  boost: 2
 tags:
   - ISO 27001 A.16 Information Security Incident Management
 ---

--- a/docs/user-guide/logs.md
+++ b/docs/user-guide/logs.md
@@ -1,5 +1,7 @@
 ---
 description: How to work with logs in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
+search:
+  boost: 2
 tags:
   - ISO 27001 A.12.4.1 Event Logging
   - ISO 27001 A.12.4.3 Administrator & Operator Logs

--- a/docs/user-guide/long-term-log-retention.md
+++ b/docs/user-guide/long-term-log-retention.md
@@ -1,4 +1,6 @@
 ---
+search:
+  boost: 2
 tags:
   - HIPAA S48 - Audit Controls - § 164.312(b)
   - GDPR Art. 17 Right to erasure ("right to be forgotten")

--- a/docs/user-guide/maintenance.md
+++ b/docs/user-guide/maintenance.md
@@ -1,5 +1,7 @@
 ---
 description: Learn what to expect from our different kinds of Compliant Kubernetes maintenance windows.
+search:
+  boost: 2
 ---
 
 # What to expect from maintenance

--- a/docs/user-guide/metrics.md
+++ b/docs/user-guide/metrics.md
@@ -1,5 +1,7 @@
 ---
 description: How to work with monitoring metrics on Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
+search:
+  boost: 2
 tags:
   - ISO 27001 A.12.1.3 Capacity Management
   - ISO 27001 A.16 Information Security Incident Management

--- a/docs/user-guide/namespaces.md
+++ b/docs/user-guide/namespaces.md
@@ -1,5 +1,7 @@
 ---
 description: How to work with namespaces in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
+search:
+  boost: 2
 tags:
   - ISO 27001 A.12.1.4 Separation of Development, Testing & Operational Environments
   - ISO 27001 A.14.2.5 Secure System Engineering Principles

--- a/docs/user-guide/network-model.md
+++ b/docs/user-guide/network-model.md
@@ -1,5 +1,7 @@
 ---
 description: Explanation of the network model in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
+search:
+  boost: 2
 tags:
   - ISO 27001 A.10.1.2 Key Management
   - ISO 27001 A.13.1 Network Security

--- a/docs/user-guide/operate.md
+++ b/docs/user-guide/operate.md
@@ -1,5 +1,7 @@
 ---
 description: Learn how to operate your application on Elastisys Compliant Kubernetes, the security-hardened Kubernetes distribution
+search:
+  boost: 2
 ---
 
 # Step 3: Operate

--- a/docs/user-guide/prepare-application.md
+++ b/docs/user-guide/prepare-application.md
@@ -1,5 +1,7 @@
 ---
 description: How to prepare your application for Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
+search:
+  boost: 2
 tags:
   - ISO 27001 A.12.6.1 Management of Technical Vulnerabilities
   - BSI IT-Grundschutz APP.4.4.A21

--- a/docs/user-guide/prepare-idp.md
+++ b/docs/user-guide/prepare-idp.md
@@ -1,5 +1,7 @@
 ---
 description: How to configure your Identity Provider (IdP) for Single Sign-on (SSO) use in Compliant Kubernetes
+search:
+  boost: 2
 tags:
   - HSLF-FS 2016:40 4 kap. 2 § Styrning av behörigheter
   - MSBFS 2020:7 4 kap. 5 §

--- a/docs/user-guide/prepare.md
+++ b/docs/user-guide/prepare.md
@@ -1,5 +1,7 @@
 ---
 description: Learn how to prepare for Elastisys Compliant Kubernetes, the security-hardened Kubernetes distribution
+search:
+  boost: 2
 ---
 
 <!-- markdownlint-disable-file first-line-h1 -->

--- a/docs/user-guide/registry.md
+++ b/docs/user-guide/registry.md
@@ -1,5 +1,7 @@
 ---
 description: How to work with the container registry in Elastisys Compliant Kubernetes, the security-focused Kubernetes distribution.
+search:
+  boost: 2
 tags:
   - ISO 27001 A.12.6.1 Management of Technical Vulnerabilities
   - HIPAA S17 - Security Awareness, Training, and Tools - Protection from Malicious Software - § 164.308(a)(5)(ii)(B)

--- a/docs/user-guide/safeguards/enforce-job-ttl.md
+++ b/docs/user-guide/safeguards/enforce-job-ttl.md
@@ -1,4 +1,6 @@
 ---
+search:
+  boost: 2
 tags: []
 ---
 

--- a/docs/user-guide/safeguards/enforce-minimum-replicas.md
+++ b/docs/user-guide/safeguards/enforce-minimum-replicas.md
@@ -1,4 +1,6 @@
 ---
+search:
+  boost: 2
 tags: []
 ---
 

--- a/docs/user-guide/safeguards/enforce-networkpolicies.md
+++ b/docs/user-guide/safeguards/enforce-networkpolicies.md
@@ -1,4 +1,6 @@
 ---
+search:
+  boost: 2
 tags:
   - ISO 27001 A.13.1 Network Security
   - BSI IT-Grundschutz APP.4.4.A7

--- a/docs/user-guide/safeguards/enforce-no-latest-tag.md
+++ b/docs/user-guide/safeguards/enforce-no-latest-tag.md
@@ -1,4 +1,6 @@
 ---
+search:
+  boost: 2
 tags:
   - ISO 27001 A.12.1.2 Change Management
   - ISO 27001 A.14.2.2 System Change Control Procedures

--- a/docs/user-guide/safeguards/enforce-no-load-balancer-service.md
+++ b/docs/user-guide/safeguards/enforce-no-load-balancer-service.md
@@ -1,4 +1,6 @@
 ---
+search:
+  boost: 2
 tags: []
 ---
 

--- a/docs/user-guide/safeguards/enforce-no-root.md
+++ b/docs/user-guide/safeguards/enforce-no-root.md
@@ -1,4 +1,6 @@
 ---
+search:
+  boost: 2
 tags:
   - ISO 27001 A.9.4.4 Use of Privileged Utility Programmes
   - ISO 27001 A.12.6.1 Management of Technical Vulnerabilities

--- a/docs/user-guide/safeguards/enforce-podsecuritypolicies.md
+++ b/docs/user-guide/safeguards/enforce-podsecuritypolicies.md
@@ -1,4 +1,6 @@
 ---
+search:
+  boost: 2
 tags:
   - NIST SP 800-171 3.1.7
 ---

--- a/docs/user-guide/safeguards/enforce-resources.md
+++ b/docs/user-guide/safeguards/enforce-resources.md
@@ -1,4 +1,6 @@
 ---
+search:
+  boost: 2
 tags:
   - ISO 27001 A.12.1.3 Capacity Management
 ---

--- a/docs/user-guide/safeguards/enforce-trusted-registries.md
+++ b/docs/user-guide/safeguards/enforce-trusted-registries.md
@@ -1,4 +1,6 @@
 ---
+search:
+  boost: 2
 tags:
   - ISO 27001 A.12.6.1 Management of Technical Vulnerabilities
   - NIST SP 800-171 3.4.8

--- a/docs/user-guide/safeguards/index.md
+++ b/docs/user-guide/safeguards/index.md
@@ -1,4 +1,6 @@
 ---
+search:
+  boost: 2
 tags:
   - BSI IT-Grundschutz APP.4.4.A13
 ---

--- a/docs/user-guide/self-managed-services/ferretdb.md
+++ b/docs/user-guide/self-managed-services/ferretdb.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: 2
+---
 # FerretDB® (self-managed)
 
 {%

--- a/docs/user-guide/self-managed-services/flux.md
+++ b/docs/user-guide/self-managed-services/flux.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: 2
+---
 # Flux™ (self-managed)
 
 {%

--- a/docs/user-guide/self-managed-services/jupyterhub.md
+++ b/docs/user-guide/self-managed-services/jupyterhub.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: 2
+---
 # JupyterHub (self-managed)
 
 {%

--- a/docs/user-guide/self-managed-services/kafka.md
+++ b/docs/user-guide/self-managed-services/kafka.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: 2
+---
 # Kafka® (self-managed)
 
 {%

--- a/docs/user-guide/self-managed-services/keycloak.md
+++ b/docs/user-guide/self-managed-services/keycloak.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: 2
+---
 # Keycloak™ (self-managed)
 
 {%

--- a/docs/user-guide/self-managed-services/mongodb.md
+++ b/docs/user-guide/self-managed-services/mongodb.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: 2
+---
 # MongoDB Community Operator (self-managed)
 
 {%

--- a/docs/user-guide/self-managed-services/sealedsecrets.md
+++ b/docs/user-guide/self-managed-services/sealedsecrets.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: 2
+---
 # SealedSecrets (self-managed)
 
 {%

--- a/docs/user-guide/self-managed-services/sjunet.md
+++ b/docs/user-guide/self-managed-services/sjunet.md
@@ -1,3 +1,7 @@
+---
+search:
+  boost: 2
+---
 <!-- markdownlint-disable-file first-line-h1 -->
 
 !!! elastisys "For Elastisys Managed Services Customers"

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -1,5 +1,7 @@
 ---
 description: Troubleshooting help for Application Developers on Elastisys Compliant Kubernetes, the security-hardened Kubernetes distribution
+search:
+  boost: 2
 ---
 
 # Troubleshooting for Application Developers


### PR DESCRIPTION
We recently added configuration reference. Those pages are long and detailed and tend to come up when searching for everything. This may confuse application developers.

Therefore, we decided to boost the ranking of pages relevant for application developers. We also decided to make sure that searching for "Alertmanager" bring the most relevant application developer page, by adding "via Alertmanager" in the title.

⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](docs/glossary.md) and did my best to use those terms.
