### PR TITLE
adr: open cert-manager netpols

### DIFF
--- a/docs/adr/0051-open-cert-manager-netpols.md
+++ b/docs/adr/0051-open-cert-manager-netpols.md
@@ -1,0 +1,87 @@
+# Open cert-manager Network Policies
+
+- Status: accepted
+- Deciders: Product Team
+- Date: 2024-08-22
+
+## Context and Problem Statement
+
+Certificates is a critical component of any web-based application, as it asserts trust and security for the End User.
+
+Setting up certificates require a few fundamental things which is different depending on if the issuer is using DNS-01 challenges or HTTP-01 challenges:
+
+For DNS-01 challenges one needs:
+
+- The issuer must be configured with correct credentials for the DNS provider.
+    - Application developer responsibility
+- The Network Policy must be configured to allow cert-manager controller access to the DNS provider, for both API and DNS.
+    - Platform administrator responsibility
+
+For HTTP-01 challenges one needs:
+
+- The certificate domain must point towards the Ingress-controller of the cluster.
+    - Application developer responsibility.
+- The Network Policy must be configured to allow cert-manager controller access to the Ingress-controller of the cluster, and the Ingress-controller access to the cert-manager resolver.
+    - Platform administrator responsibility.
+
+This means that there is a shared responsibility.
+For DNS-01 challenges this may cause complete failure of certificate issuing if platform administrators are not updated on the issuer application developers are using.
+And for HTTP-01 challenges this may cause frequent alerts if certificates are misconfigured regarding packets blocked by Network Policies which may hide potentially critical issues.
+
+The certificates setup by application developers should be application developers full responsibility to keep correctly configured and valid.
+However the platform does not currently provide the best experience for application developers to take that responsibility.
+
+Therefore we must consider opening up the Network Policy for cert-manager more to ensure that application developers have the best chance to manage certificates, and minimise the potential of the platform hindering it.
+
+## Decision Drivers <!-- optional -->
+
+- We want to maintain platform security and stability
+- We want to find a solution that is scalable and minimises platform administrator burden
+- We want to find a solution that is the least astonishing and that best serves application developers
+- We want to make it easier to understand faults within the platform
+
+## Considered Options
+
+1. Open egress by default from cert-manager to `0.0.0.0:53/tcp` and `0.0.0.0:53/udp` to ensure any DNS providers should just work for DNS-01 challenges.
+1. Open egress by default from cert-manager to `0.0.0.0:80/tcp` to ensure cert-manager can perform self-checks to identify invalid HTTP-01 challenges.
+1. Do not open additional egress from cert-manager.
+
+## Decision Outcome
+
+Chosen option: option 1 and option 2.
+
+### Positive Consequences <!-- optional -->
+
+- It give the application developer better experience when setting up issuers and certificates.
+    - It should just work for application developers to setup DNS-01 issuers.
+    - It should giver clearer responses for application developers to why certificates cannot be issued.
+- It gives the platform administrator better experience when monitoring environments.
+    - It minimises the role of the platform administrator to ensure certificates can be issued.
+    - It minimises the risk of critical alerts for cert-manager being shadowed by misconfigured certificates.
+
+### Negative Consequences <!-- optional -->
+
+- The Network Policy for cert-manager will be more permissive.
+    - This would add unrestricted egress on `:80/tcp`, `:53/tcp`, and `:53/udp`.
+    - This is somewhat offset by the fact that cert-manager is normally configured by default to allow egress to `0.0.0.0:443/tcp` to connect to Let's Encrypt as they by choice do not provide list of IPs to allowlist.
+
+## Pros and Cons of the Options <!-- optional -->
+
+### Option 1
+
+- Good because it ensure that any DNS provider for DNS-01 challenges should just work.
+- Good because it gives application developers more independence.
+- Bad, because it opens up cert-manager to talk to any DNS server.
+
+### Option 2
+
+- Good because it ensure that cert-manager can identify invalid HTTP-01 challenges.
+- Good because it gives application developers more independence.
+- Bad, because it opens up cert-manager to talk to any HTTP server.
+
+### Option 3
+
+- Good, because it ensure that cert-manager runs with the most limited Network Policies.
+- Bad, because application developers cannot configure DNS-01 and HTTP-01 challenges as they want.
+- Bad, because it can cause constant Network Policy alerts that shadows larger problems.
+- Bad, because it can lead to certificates in risk of expiry due to missed errors.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -127,6 +127,7 @@ This log lists the architectural decisions for Compliant Kubernetes.
 - [ADR-0048](0048-access-management-for-AMS-with-network-policies.md) - Access Management for Additional Managed Services (AMS-es)
 - [ADR-0049](0049-run-ingress-nginx-in-chroot.md) - Running NGINX with Chroot Option
 - [ADR-0050](0050-use-cluster-isolation.md) - Use Cluster Isolation to separate the application and its traces from its logs and metrics
+- [ADR-0051](0051-open-cert-manager-netpols.md) - Open cert-manager Network Policies
 
 <!-- adrlogstop -->
 


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

Add the decision on cert-manager.

Note: I realise that we don't actually give cert-manager `0.0.0.0:443/tcp` by default in apps config, rather when we configure it we do set it to `0.0.0.0:443/tcp` as that is required to communicate to Let's Encrypt.

So, should I add that this is plainly recommendation, and the standard practice for us?
Or should we make it the default for prod and dev flavours, and leave it to be set explicitly in air-gapped?