### PR TITLE
docs: add default scrape interval and timeout

### DIFF
--- a/docs/user-guide/metrics.md
+++ b/docs/user-guide/metrics.md
@@ -99,6 +99,8 @@ Configuring Prometheus to collect metrics from an application requires either a 
 
 In Compliant Kubernetes the Prometheus Operator in the Workload Cluster is configured to pick up all ServiceMonitors and PodMonitors, regardless in which namespace they are or which labels they have.
 
+The default scrape interval is 30 seconds, this is how often Prometheus will gather metrics from the Pods. The default scrape timeout is 10 seconds, this is how long Prometheus will wait after starting a scrape before it considers the scrape to have failed. These can be configured in your ServiceMonitor or PodMonitor, but we do recommend you to keep the default.
+
 ### Running Example
 
 <!--user-demo-metrics-start-->


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [ ] personal data beyond what is necessary for interacting with this Pull Request;
- [ ] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

Added info about default scrape interval and timeout. A user recently asked a question about this.