### PR TITLE
Ignore http-rate-limited for stackoverflow.com

### DIFF
--- a/linkchecker.conf
+++ b/linkchecker.conf
@@ -18,6 +18,8 @@ ignore=
     \/\/www.oreilly.com
     \/\/inera.atlassian.net
 ignorewarnings=http-redirected
+ignorewarningsforurls=
+  ^https://stackoverflow.com ^http-rate-limited
 
 [output]
 ignoreerrors=

--- a/requirements-linkchecker.txt
+++ b/requirements-linkchecker.txt
@@ -3,7 +3,7 @@ certifi==2024.2.2
 charset-normalizer==3.3.2
 dnspython==2.6.1
 idna==3.6
-LinkChecker==10.4.0
+LinkChecker==10.5.0
 pdfminer==20191125
 pycryptodome==3.20.0
 requests==2.31.0


### PR DESCRIPTION
Also upgraded linkchecker to 10.5.0 to gain access to the `ignorewarningsforurls` feature.

See release notes:

- https://github.com/linkchecker/linkchecker/releases/tag/v10.5.0

⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.
