### PR TITLE
Add Information Security page to nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -224,7 +224,9 @@ nav:
       - "GDPR (EU)": "ciso-guide/controls/gdpr.md"
       - "ISO 27001 (EU)": "ciso-guide/controls/iso-27001.md"
       - "NIST SP 800-171": "ciso-guide/controls/nist-sp-800-171.md"
-      - "DoD Enterprise DevSecOps Reference Design": "ciso-guide/information-security/dod-enterprise-devsecops-reference-design-kubernetes.md"
+      - "Information Security":
+          - "Overview": "ciso-guide/information-security/index.md"
+          - "DoD Enterprise DevSecOps Reference Design": "ciso-guide/information-security/dod-enterprise-devsecops-reference-design-kubernetes.md"
       - "Healthcare":
           - "HSLF-FS 2016:40 (SE)": "ciso-guide/controls/hslf-fs-201640.md"
           - "HIPAA (US)": "ciso-guide/controls/hipaa.md"


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

Fixes the following mkdocs warning:

```
INFO    -  The following pages exist in the docs directory, but are not included in the "nav"
           configuration:
             - ciso-guide/information-security/index.md
```