### PR TITLE
docs: add postgres v1.12.2-ck8s1 release notes

### DIFF
--- a/docs/release-notes/postgres.md
+++ b/docs/release-notes/postgres.md
@@ -4,6 +4,7 @@
 
 <!-- BEGIN TOC -->
 
+- [v1.12.2-ck8s1](#v1122-ck8s1) - 2024-09-25
 - [v1.8.2-ck8s1](#v182-ck8s1) - 2022-08-24
 - [v1.7.1-ck8s2](#v171-ck8s2) - 2022-04-26
 - [v1.7.1-ck8s1](#v171-ck8s1) - 2021-12-21
@@ -12,6 +13,27 @@
 !!!note
 
     These are only the user-facing changes.
+
+!!!note
+
+    The public changelog has not been kept up-to-date with development and new releases.
+    Expect the naming schema to change and the content of new releases to be more full and descriptive.
+
+### v1.12.2-ck8s1
+
+Released 2024-09-25
+
+Default postgres versions:
+
+- 16.4
+- 15.8
+- 14.13
+- 13.16
+
+Changes:
+
+- TimescaleDB version bumped to `2.14.2`
+- pgvector version bumped to `0.7.4`
 
 ### v1.8.2-ck8s1
 


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

---

First update to the public release notes for postgres for a long time.
I added a note on the fact that this page has not been updated properly and that there is work to improve the release notes for additional managed services (postgres in this case)
