### PR TITLE
Add CAPI cluster autoscaling warning

### DIFF
--- a/docs/user-guide/cluster-api.md
+++ b/docs/user-guide/cluster-api.md
@@ -55,6 +55,10 @@ All Ingress traffic will go through load balancers and there will not be any maj
 
 ## Cluster autoscaling
 
+> [!WARNING]
+> For Elastisys Managed Services customers that have or want to use the cluster autoscaling feature, please ensure your workload does not prevent the autoscaler from removing nodes, e.g. running pods that configure non-memory `emptyDir` volumes.
+> Please go through the list in the [cluster autoscaling documentation](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node).
+
 The [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md) will scale up a Cluster if there are Pods in the Pending state (refer to the [Kubernetes documentation on Pod Lifecycle](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/)) that cannot currently be scheduled because of a lack of resources with the current set of Nodes.
 This means that the scaling is based on resource **requests** on Pods, not the actual current CPU/memory utilization.
 In turn, this means the autoscaler cannot prevent Nodes from running out of CPU or memory if the resource requests are not close to the actual usage: to benefit the most from autoscaling, you need to set resource requests as correctly as possible.


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

Application Developer applications could potentially block the cluster autoscaler from downscaling nodes. This PR adds a warning notice about this in the Cluster API documentation.

Related to https://github.com/elastisys/ck8s-issue-tracker/issues/313
