### PR TITLE
docs: add a banner about ck8s change to welkin

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -103,3 +103,9 @@ a[href*="//"]:not([href*="elastisys."])::after {
 .md-copyright {
   padding: 24px 0;
 }
+
+.banner {
+  text-align: center;
+  background-color: var(--elastisys-northern-lights-1);
+  color: var(--elastisys-night-blue);
+}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -56,3 +56,9 @@ if(!document.__defineGetter__) {
 <meta name="msapplication-config" content="https://elastisys.io/compliantkubernetes/img/browserconfig.xml?v=1">
 <meta name="theme-color" content="#ffffff">
 {% endblock %}
+
+{% block announce %}
+<div class="banner">
+We're undergoing a transformation! We're rebranding our platform and changing the name from Compliant Kubernetes to Welkin. As we work on updating our documentation, there may be some temporary inconsistencies in how the platform is referred to. Thank you for your understanding. Read more about it in this <strong><a style="color: var(--elastisys-night-blue);"href="https://elastisys.com/elastisys-compliant-kubernetes-becomes-welkin/">press release</a></strong>.
+</div>
+{% endblock %}


### PR DESCRIPTION
⚠️ IMPORTANT ⚠️: This is a public repository. Make sure to not disclose:

- [x] personal data beyond what is necessary for interacting with this Pull Request;
- [x] business confidential information, such as customer names.

Quality gates:

- [x] I'm aware of the [Contributor Guide](../CONTRIBUTING.md) and did my best to follow the guidelines.
- [x] I'm aware of the [Glossary](../docs/glossary.md) and did my best to use those terms.

I added a banner on the whole site explaining the changes that are going to occur when we move from Compliant Kubernetes to welkin.

This is how the banner looks:
![image](https://github.com/user-attachments/assets/e4c8d885-c4fb-4b32-956f-6dd669cf2963)

The banner is also only on the top of the page so it goes away if you scroll down:
![image](https://github.com/user-attachments/assets/73387f02-0e87-413c-b890-8d32922d949e)
